### PR TITLE
fix: doc links

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,8 @@
 //! most operations are asynchronous and non-blocking,
 //! providing efficient concurrent processing capabilities.
 //!
-//! `tonbo` constructs an instance using the [`DB::new`](struct.DB.html#method.new) method
-//! to serve a specific `Tonbo Record` type.
+//! `tonbo` constructs an instance using the [`DB::new`] method to serve a
+//! specific `Tonbo Record` type.
 //!
 //! `Tonbo Record` is automatically implemented by the macro [`tonbo_record`].
 //! Support type
@@ -25,9 +25,8 @@
 //! - UInt32
 //! - UInt64
 //!
-//! ACID `optimistic` transactions for concurrent data
-//! reading and writing are supported with the
-//! [`DB::transaction`](struct.DB.html#method.transaction) method.
+//! ACID `optimistic` transactions for concurrent data reading and writing are
+//! supported with the [`DB::transaction`] method.
 //!
 //! # Examples
 //!
@@ -180,12 +179,11 @@ where
     R::Columns: Send + Sync,
     E: Executor + Send + Sync + 'static,
 {
-    /// Open [`DB`](struct.DB.html) with a [`DbOption`](struct.DbOption.html). This will create a
-    /// new directory at the path specified in [`DbOption`](struct.DbOption.html) (if it does
-    /// not exist before) and run it according to the configuration of
-    /// [`DbOption`](struct.DbOption.html).
+    /// Open [`DB`] with a [`DbOption`]. This will create a new directory at the
+    /// path specified in [`DbOption`] (if it does not exist before) and run it
+    /// according to the configuration of [`DbOption`].
     ///
-    /// For more configurable options, please refer to [`DbOption`](struct.DbOption.html)
+    /// For more configurable options, please refer to [`DbOption`].
     pub async fn new(option: DbOption<R>, executor: E) -> Result<Self, DbError<R>> {
         let option = Arc::new(option);
         E::create_dir_all(&option.path).await?;

--- a/src/option.rs
+++ b/src/option.rs
@@ -12,7 +12,7 @@ use crate::{
     version::Version,
 };
 
-/// configure the operating parameters of each component in the [`DB`](../struct.DB.html)
+/// configure the operating parameters of each component in the [`DB`](crate::DB)
 #[derive(Debug, Clone)]
 pub struct DbOption<R> {
     pub(crate) path: PathBuf,
@@ -35,7 +35,7 @@ where
     P: Into<PathBuf>,
     R: Record,
 {
-    /// build the default configured [`DbOption`](struct.DbOption.html) based on the passed path
+    /// build the default configured [`DbOption`] based on the passed path
     fn from(path: P) -> Self {
         let (column_paths, sorting_columns) = R::primary_key_path();
         DbOption {
@@ -69,7 +69,7 @@ impl<R> DbOption<R>
 where
     R: Record,
 {
-    /// build the [`DB`](../struct.DB.html) storage directory based on the passed path
+    /// build the [`DB`](crate::DB) storage directory based on the passed path
     pub fn path(self, path: impl Into<PathBuf>) -> Self {
         DbOption {
             path: path.into(),

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -41,7 +41,7 @@ where
     }
 }
 /// optimistic ACID transaction, open with
-/// [`DB::transaction`](../struct.DB.html#method.transaction) method
+/// [`DB::transaction`](crate::DB::transaction) method
 pub struct Transaction<'txn, R, FP>
 where
     R: Record,
@@ -74,7 +74,7 @@ where
     }
 
     /// get the record with `key` as the primary key and get only the data specified in
-    /// [`Projection`](../enum.Projection.html)
+    /// [`Projection`]
     pub async fn get<'get>(
         &'get self,
         key: &'get R::Key,
@@ -128,8 +128,8 @@ where
         }
     }
 
-    /// commit the data in the [`Transaction`](struct.Transaction.html) to the corresponding
-    /// [`DB`](../struct.DB.html)
+    /// commit the data in the [`Transaction`] to the corresponding
+    /// [`DB`](crate::DB)
     pub async fn commit(mut self) -> Result<(), CommitError<R>> {
         let mut _key_guards = Vec::new();
 


### PR DESCRIPTION
Some links didnt work, like the `DbOption` in the doc of `DB::new`. https://docs.rs/tonbo/0.1.0/tonbo/struct.DB.html

This PR should fix the problem.