### PR TITLE
chore: remove redundant judgment

### DIFF
--- a/examples/declare.rs
+++ b/examples/declare.rs
@@ -36,18 +36,6 @@ async fn main() {
         // get from primary key
         let name = "Alice".into();
 
-        // get the zero-copy reference of record without any allocations.
-        let user = txn
-            .get(
-                &name,
-                // tonbo supports pushing down projection
-                Projection::All,
-            )
-            .await
-            .unwrap();
-        assert!(user.is_some());
-        assert_eq!(user.unwrap().get().age, Some(22));
-
         {
             let upper = "Blob".into();
             // range scan of user


### PR DESCRIPTION
I think this part is redundant and should be added to the unit test. The Readme can be kept and will be deleted when I complete the unit test.