### PR TITLE
Add size calculation method and trigger mechanism

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ regex = "1"
 thiserror = "1"
 tokio = { version = "1", features = ["fs", "io-util"] }
 tokio-util = { version = "0.7" }
-tonbo_macro = "0.1.0"
+tonbo_marco = { path = "tonbo_marco" }
 tracing = "0.1"
 ulid = "1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ regex = "1"
 thiserror = "1"
 tokio = { version = "1", features = ["fs", "io-util"] }
 tokio-util = { version = "0.7" }
-tonbo_marco = { path = "tonbo_marco" }
+tonbo_macro = { version = "0.1.0", path = "tonbo_macro" }
 tracing = "0.1"
 ulid = "1"
 

--- a/src/compaction/mod.rs
+++ b/src/compaction/mod.rs
@@ -59,6 +59,8 @@ where
     ) -> Result<(), CompactionError<R>> {
         let mut guard = self.schema.write().await;
 
+        guard.mutable.trigger.reset();
+
         if guard.mutable.is_empty() {
             return Ok(());
         }

--- a/src/compaction/mod.rs
+++ b/src/compaction/mod.rs
@@ -147,7 +147,7 @@ where
                 }
                 writer.write(batch.as_record_batch()).await?;
                 if let Some(file_id) = file_id {
-                    wal_ids.push(file_id.clone());
+                    wal_ids.push(*file_id);
                 }
             }
             writer.close().await?;

--- a/src/compaction/mod.rs
+++ b/src/compaction/mod.rs
@@ -474,7 +474,7 @@ pub(crate) mod tests {
     {
         let trigger = Arc::new(TriggerFactory::create(option.trigger_type));
 
-        let mutable: Mutable<R, FP> = Mutable::new(option, trigger.clone()).await?;
+        let mutable: Mutable<R, FP> = Mutable::new(option, trigger).await?;
 
         for (log_ty, record, ts) in records {
             let _ = mutable.insert(log_ty, record, ts).await?;

--- a/src/inmem/mutable.rs
+++ b/src/inmem/mutable.rs
@@ -40,7 +40,7 @@ where
 {
     pub(crate) data: SkipMap<Timestamped<R::Key>, Option<R>>,
     wal: Option<Mutex<WalFile<FP::File, R>>>,
-    trigger: Arc<Box<dyn Trigger<R> + Send + Sync>>,
+    pub(crate) trigger: Arc<Box<dyn Trigger<R> + Send + Sync>>,
 }
 
 impl<R, FP> Mutable<R, FP>

--- a/src/inmem/mutable.rs
+++ b/src/inmem/mutable.rs
@@ -16,7 +16,7 @@ use crate::{
         timestamped::{Timestamped, TimestampedRef},
         Timestamp, EPOCH,
     },
-    trigger::{Trigger, TriggerFactory, TriggerType},
+    trigger::{Trigger, TriggerFactory},
     wal::{log::LogType, WalFile},
     DbError, DbOption,
 };
@@ -57,9 +57,7 @@ where
             wal = Some(Mutex::new(WalFile::new(file, file_id)));
         };
 
-        let trigger = Arc::new(TriggerFactory::create(TriggerType::Length(
-            option.max_mutable_len,
-        )));
+        let trigger = Arc::new(TriggerFactory::create(option.trigger_type));
 
         Ok(Self {
             data: Default::default(),

--- a/src/inmem/mutable.rs
+++ b/src/inmem/mutable.rs
@@ -57,10 +57,9 @@ where
             wal = Some(Mutex::new(WalFile::new(file, file_id)));
         };
 
-        let trigger = Arc::new(TriggerFactory::create(
-            TriggerType::Count,
+        let trigger = Arc::new(TriggerFactory::create(TriggerType::Length(
             option.max_mutable_len,
-        ));
+        )));
 
         Ok(Self {
             data: Default::default(),

--- a/src/inmem/mutable.rs
+++ b/src/inmem/mutable.rs
@@ -1,5 +1,5 @@
-use std::{intrinsics::transmute, ops::Bound};
-use std::sync::Arc;
+use std::{intrinsics::transmute, ops::Bound, sync::Arc};
+
 use async_lock::Mutex;
 use crossbeam_skiplist::{
     map::{Entry, Range},
@@ -16,10 +16,10 @@ use crate::{
         timestamped::{Timestamped, TimestampedRef},
         Timestamp, EPOCH,
     },
+    trigger::{Trigger, TriggerFactory, TriggerType},
     wal::{log::LogType, WalFile},
     DbError, DbOption,
 };
-use crate::trigger::{Trigger, TriggerFactory, TriggerType};
 
 pub(crate) type MutableScan<'scan, R> = Range<
     'scan,
@@ -57,7 +57,10 @@ where
             wal = Some(Mutex::new(WalFile::new(file, file_id)));
         };
 
-        let trigger = Arc::new(TriggerFactory::create(TriggerType::Count, option.max_mutable_len));
+        let trigger = Arc::new(TriggerFactory::create(
+            TriggerType::Count,
+            option.max_mutable_len,
+        ));
 
         Ok(Self {
             data: Default::default(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,6 +155,7 @@ use crate::{
     serdes::Decode,
     stream::{merge::MergeStream, package::PackageStream, Entry, ScanStream},
     timestamp::Timestamped,
+    trigger::{Trigger, TriggerFactory},
     version::{cleaner::Cleaner, set::VersionSet, Version, VersionError},
     wal::{log::LogType, RecoverError, WalFile},
 };
@@ -354,6 +355,7 @@ where
     compaction_tx: Sender<CompactTask>,
     option: Arc<DbOption<R>>,
     recover_wal_ids: Option<Vec<FileId>>,
+    trigger: Arc<Box<dyn Trigger<R> + Send + Sync>>,
 }
 
 impl<R, FP> Schema<R, FP>
@@ -366,12 +368,14 @@ where
         compaction_tx: Sender<CompactTask>,
         version_set: &VersionSet<R, FP>,
     ) -> Result<Self, DbError<R>> {
+        let trigger = Arc::new(TriggerFactory::create(option.trigger_type));
         let mut schema = Schema {
-            mutable: Mutable::new(&option).await?,
+            mutable: Mutable::new(&option, trigger.clone()).await?,
             immutables: Default::default(),
             compaction_tx,
             option: option.clone(),
             recover_wal_ids: None,
+            trigger: trigger.clone(),
         };
 
         let mut transaction_map = HashMap::new();
@@ -912,7 +916,11 @@ pub(crate) mod tests {
 
         let mut schema = db.schema.write().await;
 
-        let mutable = mem::replace(&mut schema.mutable, Mutable::new(&option).await.unwrap());
+        let trigger = schema.trigger.clone();
+        let mutable = mem::replace(
+            &mut schema.mutable,
+            Mutable::new(&option, trigger.clone()).await.unwrap(),
+        );
 
         Immutable::<<Test as Record>::Columns>::from(mutable.data)
             .as_record_batch()
@@ -922,7 +930,9 @@ pub(crate) mod tests {
     pub(crate) async fn build_schema(
         option: Arc<DbOption<Test>>,
     ) -> io::Result<(crate::Schema<Test, TokioExecutor>, Receiver<CompactTask>)> {
-        let mutable = Mutable::new(&option).await?;
+        let trigger = Arc::new(TriggerFactory::create(option.trigger_type));
+
+        let mutable = Mutable::new(&option, trigger.clone()).await?;
 
         mutable
             .insert(
@@ -962,7 +972,10 @@ pub(crate) mod tests {
             .unwrap();
 
         let immutables = {
-            let mutable: Mutable<Test, TokioExecutor> = Mutable::new(&option).await?;
+            let trigger = Arc::new(TriggerFactory::create(option.trigger_type));
+
+            let mutable: Mutable<Test, TokioExecutor> =
+                Mutable::new(&option, trigger.clone()).await?;
 
             mutable
                 .insert(
@@ -1013,6 +1026,7 @@ pub(crate) mod tests {
                 compaction_tx,
                 option,
                 recover_wal_ids: None,
+                trigger: trigger.clone(),
             },
             compaction_rx,
         ))
@@ -1312,12 +1326,14 @@ pub(crate) mod tests {
 
         let (task_tx, _task_rx) = bounded(1);
 
+        let trigger = Arc::new(TriggerFactory::create(option.trigger_type));
         let schema: crate::Schema<Test, TokioExecutor> = crate::Schema {
-            mutable: Mutable::new(&option).await.unwrap(),
+            mutable: Mutable::new(&option, trigger.clone()).await.unwrap(),
             immutables: Default::default(),
             compaction_tx: task_tx.clone(),
             option: option.clone(),
             recover_wal_ids: None,
+            trigger: trigger.clone(),
         };
 
         for (i, item) in test_items().into_iter().enumerate() {
@@ -1328,12 +1344,15 @@ pub(crate) mod tests {
         }
         drop(schema);
 
+        let trigger = Arc::new(TriggerFactory::create(option.trigger_type));
+
         let schema: crate::Schema<Test, TokioExecutor> = crate::Schema {
-            mutable: Mutable::new(&option).await.unwrap(),
+            mutable: Mutable::new(&option, trigger.clone()).await.unwrap(),
             immutables: Default::default(),
             compaction_tx: task_tx,
             option: option.clone(),
             recover_wal_ids: None,
+            trigger: trigger.clone(),
         };
         let range = schema
             .mutable

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1281,6 +1281,7 @@ pub(crate) mod tests {
         option.level_sst_magnification = 10;
         option.max_sst_file_size = 2 * 1024 * 1024;
         option.major_default_oldest_table_num = 1;
+        option.trigger_type = TriggerType::Length(5);
 
         let db: DB<Test, TokioExecutor> = DB::new(option, TokioExecutor::new()).await.unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -431,7 +431,7 @@ where
     }
 
     async fn write(&self, log_ty: LogType, record: R, ts: Timestamp) -> Result<bool, DbError<R>> {
-        Ok(self.mutable.insert(log_ty, record, ts).await?)
+        self.mutable.insert(log_ty, record, ts).await
     }
 
     async fn remove(
@@ -440,7 +440,7 @@ where
         key: R::Key,
         ts: Timestamp,
     ) -> Result<bool, DbError<R>> {
-        Ok(self.mutable.remove(log_ty, key, ts).await?)
+        self.mutable.remove(log_ty, key, ts).await
     }
 
     async fn recover_append(
@@ -449,7 +449,7 @@ where
         ts: Timestamp,
         value: Option<R>,
     ) -> Result<bool, DbError<R>> {
-        Ok(self.mutable.append(None, key, ts, value).await?)
+        self.mutable.append(None, key, ts, value).await
     }
 
     async fn get<'get>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,7 +375,7 @@ where
             compaction_tx,
             option: option.clone(),
             recover_wal_ids: None,
-            trigger: trigger.clone(),
+            trigger,
         };
 
         let mut transaction_map = HashMap::new();
@@ -919,7 +919,7 @@ pub(crate) mod tests {
         let trigger = schema.trigger.clone();
         let mutable = mem::replace(
             &mut schema.mutable,
-            Mutable::new(&option, trigger.clone()).await.unwrap(),
+            Mutable::new(&option, trigger).await.unwrap(),
         );
 
         Immutable::<<Test as Record>::Columns>::from(mutable.data)
@@ -1026,7 +1026,7 @@ pub(crate) mod tests {
                 compaction_tx,
                 option,
                 recover_wal_ids: None,
-                trigger: trigger.clone(),
+                trigger,
             },
             compaction_rx,
         ))
@@ -1333,7 +1333,7 @@ pub(crate) mod tests {
             compaction_tx: task_tx.clone(),
             option: option.clone(),
             recover_wal_ids: None,
-            trigger: trigger.clone(),
+            trigger,
         };
 
         for (i, item) in test_items().into_iter().enumerate() {
@@ -1352,7 +1352,7 @@ pub(crate) mod tests {
             compaction_tx: task_tx,
             option: option.clone(),
             recover_wal_ids: None,
-            trigger: trigger.clone(),
+            trigger,
         };
         let range = schema
             .mutable

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,9 +122,9 @@ pub mod serdes;
 pub mod stream;
 pub mod timestamp;
 pub mod transaction;
+mod trigger;
 mod version;
 mod wal;
-mod trigger;
 
 use std::{collections::HashMap, io, marker::PhantomData, mem, ops::Bound, pin::pin, sync::Arc};
 
@@ -243,7 +243,7 @@ where
     /// insert a sequence of data as a single batch
     pub async fn insert_batch(
         &self,
-        records: impl ExactSizeIterator<Item=R>,
+        records: impl ExactSizeIterator<Item = R>,
     ) -> Result<(), CommitError<R>> {
         Ok(self
             .write_batch(records, self.version_set.transaction_ts())
@@ -285,7 +285,7 @@ where
         &'scan self,
         range: (Bound<&'scan R::Key>, Bound<&'scan R::Key>),
         mut f: impl FnMut(TransactionEntry<'_, R>) -> T + 'scan,
-    ) -> impl Stream<Item=Result<T, CommitError<R>>> + 'scan {
+    ) -> impl Stream<Item = Result<T, CommitError<R>>> + 'scan {
         stream! {
             let schema = self.schema.read().await;
             let current = self.version_set.current().await;
@@ -315,7 +315,7 @@ where
 
     pub(crate) async fn write_batch(
         &self,
-        mut records: impl ExactSizeIterator<Item=R>,
+        mut records: impl ExactSizeIterator<Item = R>,
         ts: Timestamp,
     ) -> Result<(), DbError<R>> {
         let schema = self.schema.read().await;
@@ -475,10 +475,10 @@ where
     fn check_conflict(&self, key: &R::Key, ts: Timestamp) -> bool {
         self.mutable.check_conflict(key, ts)
             || self
-            .immutables
-            .iter()
-            .rev()
-            .any(|(_, immutable)| immutable.check_conflict(key, ts))
+                .immutables
+                .iter()
+                .rev()
+                .any(|(_, immutable)| immutable.check_conflict(key, ts))
     }
 }
 
@@ -559,7 +559,7 @@ where
     /// get a Stream that returns single row of Record
     pub async fn take(
         mut self,
-    ) -> Result<impl Stream<Item=Result<Entry<'scan, R>, ParquetError>>, DbError<R>> {
+    ) -> Result<impl Stream<Item = Result<Entry<'scan, R>, ParquetError>>, DbError<R>> {
         self.streams.push(
             self.schema
                 .mutable
@@ -590,7 +590,7 @@ where
     pub async fn package(
         mut self,
         batch_size: usize,
-    ) -> Result<impl Stream<Item=Result<R::Columns, ParquetError>> + 'scan, DbError<R>> {
+    ) -> Result<impl Stream<Item = Result<R::Columns, ParquetError>> + 'scan, DbError<R>> {
         self.streams.push(
             self.schema
                 .mutable
@@ -674,10 +674,10 @@ pub(crate) mod tests {
         inmem::{immutable::tests::TestImmutableArrays, mutable::Mutable},
         record::{internal::InternalRecordRef, RecordDecodeError, RecordEncodeError, RecordRef},
         serdes::{Decode, Encode},
+        trigger::{TriggerFactory, TriggerType},
         version::{cleaner::Cleaner, set::tests::build_version_set, Version},
         wal::log::LogType,
         DbError, DbOption, Immutable, Projection, Record, DB,
-        trigger::{TriggerFactory, TriggerType},
     };
 
     #[derive(Debug, PartialEq, Eq, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1274,14 +1274,13 @@ pub(crate) mod tests {
         let temp_dir = TempDir::new().unwrap();
 
         let mut option = DbOption::from(temp_dir.path());
-        option.max_mutable_len = 5;
         option.immutable_chunk_num = 1;
         option.immutable_chunk_max_num = 1;
         option.major_threshold_with_sst_size = 3;
         option.level_sst_magnification = 10;
         option.max_sst_file_size = 2 * 1024 * 1024;
         option.major_default_oldest_table_num = 1;
-        option.trigger_type = TriggerType::Length(5);
+        option.trigger_type = TriggerType::Length(/* max_mutable_len */ 5);
 
         let db: DB<Test, TokioExecutor> = DB::new(option, TokioExecutor::new()).await.unwrap();
 

--- a/src/option.rs
+++ b/src/option.rs
@@ -16,7 +16,6 @@ use crate::{
 #[derive(Debug, Clone)]
 pub struct DbOption<R> {
     pub(crate) path: PathBuf,
-    pub(crate) max_mutable_len: usize,
     pub(crate) immutable_chunk_num: usize,
     pub(crate) immutable_chunk_max_num: usize,
     pub(crate) major_threshold_with_sst_size: usize,
@@ -39,10 +38,8 @@ where
     /// build the default configured [`DbOption`](struct.DbOption.html) based on the passed path
     fn from(path: P) -> Self {
         let (column_paths, sorting_columns) = R::primary_key_path();
-        let max_mutable_len = 3000;
         DbOption {
             path: path.into(),
-            max_mutable_len,
             immutable_chunk_num: 3,
             immutable_chunk_max_num: 5,
             major_threshold_with_sst_size: 4,
@@ -62,7 +59,7 @@ where
             use_wal: true,
             major_default_oldest_table_num: 3,
             major_l_selection_table_max_num: 4,
-            trigger_type: TriggerType::Length(max_mutable_len),
+            trigger_type: TriggerType::Length(/* max_mutable_len */ 3000),
             _p: Default::default(),
         }
     }
@@ -76,14 +73,6 @@ where
     pub fn path(self, path: impl Into<PathBuf>) -> Self {
         DbOption {
             path: path.into(),
-            ..self
-        }
-    }
-
-    /// len threshold of `mutable` when freeze is triggered
-    pub fn max_mutable_len(self, max_mutable_len: usize) -> Self {
-        DbOption {
-            max_mutable_len,
             ..self
         }
     }

--- a/src/option.rs
+++ b/src/option.rs
@@ -8,6 +8,7 @@ use parquet::{
 use crate::{
     fs::{FileId, FileProvider, FileType},
     record::Record,
+    trigger::TriggerType,
     version::Version,
 };
 
@@ -26,6 +27,7 @@ pub struct DbOption<R> {
     pub(crate) use_wal: bool,
     pub(crate) major_default_oldest_table_num: usize,
     pub(crate) major_l_selection_table_max_num: usize,
+    pub(crate) trigger_type: TriggerType,
     _p: PhantomData<R>,
 }
 
@@ -37,10 +39,10 @@ where
     /// build the default configured [`DbOption`](struct.DbOption.html) based on the passed path
     fn from(path: P) -> Self {
         let (column_paths, sorting_columns) = R::primary_key_path();
-
+        let max_mutable_len = 3000;
         DbOption {
             path: path.into(),
-            max_mutable_len: 3000,
+            max_mutable_len,
             immutable_chunk_num: 3,
             immutable_chunk_max_num: 5,
             major_threshold_with_sst_size: 4,
@@ -60,6 +62,7 @@ where
             use_wal: true,
             major_default_oldest_table_num: 3,
             major_l_selection_table_max_num: 4,
+            trigger_type: TriggerType::Length(max_mutable_len),
             _p: Default::default(),
         }
     }

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -36,6 +36,8 @@ pub trait Record: 'static + Sized + Decode + Debug + Send + Sync {
     fn as_record_ref(&self) -> Self::Ref<'_>;
 
     fn arrow_schema() -> &'static Arc<Schema>;
+
+    fn size(&self) -> usize;
 }
 
 pub trait RecordRef<'r>: Clone + Sized + Encode + Send + Sync {

--- a/src/record/str.rs
+++ b/src/record/str.rs
@@ -60,6 +60,10 @@ impl Record for String {
 
         &SCHEMA
     }
+
+    fn size(&self) -> usize {
+        self.len()
+    }
 }
 
 impl<'r> RecordRef<'r> for &'r str {

--- a/src/record/str.rs
+++ b/src/record/str.rs
@@ -16,7 +16,7 @@ use crate::{
     timestamp::Timestamped,
 };
 
-const PRIMARY_FIELD_NAME: &'static str = "vstring";
+const PRIMARY_FIELD_NAME: &str = "vstring";
 
 impl Record for String {
     type Columns = StringColumns;

--- a/src/stream/merge.rs
+++ b/src/stream/merge.rs
@@ -134,14 +134,14 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::ops::Bound;
+    use std::{ops::Bound, sync::Arc};
 
     use futures_util::StreamExt;
 
     use super::MergeStream;
     use crate::{
         executor::tokio::TokioExecutor, fs::FileProvider, inmem::mutable::Mutable, stream::Entry,
-        wal::log::LogType, DbOption,
+        trigger::TriggerFactory, wal::log::LogType, DbOption,
     };
 
     #[tokio::test]
@@ -152,9 +152,12 @@ mod tests {
             .await
             .unwrap();
 
-        let m1 = Mutable::<String, TokioExecutor>::new(&option)
+        let trigger = Arc::new(TriggerFactory::create(option.trigger_type));
+
+        let m1 = Mutable::<String, TokioExecutor>::new(&option, trigger.clone())
             .await
             .unwrap();
+
         m1.remove(LogType::Full, "b".into(), 3.into())
             .await
             .unwrap();
@@ -165,7 +168,9 @@ mod tests {
             .await
             .unwrap();
 
-        let m2 = Mutable::<String, TokioExecutor>::new(&option)
+        let trigger = Arc::new(TriggerFactory::create(option.trigger_type));
+
+        let m2 = Mutable::<String, TokioExecutor>::new(&option, trigger.clone())
             .await
             .unwrap();
         m2.insert(LogType::Full, "a".into(), 1.into())
@@ -178,7 +183,9 @@ mod tests {
             .await
             .unwrap();
 
-        let m3 = Mutable::<String, TokioExecutor>::new(&option)
+        let trigger = Arc::new(TriggerFactory::create(option.trigger_type));
+
+        let m3 = Mutable::<String, TokioExecutor>::new(&option, trigger.clone())
             .await
             .unwrap();
         m3.insert(LogType::Full, "e".into(), 4.into())
@@ -242,7 +249,9 @@ mod tests {
             .await
             .unwrap();
 
-        let m1 = Mutable::<String, TokioExecutor>::new(&option)
+        let trigger = Arc::new(TriggerFactory::create(option.trigger_type));
+
+        let m1 = Mutable::<String, TokioExecutor>::new(&option, trigger.clone())
             .await
             .unwrap();
         m1.insert(LogType::Full, "1".into(), 0_u32.into())

--- a/src/stream/merge.rs
+++ b/src/stream/merge.rs
@@ -154,7 +154,7 @@ mod tests {
 
         let trigger = Arc::new(TriggerFactory::create(option.trigger_type));
 
-        let m1 = Mutable::<String, TokioExecutor>::new(&option, trigger.clone())
+        let m1 = Mutable::<String, TokioExecutor>::new(&option, trigger)
             .await
             .unwrap();
 
@@ -170,7 +170,7 @@ mod tests {
 
         let trigger = Arc::new(TriggerFactory::create(option.trigger_type));
 
-        let m2 = Mutable::<String, TokioExecutor>::new(&option, trigger.clone())
+        let m2 = Mutable::<String, TokioExecutor>::new(&option, trigger)
             .await
             .unwrap();
         m2.insert(LogType::Full, "a".into(), 1.into())
@@ -185,7 +185,7 @@ mod tests {
 
         let trigger = Arc::new(TriggerFactory::create(option.trigger_type));
 
-        let m3 = Mutable::<String, TokioExecutor>::new(&option, trigger.clone())
+        let m3 = Mutable::<String, TokioExecutor>::new(&option, trigger)
             .await
             .unwrap();
         m3.insert(LogType::Full, "e".into(), 4.into())
@@ -251,7 +251,7 @@ mod tests {
 
         let trigger = Arc::new(TriggerFactory::create(option.trigger_type));
 
-        let m1 = Mutable::<String, TokioExecutor>::new(&option, trigger.clone())
+        let m1 = Mutable::<String, TokioExecutor>::new(&option, trigger)
             .await
             .unwrap();
         m1.insert(LogType::Full, "1".into(), 0_u32.into())

--- a/src/stream/package.rs
+++ b/src/stream/package.rs
@@ -113,7 +113,7 @@ mod tests {
 
         let trigger = Arc::new(TriggerFactory::create(option.trigger_type));
 
-        let m1 = Mutable::<Test, TokioExecutor>::new(&option, trigger.clone())
+        let m1 = Mutable::<Test, TokioExecutor>::new(&option, trigger)
             .await
             .unwrap();
         m1.insert(

--- a/src/stream/package.rs
+++ b/src/stream/package.rs
@@ -98,6 +98,7 @@ mod tests {
         record::Record,
         stream::{merge::MergeStream, package::PackageStream},
         tests::Test,
+        trigger::TriggerFactory,
         wal::log::LogType,
         DbOption,
     };
@@ -110,7 +111,11 @@ mod tests {
             .await
             .unwrap();
 
-        let m1 = Mutable::<Test, TokioExecutor>::new(&option).await.unwrap();
+        let trigger = Arc::new(TriggerFactory::create(option.trigger_type));
+
+        let m1 = Mutable::<Test, TokioExecutor>::new(&option, trigger.clone())
+            .await
+            .unwrap();
         m1.insert(
             LogType::Full,
             Test {

--- a/src/trigger.rs
+++ b/src/trigger.rs
@@ -78,21 +78,18 @@ impl<R: Record> Trigger<R> for CountTrigger {
 
 #[derive(Copy, Clone, Debug)]
 pub enum TriggerType {
-    Count,
-    SizeOfMem,
+    SizeOfMem(usize),
+    Length(usize),
 }
 pub(crate) struct TriggerFactory<R> {
     _p: PhantomData<R>,
 }
 
 impl<R: Record> TriggerFactory<R> {
-    pub fn create(
-        trigger_type: TriggerType,
-        threshold: usize,
-    ) -> Box<dyn Trigger<R> + Send + Sync> {
+    pub fn create(trigger_type: TriggerType) -> Box<dyn Trigger<R> + Send + Sync> {
         match trigger_type {
-            TriggerType::SizeOfMem => Box::new(SizeOfMemTrigger::new(threshold)),
-            TriggerType::Count => Box::new(CountTrigger::new(threshold)),
+            TriggerType::SizeOfMem(threshold) => Box::new(SizeOfMemTrigger::new(threshold)),
+            TriggerType::Length(threshold) => Box::new(CountTrigger::new(threshold)),
         }
     }
 }

--- a/src/trigger.rs
+++ b/src/trigger.rs
@@ -177,34 +177,26 @@ mod tests {
         let size_of_mem_trigger = TriggerFactory::<Test>::create(TriggerType::SizeOfMem(9));
         let length_trigger = TriggerFactory::<Test>::create(TriggerType::Length(2));
 
-        assert!(
-            !size_of_mem_trigger.item(&Some(Test {
-                vstring: "test".to_string(),
-                vu32: 0,
-                vbool: None
-            }))
-        );
-        assert!(
-            size_of_mem_trigger.item(&Some(Test {
-                vstring: "test".to_string(),
-                vu32: 0,
-                vbool: None
-            }))
-        );
+        assert!(!size_of_mem_trigger.item(&Some(Test {
+            vstring: "test".to_string(),
+            vu32: 0,
+            vbool: None
+        })));
+        assert!(size_of_mem_trigger.item(&Some(Test {
+            vstring: "test".to_string(),
+            vu32: 0,
+            vbool: None
+        })));
 
-        assert!(
-            !length_trigger.item(&Some(Test {
-                vstring: "test".to_string(),
-                vu32: 1,
-                vbool: Some(true)
-            }))
-        );
-        assert!(
-            length_trigger.item(&Some(Test {
-                vstring: "test".to_string(),
-                vu32: 1,
-                vbool: Some(true)
-            }))
-        );
+        assert!(!length_trigger.item(&Some(Test {
+            vstring: "test".to_string(),
+            vu32: 1,
+            vbool: Some(true)
+        })));
+        assert!(length_trigger.item(&Some(Test {
+            vstring: "test".to_string(),
+            vu32: 1,
+            vbool: Some(true)
+        })));
     }
 }

--- a/src/trigger.rs
+++ b/src/trigger.rs
@@ -115,29 +115,25 @@ mod tests {
         let record_size = record.clone().unwrap().size();
         assert_eq!(record_size, 8);
 
-        assert_eq!(
-            trigger.exceeded(),
-            false,
+        assert!(
+            !trigger.exceeded(),
             "Trigger should not be exceeded initially"
         );
         trigger.item(&record);
-        assert_eq!(
-            trigger.exceeded(),
-            false,
+        assert!(
+            !trigger.exceeded(),
             "Trigger should not be exceeded after 1 record"
         );
 
         trigger.item(&record);
-        assert_eq!(
+        assert!(
             trigger.exceeded(),
-            true,
             "Trigger should be exceeded after 2 records"
         );
 
         trigger.reset();
-        assert_eq!(
-            trigger.exceeded(),
-            false,
+        assert!(
+            !trigger.exceeded(),
             "Trigger should not be exceeded after reset"
         );
     }
@@ -153,30 +149,26 @@ mod tests {
             vbool: None,
         });
 
-        assert_eq!(
-            trigger.exceeded(),
-            false,
+        assert!(
+            !trigger.exceeded(),
             "Trigger should not be exceeded initially"
         );
         trigger.item(&record);
 
-        assert_eq!(
-            trigger.exceeded(),
-            false,
+        assert!(
+            !trigger.exceeded(),
             "Trigger should not be exceeded after 1 record"
         );
 
         trigger.item(&record);
-        assert_eq!(
+        assert!(
             trigger.exceeded(),
-            true,
             "Trigger should be exceeded after 2 records"
         );
 
         trigger.reset();
-        assert_eq!(
-            trigger.exceeded(),
-            false,
+        assert!(
+            !trigger.exceeded(),
             "Trigger should not be exceeded after reset"
         );
     }
@@ -185,38 +177,34 @@ mod tests {
         let size_of_mem_trigger = TriggerFactory::<Test>::create(TriggerType::SizeOfMem(9));
         let length_trigger = TriggerFactory::<Test>::create(TriggerType::Length(2));
 
-        assert_eq!(
-            size_of_mem_trigger.item(&Some(Test {
+        assert!(
+            !size_of_mem_trigger.item(&Some(Test {
                 vstring: "test".to_string(),
                 vu32: 0,
                 vbool: None
-            })),
-            false
+            }))
         );
-        assert_eq!(
+        assert!(
             size_of_mem_trigger.item(&Some(Test {
                 vstring: "test".to_string(),
                 vu32: 0,
                 vbool: None
-            })),
-            true
+            }))
         );
 
-        assert_eq!(
-            length_trigger.item(&Some(Test {
+        assert!(
+            !length_trigger.item(&Some(Test {
                 vstring: "test".to_string(),
                 vu32: 1,
                 vbool: Some(true)
-            })),
-            false
+            }))
         );
-        assert_eq!(
+        assert!(
             length_trigger.item(&Some(Test {
                 vstring: "test".to_string(),
                 vu32: 1,
                 vbool: Some(true)
-            })),
-            true
+            }))
         );
     }
 }

--- a/src/trigger.rs
+++ b/src/trigger.rs
@@ -1,9 +1,11 @@
-use std::fmt;
-use std::fmt::{Debug};
-use std::marker::PhantomData;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use crate::record::{Record};
+use std::{
+    fmt,
+    fmt::Debug,
+    marker::PhantomData,
+    sync::atomic::{AtomicUsize, Ordering},
+};
 
+use crate::record::Record;
 
 pub trait Trigger<R: Record>: fmt::Debug {
     fn item(&self, item: &Option<R>) -> bool;
@@ -18,7 +20,6 @@ pub struct SizeOfMemTrigger<R> {
     current_size: AtomicUsize,
     _p: PhantomData<R>,
 }
-
 
 impl<T> SizeOfMemTrigger<T> {
     pub fn new(max_size: usize) -> Self {
@@ -75,7 +76,6 @@ impl<R: Record> Trigger<R> for CountTrigger {
     }
 }
 
-
 #[derive(Copy, Clone, Debug)]
 pub enum TriggerType {
     Count,
@@ -86,7 +86,10 @@ pub(crate) struct TriggerFactory<R> {
 }
 
 impl<R: Record> TriggerFactory<R> {
-    pub fn create(trigger_type: TriggerType, threshold: usize) -> Box<dyn Trigger<R> + Send + Sync> {
+    pub fn create(
+        trigger_type: TriggerType,
+        threshold: usize,
+    ) -> Box<dyn Trigger<R> + Send + Sync> {
         match trigger_type {
             TriggerType::SizeOfMem => Box::new(SizeOfMemTrigger::new(threshold)),
             TriggerType::Count => Box::new(CountTrigger::new(threshold)),

--- a/src/trigger.rs
+++ b/src/trigger.rs
@@ -1,0 +1,95 @@
+use std::fmt;
+use std::fmt::{Debug};
+use std::marker::PhantomData;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use crate::record::{Record};
+
+
+pub trait Trigger<R: Record>: fmt::Debug {
+    fn item(&self, item: &Option<R>) -> bool;
+
+    fn exceeded(&self) -> bool;
+
+    fn reset(&self);
+}
+#[derive(Debug)]
+pub struct SizeOfMemTrigger<R> {
+    threshold: usize,
+    current_size: AtomicUsize,
+    _p: PhantomData<R>,
+}
+
+
+impl<T> SizeOfMemTrigger<T> {
+    pub fn new(max_size: usize) -> Self {
+        Self {
+            threshold: max_size,
+            current_size: AtomicUsize::new(0),
+            _p: Default::default(),
+        }
+    }
+}
+
+impl<R: Record> Trigger<R> for SizeOfMemTrigger<R> {
+    fn item(&self, item: &Option<R>) -> bool {
+        let size = item.as_ref().map_or(0, R::size);
+        self.current_size.fetch_add(size, Ordering::SeqCst) + size > self.threshold
+    }
+
+    fn exceeded(&self) -> bool {
+        self.current_size.load(Ordering::SeqCst) >= self.threshold
+    }
+
+    fn reset(&self) {
+        self.current_size.store(0, Ordering::SeqCst);
+    }
+}
+
+#[derive(Debug)]
+pub struct CountTrigger {
+    threshold: usize,
+    count: AtomicUsize,
+}
+
+impl CountTrigger {
+    pub fn new(threshold: usize) -> Self {
+        CountTrigger {
+            threshold,
+            count: AtomicUsize::new(0),
+        }
+    }
+}
+
+impl<R: Record> Trigger<R> for CountTrigger {
+    fn item(&self, _: &Option<R>) -> bool {
+        self.count.fetch_add(1, Ordering::SeqCst);
+        self.count.load(Ordering::SeqCst) > self.threshold
+    }
+
+    fn exceeded(&self) -> bool {
+        self.count.load(Ordering::SeqCst) > self.threshold
+    }
+
+    fn reset(&self) {
+        self.count.store(0, Ordering::SeqCst);
+    }
+}
+
+
+#[derive(Copy, Clone, Debug)]
+pub enum TriggerType {
+    Count,
+    SizeOfMem,
+}
+pub(crate) struct TriggerFactory<R> {
+    _p: PhantomData<R>,
+}
+
+impl<R: Record> TriggerFactory<R> {
+    pub fn create(trigger_type: TriggerType, threshold: usize) -> Box<dyn Trigger<R> + Send + Sync> {
+        match trigger_type {
+            TriggerType::SizeOfMem => Box::new(SizeOfMemTrigger::new(threshold)),
+            TriggerType::Count => Box::new(CountTrigger::new(threshold)),
+        }
+    }
+}

--- a/tonbo_macro/src/lib.rs
+++ b/tonbo_macro/src/lib.rs
@@ -61,6 +61,7 @@ pub fn tonbo_record(args: TokenStream, input: TokenStream) -> TokenStream {
     let mut encode_method_fields: Vec<proc_macro2::TokenStream> = Vec::new();
     let mut encode_size_fields: Vec<proc_macro2::TokenStream> = Vec::new();
     let mut decode_method_fields: Vec<proc_macro2::TokenStream> = Vec::new();
+    let mut size_fields: Vec<proc_macro2::TokenStream> = Vec::new();
 
     let mut to_ref_init_fields: Vec<proc_macro2::TokenStream> = Vec::new();
     let mut schema_fields: Vec<proc_macro2::TokenStream> = Vec::new();
@@ -100,6 +101,7 @@ pub fn tonbo_record(args: TokenStream, input: TokenStream) -> TokenStream {
                     builder_with_capacity_method,
                     builder,
                     size_method,
+                    size_field,
                 ) = match to_data_type(&field.ty) {
                     Some((DataType::UInt8, is_nullable)) => (
                         is_nullable,
@@ -112,6 +114,7 @@ pub fn tonbo_record(args: TokenStream, input: TokenStream) -> TokenStream {
                         >::with_capacity(capacity)),
                         quote!(::arrow::array::PrimitiveBuilder<::arrow::datatypes::UInt8Type>),
                         quote!(std::mem::size_of_val(self.#field_name.values_slice())),
+                        quote!(std::mem::size_of::<u8>()),
                     ),
                     Some((DataType::UInt16, is_nullable)) => (
                         is_nullable,
@@ -124,6 +127,7 @@ pub fn tonbo_record(args: TokenStream, input: TokenStream) -> TokenStream {
                         >::with_capacity(capacity)),
                         quote!(::arrow::array::PrimitiveBuilder<::arrow::datatypes::UInt16Type>),
                         quote!(std::mem::size_of_val(self.#field_name.values_slice())),
+                        quote!(std::mem::size_of::<u16>()),
                     ),
                     Some((DataType::UInt32, is_nullable)) => (
                         is_nullable,
@@ -136,6 +140,7 @@ pub fn tonbo_record(args: TokenStream, input: TokenStream) -> TokenStream {
                         >::with_capacity(capacity)),
                         quote!(::arrow::array::PrimitiveBuilder<::arrow::datatypes::UInt32Type>),
                         quote!(std::mem::size_of_val(self.#field_name.values_slice())),
+                        quote! {std::mem::size_of::<u32>()},
                     ),
                     Some((DataType::UInt64, is_nullable)) => (
                         is_nullable,
@@ -148,6 +153,7 @@ pub fn tonbo_record(args: TokenStream, input: TokenStream) -> TokenStream {
                         >::with_capacity(capacity)),
                         quote!(::arrow::array::PrimitiveBuilder<::arrow::datatypes::UInt64Type>),
                         quote!(std::mem::size_of_val(self.#field_name.values_slice())),
+                        quote! {std::mem::size_of::<u64>()},
                     ),
 
                     Some((DataType::Int8, is_nullable)) => (
@@ -161,6 +167,7 @@ pub fn tonbo_record(args: TokenStream, input: TokenStream) -> TokenStream {
                         >::with_capacity(capacity)),
                         quote!(::arrow::array::PrimitiveBuilder<::arrow::datatypes::Int8Type>),
                         quote!(std::mem::size_of_val(self.#field_name.values_slice())),
+                        quote! {std::mem::size_of::<i8>()},
                     ),
                     Some((DataType::Int16, is_nullable)) => (
                         is_nullable,
@@ -173,6 +180,7 @@ pub fn tonbo_record(args: TokenStream, input: TokenStream) -> TokenStream {
                         >::with_capacity(capacity)),
                         quote!(::arrow::array::PrimitiveBuilder<::arrow::datatypes::Int16Type>),
                         quote!(std::mem::size_of_val(self.#field_name.values_slice())),
+                        quote! {std::mem::size_of::<i16>()},
                     ),
                     Some((DataType::Int32, is_nullable)) => (
                         is_nullable,
@@ -185,6 +193,7 @@ pub fn tonbo_record(args: TokenStream, input: TokenStream) -> TokenStream {
                         >::with_capacity(capacity)),
                         quote!(::arrow::array::PrimitiveBuilder<::arrow::datatypes::Int32Type>),
                         quote!(std::mem::size_of_val(self.#field_name.values_slice())),
+                        quote! {std::mem::size_of::<i32>()},
                     ),
                     Some((DataType::Int64, is_nullable)) => (
                         is_nullable,
@@ -197,6 +206,7 @@ pub fn tonbo_record(args: TokenStream, input: TokenStream) -> TokenStream {
                         >::with_capacity(capacity)),
                         quote!(::arrow::array::PrimitiveBuilder<::arrow::datatypes::Int64Type>),
                         quote!(std::mem::size_of_val(self.#field_name.values_slice())),
+                        quote! {std::mem::size_of::<i64>()},
                     ),
 
                     Some((DataType::String, is_nullable)) => {
@@ -210,6 +220,11 @@ pub fn tonbo_record(args: TokenStream, input: TokenStream) -> TokenStream {
                             quote!(::arrow::array::StringBuilder::with_capacity(capacity, 0)),
                             quote!(::arrow::array::StringBuilder),
                             quote!(self.#field_name.values_slice().len()),
+                            if is_nullable {
+                                quote!(0)
+                            } else {
+                                quote!(self.#field_name.len())
+                            }
                         )
                     }
                     Some((DataType::Boolean, is_nullable)) => (
@@ -221,6 +236,7 @@ pub fn tonbo_record(args: TokenStream, input: TokenStream) -> TokenStream {
                         quote!(::arrow::array::BooleanBuilder::with_capacity(capacity)),
                         quote!(::arrow::array::BooleanBuilder),
                         quote!(self.#field_name.values_slice().len()),
+                        quote! {std::mem::size_of::<bool>()},
                     ),
 
                     None => unreachable!(),
@@ -229,7 +245,7 @@ pub fn tonbo_record(args: TokenStream, input: TokenStream) -> TokenStream {
                 schema_fields.push(quote! {
                     ::arrow::datatypes::Field::new(stringify!(#field_name), #mapped_type, #is_nullable),
                 });
-                field_names.push(quote! (#field_name,));
+                field_names.push(quote!(#field_name,));
                 arrays_init_fields.push(quote! {
                     #field_name: ::std::sync::Arc<#array_ty>,
                 });
@@ -256,6 +272,9 @@ pub fn tonbo_record(args: TokenStream, input: TokenStream) -> TokenStream {
                 });
                 builder_size_fields.push(quote! {
                     + #size_method
+                });
+                size_fields.push(quote! {
+                    + #size_field
                 });
 
                 match ModelAttributes::parse_field(field) {
@@ -373,8 +392,8 @@ pub fn tonbo_record(args: TokenStream, input: TokenStream) -> TokenStream {
                                 ast.ident,
                                 "primary key cannot be nullable",
                             )
-                            .to_compile_error()
-                            .into();
+                                .to_compile_error()
+                                .into();
                         }
                         if is_string {
                             to_ref_init_fields.push(quote! { #field_name: &self.#field_name, });
@@ -468,6 +487,10 @@ pub fn tonbo_record(args: TokenStream, input: TokenStream) -> TokenStream {
                 });
 
                 &SCHEMA
+            }
+
+            fn size(&self) -> usize {
+                0 #(#size_fields)*
             }
         }
 

--- a/tonbo_macro/src/lib.rs
+++ b/tonbo_macro/src/lib.rs
@@ -224,7 +224,7 @@ pub fn tonbo_record(args: TokenStream, input: TokenStream) -> TokenStream {
                                 quote!(0)
                             } else {
                                 quote!(self.#field_name.len())
-                            }
+                            },
                         )
                     }
                     Some((DataType::Boolean, is_nullable)) => (
@@ -392,8 +392,8 @@ pub fn tonbo_record(args: TokenStream, input: TokenStream) -> TokenStream {
                                 ast.ident,
                                 "primary key cannot be nullable",
                             )
-                                .to_compile_error()
-                                .into();
+                            .to_compile_error()
+                            .into();
                         }
                         if is_string {
                             to_ref_init_fields.push(quote! { #field_name: &self.#field_name, });


### PR DESCRIPTION
Implemented a `size` method for `Record` and added a trigger mechanism (`Trigger`, `TriggerFactory`) to handle dynamic item insertion and manage memory efficiently. Adjusted related stream implementations and updated dependency path for `tonbo_marco`.