### PR TITLE
point query optimization

### DIFF
--- a/src/inmem/immutable.rs
+++ b/src/inmem/immutable.rs
@@ -123,6 +123,20 @@ where
         ImmutableScan::<A::Record>::new(range, self.data.as_record_batch(), projection_mask)
     }
 
+    pub(crate) fn get(
+        &self,
+        key: &<A::Record as Record>::Key,
+        ts: Timestamp,
+        projection_mask: ProjectionMask,
+    ) -> Option<RecordBatchEntry<A::Record>> {
+        self.scan(
+            (Bound::Included(key), Bound::Included(key)),
+            ts,
+            projection_mask,
+        )
+        .next()
+    }
+
     pub(crate) fn check_conflict(&self, key: &<A::Record as Record>::Key, ts: Timestamp) -> bool {
         self.index
             .range::<TimestampedRef<<A::Record as Record>::Key>, _>((

--- a/src/inmem/mutable.rs
+++ b/src/inmem/mutable.rs
@@ -120,8 +120,7 @@ where
         Ok(is_exceeded)
     }
 
-    #[allow(unused)]
-    fn get(
+    pub(crate) fn get(
         &self,
         key: &R::Key,
         ts: Timestamp,
@@ -129,16 +128,9 @@ where
         self.data
             .range::<TimestampedRef<R::Key>, _>((
                 Bound::Included(TimestampedRef::new(key, ts)),
-                Bound::Unbounded,
+                Bound::Included(TimestampedRef::new(key, EPOCH)),
             ))
             .next()
-            .and_then(|entry| {
-                if &entry.key().value == key {
-                    Some(entry)
-                } else {
-                    None
-                }
-            })
     }
 
     pub(crate) fn scan<'scan>(
@@ -265,7 +257,9 @@ mod tests {
                 vu32: Some(1),
                 vbool: Some(true)
             }
-        )
+        );
+        assert!(mem_table.get(&key_2, 0_u32.into()).is_none());
+        assert!(mem_table.get(&key_2, 1_u32.into()).is_some());
     }
 
     #[tokio::test]


### PR DESCRIPTION
#126 
break point query into memory query and  disk query: return immediately, if data is found in memory table. Otherwise search on disk files