### PR TITLE
fix range query

### DIFF
--- a/src/inmem/immutable.rs
+++ b/src/inmem/immutable.rs
@@ -105,8 +105,16 @@ where
         ts: Timestamp,
         projection_mask: ProjectionMask,
     ) -> ImmutableScan<'scan, A::Record> {
-        let lower = range.0.map(|key| TimestampedRef::new(key, ts));
-        let upper = range.1.map(|key| TimestampedRef::new(key, EPOCH));
+        let lower = match range.0 {
+            Bound::Included(key) => Bound::Included(TimestampedRef::new(key, ts)),
+            Bound::Excluded(key) => Bound::Excluded(TimestampedRef::new(key, EPOCH)),
+            Bound::Unbounded => Bound::Unbounded,
+        };
+        let upper = match range.1 {
+            Bound::Included(key) => Bound::Included(TimestampedRef::new(key, EPOCH)),
+            Bound::Excluded(key) => Bound::Excluded(TimestampedRef::new(key, ts)),
+            Bound::Unbounded => Bound::Unbounded,
+        };
 
         let range = self
             .index

--- a/src/inmem/mutable.rs
+++ b/src/inmem/mutable.rs
@@ -146,8 +146,16 @@ where
         range: (Bound<&'scan R::Key>, Bound<&'scan R::Key>),
         ts: Timestamp,
     ) -> MutableScan<'scan, R> {
-        let lower = range.0.map(|key| TimestampedRef::new(key, ts));
-        let upper = range.1.map(|key| TimestampedRef::new(key, EPOCH));
+        let lower = match range.0 {
+            Bound::Included(key) => Bound::Included(TimestampedRef::new(key, ts)),
+            Bound::Excluded(key) => Bound::Excluded(TimestampedRef::new(key, EPOCH)),
+            Bound::Unbounded => Bound::Unbounded,
+        };
+        let upper = match range.1 {
+            Bound::Included(key) => Bound::Included(TimestampedRef::new(key, EPOCH)),
+            Bound::Excluded(key) => Bound::Excluded(TimestampedRef::new(key, ts)),
+            Bound::Unbounded => Bound::Unbounded,
+        };
 
         self.data.range((lower, upper))
     }

--- a/src/ondisk/arrows.rs
+++ b/src/ondisk/arrows.rs
@@ -83,8 +83,8 @@ where
             ProjectionMask::roots(schema_descriptor, [2]),
             move |record_batch| {
                 upper_cmp(
-                    record_batch.column(0),
                     &upper_key.to_arrow_datum() as &dyn Datum,
+                    record_batch.column(0),
                 )
             },
         )));


### PR DESCRIPTION
#93 
The result is not correct when using `Bound::Exclude` and `Bound::Include` in `Transaction::scan`. 

This PR fixes the issue:
- fix range filter in disk table
- fix range bound in memory table

