### PR TITLE
fix oneshot channel dropped while mutable is empty

### DIFF
--- a/src/compaction/mod.rs
+++ b/src/compaction/mod.rs
@@ -66,6 +66,9 @@ where
         guard.trigger.reset();
 
         if guard.mutable.is_empty() {
+            if let Some(tx) = option_tx {
+                tx.send(()).map_err(|_| CommitError::ChannelClose)?
+            }
             return Ok(());
         }
 


### PR DESCRIPTION
fix manually flush panic when mutable is empty(due to channel dropping before sending)