### PR TITLE
ci: only run benchmark in pr event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
   benchmark:
     name: Rust benchmark
     runs-on: self-hosted
-    if: github.event_name == 'push'
+    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4
       - name: Install latest nightly


### PR DESCRIPTION
when the pr is merged, the benchmark action will make an error when commenting because the pr cannot be found.
