### PR TITLE
feat:  avoid sst compacat twice

### DIFF
--- a/src/stream/level.rs
+++ b/src/stream/level.rs
@@ -14,7 +14,6 @@ use crate::{
     fs::{FileId, FileProvider},
     ondisk::{scan::SsTableScan, sstable::SsTable},
     record::Record,
-    scope::Scope,
     stream::record_batch::RecordBatchEntry,
     timestamp::Timestamp,
     version::Version,
@@ -64,19 +63,13 @@ where
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         version: &Version<R, FP>,
-        level: usize,
-        start: usize,
-        end: usize,
+        mut gens: VecDeque<FileId>,
         range: (Bound<&'level R::Key>, Bound<&'level R::Key>),
         ts: Timestamp,
         limit: Option<usize>,
         projection_mask: ProjectionMask,
     ) -> Option<Self> {
         let (lower, upper) = range;
-        let mut gens: VecDeque<FileId> = version.level_slice[level][start..end + 1]
-            .iter()
-            .map(Scope::gen)
-            .collect();
         let first_gen = gens.pop_front()?;
         let status = FutureStatus::Init(first_gen);
 
@@ -155,15 +148,18 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::Bound, sync::Arc};
+    use std::{
+        collections::{Bound, VecDeque},
+        sync::Arc,
+    };
 
     use futures_util::StreamExt;
     use parquet::arrow::{arrow_to_parquet_schema, ProjectionMask};
     use tempfile::TempDir;
 
     use crate::{
-        compaction::tests::build_version, record::Record, stream::level::LevelStream, tests::Test,
-        DbOption,
+        compaction::tests::build_version, fs::FileId, record::Record, stream::level::LevelStream,
+        tests::Test, DbOption,
     };
 
     #[tokio::test]
@@ -171,14 +167,14 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let option = Arc::new(DbOption::from(temp_dir.path()));
 
-        let (_, version) = build_version(&option).await;
+        let ((gen1, gen2, _, _, _), version) = build_version(&option).await;
+
+        let gens: VecDeque<FileId> = [gen1, gen2].into_iter().collect();
 
         {
             let mut level_stream_1 = LevelStream::new(
                 &version,
-                0,
-                0,
-                1,
+                gens.clone(),
                 (Bound::Unbounded, Bound::Unbounded),
                 1_u32.into(),
                 None,
@@ -211,9 +207,7 @@ mod tests {
         {
             let mut level_stream_1 = LevelStream::new(
                 &version,
-                0,
-                0,
-                1,
+                gens.clone(),
                 (Bound::Unbounded, Bound::Unbounded),
                 1_u32.into(),
                 None,
@@ -246,9 +240,7 @@ mod tests {
         {
             let mut level_stream_1 = LevelStream::new(
                 &version,
-                0,
-                0,
-                1,
+                gens,
                 (Bound::Unbounded, Bound::Unbounded),
                 1_u32.into(),
                 None,


### PR DESCRIPTION
#151 
- Add a compact status to avoid sst compact twice
- Modify `LevelStream::new` declaration to accept needed data only
- remove range index returned by `this_level_scopes` and `next_level_scopes`