### PR TITLE
fix: add ts filter on MergeStream

### DIFF
--- a/src/compaction/mod.rs
+++ b/src/compaction/mod.rs
@@ -342,7 +342,7 @@ where
     where
         FP: 'scan,
     {
-        let mut stream = MergeStream::<R, FP>::from_vec(streams).await?;
+        let mut stream = MergeStream::<R, FP>::from_vec(streams, u32::MAX.into()).await?;
 
         // Kould: is the capacity parameter necessary?
         let mut builder = R::Columns::builder(8192);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -586,7 +586,7 @@ where
             )
             .await?;
 
-        Ok(MergeStream::from_vec(self.streams).await?)
+        Ok(MergeStream::from_vec(self.streams, self.ts).await?)
     }
 
     /// Get a Stream that returns RecordBatch consisting of a `batch_size` number of records
@@ -616,7 +616,7 @@ where
                 self.projection,
             )
             .await?;
-        let merge_stream = MergeStream::from_vec(self.streams).await?;
+        let merge_stream = MergeStream::from_vec(self.streams, self.ts).await?;
 
         Ok(PackageStream::new(
             batch_size,

--- a/src/stream/package.rs
+++ b/src/stream/package.rs
@@ -183,9 +183,12 @@ mod tests {
         .await
         .unwrap();
 
-        let merge = MergeStream::<Test, TokioExecutor>::from_vec(vec![m1
-            .scan((Bound::Unbounded, Bound::Unbounded), 6.into())
-            .into()])
+        let merge = MergeStream::<Test, TokioExecutor>::from_vec(
+            vec![m1
+                .scan((Bound::Unbounded, Bound::Unbounded), 6.into())
+                .into()],
+            6.into(),
+        )
         .await
         .unwrap();
         let projection_indices = vec![0, 1, 2, 3];

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -349,6 +349,11 @@ mod tests {
             .await
             .unwrap();
 
+        {
+            // to increase timestamps to 1
+            let txn = db.transaction().await;
+            txn.commit().await.unwrap();
+        }
         let mut txn = db.transaction().await;
         txn.insert(Test {
             vstring: "king".to_string(),

--- a/src/trigger.rs
+++ b/src/trigger.rs
@@ -69,8 +69,8 @@ impl<R: Record> Trigger<R> for LengthTrigger<R> {
 
 #[derive(Copy, Clone, Debug)]
 pub enum TriggerType {
-    #[allow(unused)]
     SizeOfMem(usize),
+    #[allow(unused)]
     Length(usize),
 }
 pub(crate) struct TriggerFactory<R> {


### PR DESCRIPTION
related to #103 

This pr add a filter logic on `MergeStream::poll_next` to filter the data that has larger timestamp.
