### PR TITLE
separate major and minor compaction

### DIFF
--- a/src/compaction/mod.rs
+++ b/src/compaction/mod.rs
@@ -958,9 +958,6 @@ pub(crate) mod tests {
         }
 
         db.flush().await.unwrap();
-        let version = db.version_set.current().await;
-
-        dbg!(version.clone());
         for i in 0..4 {
             let item = Test {
                 vstring: i.to_string(),
@@ -971,9 +968,6 @@ pub(crate) mod tests {
         }
 
         db.flush().await.unwrap();
-        let version = db.version_set.current().await;
-
-        dbg!(version.clone());
 
         db.insert(Test {
             vstring: "6".to_owned(),
@@ -990,9 +984,6 @@ pub(crate) mod tests {
         .await
         .unwrap();
         db.flush().await.unwrap();
-        let version = db.version_set.current().await;
-
-        dbg!(version.clone());
         db.insert(Test {
             vstring: "1".to_owned(),
             vu32: 22,
@@ -1008,9 +999,6 @@ pub(crate) mod tests {
         .await
         .unwrap();
         db.flush().await.unwrap();
-        let version = db.version_set.current().await;
-
-        dbg!(version.clone());
 
         db.insert(Test {
             vstring: "2".to_owned(),
@@ -1030,7 +1018,6 @@ pub(crate) mod tests {
 
         let version = db.version_set.current().await;
 
-        dbg!(version.clone());
         for level in 0..MAX_LEVEL {
             let sort_runs = &version.level_slice[level];
 

--- a/src/compaction/states.rs
+++ b/src/compaction/states.rs
@@ -1,0 +1,92 @@
+use std::{
+    collections::{HashSet, VecDeque},
+    sync::Arc,
+};
+
+use async_lock::RwLock;
+
+use super::task::CompactionTask;
+use crate::{fs::FileId, record::Record, DbOption};
+
+/// `CompactionStates` is a global state of compaction, containing the compaction tasks that will be
+/// compacted
+#[allow(unused)]
+pub(crate) struct CompactionStates<R>
+where
+    R: Record,
+{
+    inner: Arc<RwLock<CompactionStatesInner>>,
+    pub(crate) option: Arc<DbOption<R>>,
+}
+
+impl<R> CompactionStates<R>
+where
+    R: Record,
+{
+    pub(crate) fn new(option: Arc<DbOption<R>>) -> Self {
+        Self {
+            option,
+            inner: Arc::new(RwLock::new(CompactionStatesInner::new())),
+        }
+    }
+
+    #[allow(unused)]
+    pub(crate) async fn in_process(&self, gen: &FileId) -> bool {
+        self.inner.read().await.status.contains(gen)
+    }
+
+    #[allow(unused)]
+    pub(crate) async fn add_task(&self, task: CompactionTask) {
+        self.inner.write().await.add_task(task)
+    }
+
+    pub(crate) async fn add_task_batch(&self, task_batch: Vec<CompactionTask>) {
+        let mut guard = self.inner.write().await;
+        for task in task_batch {
+            guard.add_task(task)
+        }
+    }
+
+    pub(crate) async fn consume_task(&self) -> Option<CompactionTask> {
+        self.inner.write().await.consume_task()
+    }
+
+    pub(crate) async fn finish_task(&self, task: &CompactionTask) {
+        self.inner.write().await.finish_task(task)
+    }
+}
+
+struct CompactionStatesInner {
+    tasks: VecDeque<CompactionTask>,
+    status: HashSet<FileId>,
+}
+
+impl CompactionStatesInner {
+    fn new() -> Self {
+        Self {
+            tasks: VecDeque::default(),
+            status: HashSet::default(),
+        }
+    }
+
+    fn add_task(&mut self, task: CompactionTask) {
+        if let CompactionTask::Major(task) = &task {
+            for gen in task.base().iter().chain(task.target().iter()) {
+                self.status.insert(*gen);
+            }
+        }
+        self.tasks.push_back(task);
+    }
+
+    fn consume_task(&mut self) -> Option<CompactionTask> {
+        self.tasks.pop_front()
+    }
+
+    fn finish_task(&mut self, task: &CompactionTask) {
+        if let CompactionTask::Major(task) = &task {
+            for gen in task.base().iter().chain(task.target().iter()) {
+                self.status.remove(gen);
+            }
+        }
+    }
+}

--- a/src/compaction/task.rs
+++ b/src/compaction/task.rs
@@ -1,0 +1,200 @@
+use std::{ops::Bound, sync::Arc};
+
+use parquet::arrow::ProjectionMask;
+
+use super::{states::CompactionStates, CompactionError, Compactor};
+use crate::{
+    fs::{FileId, FileProvider},
+    ondisk::sstable::SsTable,
+    record::Record,
+    stream::{level::LevelStream, ScanStream},
+    version::{edit::VersionEdit, Version, MAX_LEVEL},
+    DbOption,
+};
+
+/// `CompactionStatus` is the result of a compaction.
+pub(crate) struct CompactionStatus<R>
+where
+    R: Record,
+{
+    pub(crate) delete_gens: Option<Vec<FileId>>,
+    pub(crate) version_edits: Vec<VersionEdit<R::Key>>,
+}
+
+pub(crate) enum CompactionTask {
+    #[allow(unused)]
+    Minor,
+    Major(MajorTask),
+}
+
+pub(crate) struct MajorTask {
+    base: Vec<FileId>,
+    target: Vec<FileId>,
+    base_level: usize,
+}
+
+impl MajorTask {
+    pub(crate) fn new(base_level: usize, base: Vec<FileId>, target: Vec<FileId>) -> Self {
+        Self {
+            base,
+            target,
+            base_level,
+        }
+    }
+
+    pub(crate) fn base(&self) -> &Vec<FileId> {
+        &self.base
+    }
+
+    pub(crate) fn target(&self) -> &Vec<FileId> {
+        &self.target
+    }
+
+    #[allow(unused)]
+    pub(crate) fn level(&self) -> u8 {
+        self.base_level as u8
+    }
+
+    pub(crate) async fn compact<R, FP>(
+        &self,
+        option: Arc<DbOption<R>>,
+        version_edits: &mut Vec<VersionEdit<<R as Record>::Key>>,
+    ) -> Result<(), CompactionError<R>>
+    where
+        R: Record,
+        FP: FileProvider,
+    {
+        let mut streams = Vec::with_capacity(self.base.len() + self.target.len());
+        if self.base_level == 0 {
+            for gen in self.base().iter() {
+                let file = FP::open(option.table_path(gen)).await?;
+
+                streams.push(ScanStream::SsTable {
+                    inner: SsTable::<R, FP>::open(file)
+                        .scan(
+                            (Bound::Unbounded, Bound::Unbounded),
+                            u32::MAX.into(),
+                            None,
+                            ProjectionMask::all(),
+                        )
+                        .await?,
+                });
+            }
+        } else {
+            let gens = self.base.iter().copied().collect();
+
+            let level_scan_l = LevelStream::new(
+                option.clone(),
+                gens,
+                (Bound::Unbounded, Bound::Unbounded),
+                u32::MAX.into(),
+                None,
+                ProjectionMask::all(),
+            )
+            .ok_or(CompactionError::EmptyLevel)?;
+
+            streams.push(ScanStream::Level {
+                inner: level_scan_l,
+            });
+        }
+        if !self.target.is_empty() {
+            // Next Level
+            let gens = self.target.iter().copied().collect();
+            let level_scan_ll = LevelStream::new(
+                option.clone(),
+                gens,
+                (Bound::Unbounded, Bound::Unbounded),
+                u32::MAX.into(),
+                None,
+                ProjectionMask::all(),
+            )
+            .ok_or(CompactionError::EmptyLevel)?;
+
+            streams.push(ScanStream::Level {
+                inner: level_scan_ll,
+            });
+        }
+        Compactor::build_tables(option.as_ref(), version_edits, self.base_level, streams).await?;
+
+        for gen in self.base.iter() {
+            version_edits.push(VersionEdit::Remove {
+                level: self.base_level as u8,
+                gen: *gen,
+            });
+        }
+        for gen in self.target.iter() {
+            version_edits.push(VersionEdit::Remove {
+                level: self.base_level as u8 + 1,
+                gen: *gen,
+            });
+        }
+        Ok(())
+    }
+}
+
+impl CompactionTask {
+    pub(crate) async fn generate_major_tasks<R, FP>(
+        version: &Version<R, FP>,
+        option: &DbOption<R>,
+        mut min: &R::Key,
+        mut max: &R::Key,
+    ) -> Result<Vec<CompactionTask>, CompactionError<R>>
+    where
+        R: Record,
+        FP: FileProvider,
+    {
+        let mut level = 0;
+        let mut tasks = vec![];
+
+        while level < MAX_LEVEL - 2 {
+            if !option.is_threshold_exceeded_major(version, level) {
+                break;
+            }
+            let meet_scopes_l = Compactor::this_level_scopes(version, min, max, level);
+            let meet_scopes_ll =
+                Compactor::next_level_scopes(version, &mut min, &mut max, level, &meet_scopes_l)?;
+
+            let base = meet_scopes_l.iter().map(|scope| scope.gen).collect();
+            let target = meet_scopes_ll.iter().map(|scope| scope.gen).collect();
+
+            tasks.push(CompactionTask::Major(MajorTask::new(level, base, target)));
+            level += 1;
+        }
+
+        Ok(tasks)
+    }
+
+    pub(crate) async fn compact<R, FP>(
+        &self,
+        states: &Arc<CompactionStates<R>>,
+    ) -> Result<CompactionStatus<R>, CompactionError<R>>
+    where
+        R: Record,
+        FP: FileProvider,
+    {
+        match self {
+            CompactionTask::Minor => todo!(),
+            CompactionTask::Major(task) => {
+                let mut delete_gens = vec![];
+                task.base().iter().for_each(|gen| delete_gens.push(*gen));
+                task.target().iter().for_each(|gen| delete_gens.push(*gen));
+
+                let mut version_edits = vec![];
+                task.compact::<R, FP>(states.option.clone(), &mut version_edits)
+                    .await?;
+
+                Ok(CompactionStatus {
+                    delete_gens: Some(delete_gens),
+                    version_edits,
+                })
+            }
+        }
+    }
+
+    pub(crate) async fn finish<R>(&self, states: &Arc<CompactionStates<R>>)
+    where
+        R: Record,
+    {
+        states.finish_task(self).await;
+    }
+}

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod edit;
 pub(crate) mod set;
 
 use std::{
+    collections::VecDeque,
     marker::PhantomData,
     ops::Bound,
     sync::{
@@ -207,32 +208,26 @@ where
                     .map_err(VersionError::Parquet)?,
             })
         }
-        for (i, scopes) in self.level_slice[1..].iter().enumerate() {
+        for scopes in self.level_slice[1..].iter() {
             if scopes.is_empty() {
                 continue;
             }
 
-            let (mut start, mut end) = (None, None);
+            let gens: VecDeque<FileId> = scopes
+                .iter()
+                .filter(|scope| scope.meets_range(range))
+                .map(Scope::gen)
+                .collect();
 
-            for (idx, scope) in scopes.iter().enumerate() {
-                if scope.meets_range(range) {
-                    if start.is_none() {
-                        start = Some(idx);
-                    }
-                    end = Some(idx);
-                }
-            }
-            if start.is_none() {
+            if gens.is_empty() {
                 continue;
             }
 
             streams.push(ScanStream::Level {
                 // SAFETY: checked scopes no empty
                 inner: LevelStream::new(
-                    self,
-                    i + 1,
-                    start.unwrap(),
-                    end.unwrap(),
+                    self.option.clone(),
+                    gens,
                     range,
                     ts,
                     limit,


### PR DESCRIPTION
Use a global queue `CompactionStates` to store major compaction tasks. Whenever compaction is triggered, poll a task to compact.