### PR TITLE
enhancement: boost github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,6 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all-features
   # 2
   fmt:
     name: Rust fmt


### PR DESCRIPTION
Compiling rocksdb is too slow to CI and actually it does not necessary, therefore remove it.