### PR TITLE
feat: add flush compaction task with oneshot notification

### DIFF
--- a/src/compaction/mod.rs
+++ b/src/compaction/mod.rs
@@ -4,6 +4,7 @@ use async_lock::RwLock;
 use futures_util::StreamExt;
 use parquet::arrow::{AsyncArrowWriter, ProjectionMask};
 use thiserror::Error;
+use tokio::sync::oneshot;
 use ulid::Ulid;
 
 use crate::{
@@ -16,13 +17,15 @@ use crate::{
     record::{KeyRef, Record},
     scope::Scope,
     stream::{level::LevelStream, merge::MergeStream, ScanStream},
+    transaction::CommitError,
     version::{edit::VersionEdit, set::VersionSet, Version, VersionError, MAX_LEVEL},
     DbOption, Schema,
 };
 
 #[derive(Debug)]
-pub(crate) enum CompactTask {
+pub enum CompactTask {
     Freeze,
+    Flush(Option<oneshot::Sender<()>>),
 }
 
 pub(crate) struct Compactor<R, FP>
@@ -55,7 +58,7 @@ where
     pub(crate) async fn check_then_compaction(
         &mut self,
         // TODO
-        // option_tx: Option<oneshot::Sender<()>>,
+        option_tx: Option<oneshot::Sender<()>>,
     ) -> Result<(), CompactionError<R>> {
         let mut guard = self.schema.write().await;
 
@@ -109,9 +112,9 @@ where
             let _ = mem::replace(&mut guard.immutables, sources);
         }
         // TODO
-        // if let Some(tx) = option_tx {
-        //     let _ = tx.send(());
-        // }
+        if let Some(tx) = option_tx {
+            tx.send(()).map_err(|_| CommitError::ChannelClose)?
+        }
         Ok(())
     }
 
@@ -437,6 +440,8 @@ where
     Parquet(#[from] parquet::errors::ParquetError),
     #[error("compaction version error: {0}")]
     Version(#[from] VersionError<R>),
+    #[error("database error: {0}")]
+    Commit(#[from] CommitError<R>),
     #[error("the level being compacted does not have a table")]
     EmptyLevel,
 }

--- a/src/compaction/mod.rs
+++ b/src/compaction/mod.rs
@@ -57,7 +57,6 @@ where
 
     pub(crate) async fn check_then_compaction(
         &mut self,
-        // TODO
         option_tx: Option<oneshot::Sender<()>>,
     ) -> Result<(), CompactionError<R>> {
         let mut guard = self.schema.write().await;
@@ -111,7 +110,6 @@ where
             let sources = guard.immutables.split_off(chunk_num);
             let _ = mem::replace(&mut guard.immutables, sources);
         }
-        // TODO
         if let Some(tx) = option_tx {
             tx.send(()).map_err(|_| CommitError::ChannelClose)?
         }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use async_lock::RwLockReadGuard;
-use flume::{SendError, TrySendError};
+use flume::SendError;
 use lockable::AsyncLimit;
 use parquet::errors::ParquetError;
 use thiserror::Error;
@@ -230,8 +230,6 @@ where
     WriteConflict(R::Key),
     #[error("Failed to send compact task")]
     SendCompactTaskError(#[from] SendError<CompactTask>),
-    #[error("Failed to send compact task")]
-    TrySendCompactTaskError(#[from] TrySendError<CompactTask>),
     #[error("Channel is closed")]
     ChannelClose,
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use async_lock::RwLockReadGuard;
-use flume::SendError;
+use flume::{SendError, TrySendError};
 use lockable::AsyncLimit;
 use parquet::errors::ParquetError;
 use thiserror::Error;
@@ -230,6 +230,8 @@ where
     WriteConflict(R::Key),
     #[error("Failed to send compact task")]
     SendCompactTaskError(#[from] SendError<CompactTask>),
+    #[error("Failed to send compact task")]
+    TrySendCompactTaskError(#[from] TrySendError<CompactTask>),
     #[error("Channel is closed")]
     ChannelClose,
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use async_lock::RwLockReadGuard;
+use flume::SendError;
 use lockable::AsyncLimit;
 use parquet::errors::ParquetError;
 use thiserror::Error;
@@ -227,6 +228,10 @@ where
     Database(#[from] DbError<R>),
     #[error("transaction write conflict: {:?}", .0)]
     WriteConflict(R::Key),
+    #[error("Failed to send compact task")]
+    SendCompactTaskError(#[from] SendError<CompactTask>),
+    #[error("Channel is closed")]
+    ChannelClose,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Introduces a new `Flush` variant to the `CompactTask` enum, which includes an optional `oneshot::Sender` for notifying task completion. Updates the compaction logic to handle this new task variant and sends the notification upon completion. Adds error handling for potential transmission failures in the compaction process.