### PR TITLE
chore: annotation normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ use std::ops::Bound;
 use futures_util::stream::StreamExt;
 use tonbo::{executor::tokio::TokioExecutor, tonbo_record, Projection, DB};
 
-// use macro to define schema of column family just like ORM
-// it provides type safety read & write API
+/// Use macro to define schema of column family just like ORM
+/// It provides type-safe read & write API
 #[tonbo_record]
 pub struct User {
     #[primary_key]


### PR DESCRIPTION
I've seen some Rust projects where comments like struct and fn are usually ///, and comments inside methods are //. I think this is a better way to distinguish them.