### PR TITLE
fix: modify SQL query and streamline DataFrame execution

### DIFF
--- a/examples/datafusion.rs
+++ b/examples/datafusion.rs
@@ -237,13 +237,12 @@ async fn main() -> Result<()> {
 
     {
         // support sql query for tonbo
-        let statements = DFParser::parse_sql("select * from music")?;
+        let statements = DFParser::parse_sql("select id from music")?;
         let plan = ctx
             .state()
             .statement_to_plan(statements.front().cloned().unwrap())
             .await?;
-        ctx.execute_logical_plan(plan).await?;
-        let df = ctx.table("music").await?;
+        let df = ctx.execute_logical_plan(plan).await?;
         let physical_plan = df.create_physical_plan().await?;
         let mut stream = execute_stream(physical_plan, ctx.task_ctx())?;
         while let Some(maybe_batch) = stream.next().await {


### PR DESCRIPTION
This pull request includes a change to the SQL query and the execution order in the `main` function of the `examples/datafusion.rs` file. The most important changes are as follows:

### SQL Query Update:
* Modified the SQL query from `select * from music` to `select id from music` to limit the columns retrieved. (`examples/datafusion.rs`, [examples/datafusion.rsL240-R245](diffhunk://#diff-8465dc0f99d36da97211853d2b789fe53641b9b2b372ef10a063dad79e16d571L240-R245))

### Execution Order Adjustment:
* Changed the execution order by combining the logical plan execution and table retrieval into a single step. (`examples/datafusion.rs`, [examples/datafusion.rsL240-R245](diffhunk://#diff-8465dc0f99d36da97211853d2b789fe53641b9b2b372ef10a063dad79e16d571L240-R245))