### PR TITLE
feat: Add test for Encode and Decode traits

### DIFF
--- a/src/serdes/mod.rs
+++ b/src/serdes/mod.rs
@@ -40,3 +40,55 @@ pub trait Decode: Sized {
     where
         R: AsyncRead + Unpin;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::AsyncWriteExt;
+
+    #[tokio::test]
+    async fn test_encode_decode() {
+        // Implement a simple struct that implements Encode and Decode
+        struct TestStruct(u32);
+
+        impl Encode for TestStruct {
+            type Error = io::Error;
+
+            async fn encode<W>(&self, writer: &mut W) -> Result<(), Self::Error>
+            where
+                W: AsyncWrite + Unpin + Send,
+            {
+                writer.write_u32(self.0).await?;
+                Ok(())
+            }
+
+            fn size(&self) -> usize {
+                std::mem::size_of::<u32>()
+            }
+        }
+
+        impl Decode for TestStruct {
+            type Error = io::Error;
+
+            async fn decode<R>(reader: &mut R) -> Result<Self, Self::Error>
+            where
+                R: AsyncRead + Unpin,
+            {
+                let value = tokio::io::AsyncReadExt::read_u32(reader).await?;
+                Ok(TestStruct(value))
+            }
+        }
+
+        // Test encoding and decoding
+        let original = TestStruct(42);
+        let mut buffer = Vec::new();
+
+        original.encode(&mut buffer).await.unwrap();
+        assert_eq!(buffer.len(), original.size());
+
+        let mut cursor = std::io::Cursor::new(buffer);
+        let decoded = TestStruct::decode(&mut cursor).await.unwrap();
+
+        assert_eq!(original.0, decoded.0);
+    }
+}


### PR DESCRIPTION
- Implemented a simple struct `TestStruct` that implements `Encode` and `Decode` traits.
- Added async encode and decode methods for `TestStruct`.
- Created a test to verify encoding and decoding functionality.