### PR TITLE
fix: resolve merge & `test::transaction_get`

### DIFF
--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -295,13 +295,10 @@ mod tests {
             .await
             .unwrap();
 
-        let name = "erika".to_string();
         {
-            let txn = db.transaction().await;
-            // can't read future data
-            assert!(txn.get(&name, Projection::All).await.unwrap().is_none());
-            txn.commit().await.unwrap();
+            let _ = db.version_set.increase_ts();
         }
+        let name = "erika".to_string();
         {
             let mut txn = db.transaction().await;
             {

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -239,9 +239,7 @@ where
                 })
             }
         }
-        edits.push(VersionEdit::LatestTimeStamp {
-            ts: self.transaction_ts(),
-        });
+        edits.push(VersionEdit::LatestTimeStamp { ts: self.load_ts() });
         edits.push(VersionEdit::NewLogLength { len: 0 });
         edits
     }


### PR DESCRIPTION
https://github.com/tonbo-io/tonbo/pull/132/files#diff-ca40038cc1220f9b25a1e0808df841d4b5fafcd936bfd43b9f8e39b8719a66c5R298

Before pr: https://github.com/tonbo-io/tonbo/pull/122, transaction_ts can only be incremented by creating a transaction. After pr: https://github.com/tonbo-io/tonbo/pull/125, you need to use `increase_ts`