### PR TITLE
fix: `DbOption::table_path` with level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,8 +58,9 @@ crc32fast = "1"
 crossbeam-skiplist = "0.1"
 datafusion = { version = "42", optional = true }
 flume = { version = "0.11", features = ["async"] }
-fusio = { git = "https://github.com/tonbo-io/fusio.git", package = "fusio", rev = "65e9325daf1e8a4c363a5498058cecacc4b2e0fa", features = ["tokio", "dyn"] }
-fusio-parquet = { git = "https://github.com/tonbo-io/fusio.git", package = "fusio-parquet", rev = "65e9325daf1e8a4c363a5498058cecacc4b2e0fa" }
+fusio = { git = "https://github.com/tonbo-io/fusio.git", package = "fusio", rev = "02e26116a1bd842a3a1038947d307e81effeb8dc", features = ["tokio", "dyn", "aws", "fs", "object_store", "tokio-http"] }
+fusio-dispatch = { git = "https://github.com/tonbo-io/fusio.git", package = "fusio-dispatch", rev = "02e26116a1bd842a3a1038947d307e81effeb8dc", features = ["aws", "tokio"] }
+fusio-parquet = { git = "https://github.com/tonbo-io/fusio.git", package = "fusio-parquet", rev = "02e26116a1bd842a3a1038947d307e81effeb8dc" }
 futures-core = "0.3"
 futures-io = "0.3"
 futures-util = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,9 +58,9 @@ crc32fast = "1"
 crossbeam-skiplist = "0.1"
 datafusion = { version = "42", optional = true }
 flume = { version = "0.11", features = ["async"] }
-fusio = { git = "https://github.com/tonbo-io/fusio.git", package = "fusio", rev = "02e26116a1bd842a3a1038947d307e81effeb8dc", features = ["tokio", "dyn", "aws", "fs", "object_store", "tokio-http"] }
-fusio-dispatch = { git = "https://github.com/tonbo-io/fusio.git", package = "fusio-dispatch", rev = "02e26116a1bd842a3a1038947d307e81effeb8dc", features = ["aws", "tokio"] }
-fusio-parquet = { git = "https://github.com/tonbo-io/fusio.git", package = "fusio-parquet", rev = "02e26116a1bd842a3a1038947d307e81effeb8dc" }
+fusio = { git = "https://github.com/tonbo-io/fusio.git", package = "fusio", version = "0.2.0", features = ["tokio", "dyn", "aws", "fs", "object_store", "tokio-http"] }
+fusio-dispatch = { git = "https://github.com/tonbo-io/fusio.git", package = "fusio-dispatch", version = "0.2.0", features = ["aws", "tokio"] }
+fusio-parquet = { git = "https://github.com/tonbo-io/fusio.git", package = "fusio-parquet", version = "0.2.0" }
 futures-core = "0.3"
 futures-io = "0.3"
 futures-util = "0.3"

--- a/benches/common.rs
+++ b/benches/common.rs
@@ -12,6 +12,7 @@ use futures_util::StreamExt;
 use parquet::data_type::AsBytes;
 use redb::TableDefinition;
 use rocksdb::{Direction, IteratorMode, TransactionDB};
+use tokio::fs::create_dir_all;
 use tonbo::{
     executor::tokio::TokioExecutor, stream, transaction::TransactionEntry, DbOption, Projection,
 };
@@ -221,6 +222,8 @@ impl BenchDatabase for TonboBenchDataBase {
     }
 
     async fn build(path: impl AsRef<Path>) -> Self {
+        create_dir_all(path.as_ref()).await.unwrap();
+
         let option =
             DbOption::from(fusio::path::Path::from_filesystem_path(path.as_ref()).unwrap())
                 .disable_wal();

--- a/benches/criterion/writes.rs
+++ b/benches/criterion/writes.rs
@@ -1,9 +1,8 @@
 use std::{iter::repeat_with, sync::Arc};
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use fusio::local::TokioFs;
 use mimalloc::MiMalloc;
-use tonbo::{executor::tokio::TokioExecutor, fs::manager::StoreManager, DbOption, Record, DB};
+use tonbo::{executor::tokio::TokioExecutor, DbOption, Record, DB};
 
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;

--- a/src/compaction/mod.rs
+++ b/src/compaction/mod.rs
@@ -60,18 +60,12 @@ where
         }
     }
 
-    pub(crate) async fn check_then_compaction(
-        &mut self,
-        option_tx: Option<oneshot::Sender<()>>,
-    ) -> Result<(), CompactionError<R>> {
+    pub(crate) async fn check_then_compaction(&mut self) -> Result<(), CompactionError<R>> {
         let mut guard = self.schema.write().await;
 
         guard.trigger.reset();
 
         if guard.mutable.is_empty() {
-            if let Some(tx) = option_tx {
-                tx.send(()).map_err(|_| CommitError::ChannelClose)?
-            }
             return Ok(());
         }
 
@@ -130,9 +124,6 @@ where
             let sources = guard.immutables.split_off(chunk_num);
             let _ = mem::replace(&mut guard.immutables, sources);
         }
-        if let Some(tx) = option_tx {
-            tx.send(()).map_err(|_| CommitError::ChannelClose)?
-        }
         Ok(())
     }
 
@@ -156,7 +147,7 @@ where
             let mut writer = AsyncArrowWriter::try_new(
                 AsyncWriter::new(
                     level_0_fs
-                        .open_options(&option.table_path(&gen, 0), default_open_options())
+                        .open_options(&option.table_path(&gen, 0), default_open_options(false))
                         .await?,
                 ),
                 instance.arrow_schema::<R>().clone(),
@@ -219,7 +210,10 @@ where
             if level == 0 {
                 for scope in meet_scopes_l.iter() {
                     let file = level_fs
-                        .open_options(&option.table_path(&scope.gen, level), default_open_options())
+                        .open_options(
+                            &option.table_path(&scope.gen, level),
+                            default_open_options(false),
+                        )
                         .await?;
 
                     streams.push(ScanStream::SsTable {
@@ -273,7 +267,15 @@ where
                     inner: level_scan_ll,
                 });
             }
-            Self::build_tables(option, version_edits, level, streams, instance, level_fs).await?;
+            Self::build_tables(
+                option,
+                version_edits,
+                level + 1,
+                streams,
+                instance,
+                level_fs,
+            )
+            .await?;
 
             for scope in meet_scopes_l {
                 version_edits.push(VersionEdit::Remove {
@@ -454,7 +456,7 @@ where
         let columns = builder.finish(None);
         let mut writer = AsyncArrowWriter::try_new(
             AsyncWriter::new(
-                fs.open_options(&option.table_path(&gen, level), default_open_options())
+                fs.open_options(&option.table_path(&gen, level), default_open_options(false))
                     .await?,
             ),
             instance.arrow_schema::<R>().clone(),
@@ -463,7 +465,7 @@ where
         writer.write(columns.as_record_batch()).await?;
         writer.close().await?;
         version_edits.push(VersionEdit::Add {
-            level: (level + 1) as u8,
+            level: level as u8,
             scope: Scope {
                 min: min.take().ok_or(CompactionError::EmptyLevel)?,
                 max: max.take().ok_or(CompactionError::EmptyLevel)?,
@@ -488,6 +490,8 @@ where
     Fusio(#[from] fusio::Error),
     #[error("compaction version error: {0}")]
     Version(#[from] VersionError<R>),
+    #[error("compaction channel is closed")]
+    ChannelClose,
     #[error("database error: {0}")]
     Commit(#[from] CommitError<R>),
     #[error("the level being compacted does not have a table")]
@@ -499,7 +503,8 @@ pub(crate) mod tests {
     use std::sync::{atomic::AtomicU32, Arc};
 
     use flume::bounded;
-    use fusio::{options::FsOptions, path::Path, DynFs};
+    use fusio::{path::Path, DynFs};
+    use fusio_dispatch::FsOptions;
     use fusio_parquet::writer::AsyncWriter;
     use parquet::arrow::AsyncArrowWriter;
     use tempfile::TempDir;
@@ -552,7 +557,7 @@ pub(crate) mod tests {
         let immutable = build_immutable::<R>(option, records, instance, fs).await?;
         let mut writer = AsyncArrowWriter::try_new(
             AsyncWriter::new(
-                fs.open_options(&option.table_path(&gen, level), default_open_options())
+                fs.open_options(&option.table_path(&gen, level), default_open_options(false))
                     .await?,
             ),
             R::arrow_schema().clone(),
@@ -567,11 +572,19 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn minor_compaction() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let option = DbOption::from(Path::from_filesystem_path(temp_dir.path()).unwrap());
+        let temp_dir_l0 = tempfile::tempdir().unwrap();
+
+        let option = DbOption::from(Path::from_filesystem_path(temp_dir.path()).unwrap())
+            .level_path(
+                0,
+                Path::from_filesystem_path(temp_dir_l0.path()).unwrap(),
+                FsOptions::Local,
+            )
+            .unwrap();
         let manager =
             StoreManager::new(option.base_fs.clone(), option.level_paths.clone()).unwrap();
-
         manager
+            .base_fs()
             .create_dir_all(&option.wal_dir_path())
             .await
             .unwrap();
@@ -651,7 +664,7 @@ pub(crate) mod tests {
         .unwrap();
 
         let scope = Compactor::<Test>::minor_compaction(
-            &DbOption::from(Path::from_filesystem_path(temp_dir.path()).unwrap()),
+            &option,
             None,
             &vec![
                 (Some(FileId::new()), batch_1),
@@ -677,6 +690,7 @@ pub(crate) mod tests {
             0,
         );
         manager
+            .base_fs()
             .create_dir_all(&option.wal_dir_path())
             .await
             .unwrap();
@@ -739,18 +753,34 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn major_compaction() {
         let temp_dir = TempDir::new().unwrap();
+        let temp_dir_l0 = TempDir::new().unwrap();
+        let temp_dir_l1 = TempDir::new().unwrap();
 
-        let mut option = DbOption::from(Path::from_filesystem_path(temp_dir.path()).unwrap());
+        let mut option = DbOption::from(Path::from_filesystem_path(temp_dir.path()).unwrap())
+            .level_path(
+                0,
+                Path::from_filesystem_path(temp_dir_l0.path()).unwrap(),
+                FsOptions::Local,
+            )
+            .unwrap()
+            .level_path(
+                1,
+                Path::from_filesystem_path(temp_dir_l1.path()).unwrap(),
+                FsOptions::Local,
+            )
+            .unwrap();
         option.major_threshold_with_sst_size = 2;
         let option = Arc::new(option);
         let manager =
             StoreManager::new(option.base_fs.clone(), option.level_paths.clone()).unwrap();
 
         manager
+            .base_fs()
             .create_dir_all(&option.version_log_dir_path())
             .await
             .unwrap();
         manager
+            .base_fs()
             .create_dir_all(&option.wal_dir_path())
             .await
             .unwrap();
@@ -1072,10 +1102,12 @@ pub(crate) mod tests {
             StoreManager::new(option.base_fs.clone(), option.level_paths.clone()).unwrap();
 
         manager
+            .base_fs()
             .create_dir_all(&option.version_log_dir_path())
             .await
             .unwrap();
         manager
+            .base_fs()
             .create_dir_all(&option.wal_dir_path())
             .await
             .unwrap();

--- a/src/compaction/mod.rs
+++ b/src/compaction/mod.rs
@@ -156,7 +156,7 @@ where
             let mut writer = AsyncArrowWriter::try_new(
                 AsyncWriter::new(
                     level_0_fs
-                        .open_options(&option.table_path(&gen), default_open_options())
+                        .open_options(&option.table_path(&gen, 0), default_open_options())
                         .await?,
                 ),
                 instance.arrow_schema::<R>().clone(),
@@ -219,7 +219,7 @@ where
             if level == 0 {
                 for scope in meet_scopes_l.iter() {
                     let file = level_fs
-                        .open_options(&option.table_path(&scope.gen), default_open_options())
+                        .open_options(&option.table_path(&scope.gen, level), default_open_options())
                         .await?;
 
                     streams.push(ScanStream::SsTable {
@@ -454,7 +454,7 @@ where
         let columns = builder.finish(None);
         let mut writer = AsyncArrowWriter::try_new(
             AsyncWriter::new(
-                fs.open_options(&option.table_path(&gen), default_open_options())
+                fs.open_options(&option.table_path(&gen, level), default_open_options())
                     .await?,
             ),
             instance.arrow_schema::<R>().clone(),
@@ -543,6 +543,7 @@ pub(crate) mod tests {
         gen: FileId,
         records: Vec<(LogType, R, Timestamp)>,
         instance: &RecordInstance,
+        level: usize,
         fs: &Arc<dyn DynFs>,
     ) -> Result<(), DbError<R>>
     where
@@ -551,7 +552,7 @@ pub(crate) mod tests {
         let immutable = build_immutable::<R>(option, records, instance, fs).await?;
         let mut writer = AsyncArrowWriter::try_new(
             AsyncWriter::new(
-                fs.open_options(&option.table_path(&gen), default_open_options())
+                fs.open_options(&option.table_path(&gen, level), default_open_options())
                     .await?,
             ),
             R::arrow_schema().clone(),
@@ -851,6 +852,7 @@ pub(crate) mod tests {
                 ),
             ],
             &RecordInstance::Normal,
+            0,
             level_0_fs,
         )
         .await
@@ -888,6 +890,7 @@ pub(crate) mod tests {
                 ),
             ],
             &RecordInstance::Normal,
+            0,
             level_0_fs,
         )
         .await
@@ -930,6 +933,7 @@ pub(crate) mod tests {
                 ),
             ],
             &RecordInstance::Normal,
+            1,
             level_1_fs,
         )
         .await
@@ -967,6 +971,7 @@ pub(crate) mod tests {
                 ),
             ],
             &RecordInstance::Normal,
+            1,
             level_1_fs,
         )
         .await
@@ -1004,6 +1009,7 @@ pub(crate) mod tests {
                 ),
             ],
             &RecordInstance::Normal,
+            1,
             level_1_fs,
         )
         .await
@@ -1108,6 +1114,7 @@ pub(crate) mod tests {
             table_gen0,
             records0,
             &RecordInstance::Normal,
+            0,
             level_0_fs,
         )
         .await
@@ -1117,6 +1124,7 @@ pub(crate) mod tests {
             table_gen1,
             records1,
             &RecordInstance::Normal,
+            1,
             level_1_fs,
         )
         .await

--- a/src/fs/manager.rs
+++ b/src/fs/manager.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
-use fusio::{dynamic::DynFs, options::FsOptions, path::Path, Error};
+use fusio::{dynamic::DynFs, path::Path, Error};
+use fusio_dispatch::FsOptions;
 
 pub struct StoreManager {
     base_fs: Arc<dyn DynFs>,
@@ -20,15 +21,6 @@ impl StoreManager {
         let base_fs = base_options.parse()?;
 
         Ok(StoreManager { base_fs, fs_map })
-    }
-
-    pub async fn create_dir_all(&self, path: &Path) -> Result<(), Error> {
-        self.base_fs.create_dir_all(path).await?;
-        for (_, fs) in self.fs_map.iter() {
-            fs.create_dir_all(path).await?;
-        }
-
-        Ok(())
     }
 
     pub fn base_fs(&self) -> &Arc<dyn DynFs> {

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -26,12 +26,20 @@ impl Display for FileType {
     }
 }
 
-pub(crate) fn default_open_options(is_append: bool) -> OpenOptions {
-    let options = OpenOptions::default().create(true).read(true);
-    if is_append {
-        options.append(true)
-    } else {
-        options.write(true)
+impl FileType {
+    pub(crate) fn open_options(&self, only_read: bool) -> OpenOptions {
+        match self {
+            FileType::Wal | FileType::Log => {
+                OpenOptions::default().create(true).read(true).append(true)
+            }
+            FileType::Parquet => {
+                if only_read {
+                    OpenOptions::default().read(true)
+                } else {
+                    OpenOptions::default().create(true).write(true)
+                }
+            }
+        }
     }
 }
 

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -26,8 +26,13 @@ impl Display for FileType {
     }
 }
 
-pub(crate) fn default_open_options() -> OpenOptions {
-    OpenOptions::default().create(true).append(true).read(true)
+pub(crate) fn default_open_options(is_append: bool) -> OpenOptions {
+    let options = OpenOptions::default().create(true).read(true);
+    if is_append {
+        options.append(true)
+    } else {
+        options.write(true)
+    }
 }
 
 pub(crate) fn parse_file_id(path: &Path, suffix: FileType) -> Result<Option<FileId>, DecodeError> {

--- a/src/inmem/mutable.rs
+++ b/src/inmem/mutable.rs
@@ -9,7 +9,7 @@ use fusio::{dynamic::DynFile, DynFs};
 use ulid::Ulid;
 
 use crate::{
-    fs::{default_open_options, FileId},
+    fs::{FileId, FileType},
     inmem::immutable::Immutable,
     record::{Key, KeyRef, Record, RecordInstance},
     timestamp::{
@@ -54,7 +54,10 @@ where
         if option.use_wal {
             let file_id = Ulid::new();
             let file = fs
-                .open_options(&option.wal_path(&file_id), default_open_options(true))
+                .open_options(
+                    &option.wal_path(&file_id),
+                    FileType::Wal.open_options(false),
+                )
                 .await?;
 
             wal = Some(Mutex::new(WalFile::new(file, file_id)));

--- a/src/inmem/mutable.rs
+++ b/src/inmem/mutable.rs
@@ -54,7 +54,7 @@ where
         if option.use_wal {
             let file_id = Ulid::new();
             let file = fs
-                .open_options(&option.wal_path(&file_id), default_open_options())
+                .open_options(&option.wal_path(&file_id), default_open_options(true))
                 .await?;
 
             wal = Some(Mutex::new(WalFile::new(file, file_id)));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,7 @@ pub use crate::option::*;
 use crate::{
     compaction::{CompactTask, CompactionError, Compactor},
     executor::Executor,
-    fs::{default_open_options, manager::StoreManager, parse_file_id, FileId, FileType},
+    fs::{manager::StoreManager, parse_file_id, FileId, FileType},
     serdes::Decode,
     stream::{
         mem_projection::MemProjectionStream, merge::MergeStream, package::PackageStream, Entry,
@@ -469,7 +469,7 @@ where
             let wal_path = wal_meta.path;
 
             let file = base_fs
-                .open_options(&wal_path, default_open_options(true))
+                .open_options(&wal_path, FileType::Wal.open_options(false))
                 .await?;
             // SAFETY: wal_stream return only file name
             let wal_id = parse_file_id(&wal_path, FileType::Wal)?.unwrap();

--- a/src/ondisk/sstable.rs
+++ b/src/ondisk/sstable.rs
@@ -31,7 +31,7 @@ where
         let size = DynRead::size(&file).await?;
 
         Ok(SsTable {
-            reader: AsyncReader::new(file, size),
+            reader: AsyncReader::new(file, size).await?,
             _marker: PhantomData,
         })
     }
@@ -102,7 +102,8 @@ pub(crate) mod tests {
     use std::{borrow::Borrow, fs::File, ops::Bound, sync::Arc};
 
     use arrow::array::RecordBatch;
-    use fusio::{dynamic::DynFile, options::FsOptions, path::Path, DynFs};
+    use fusio::{dynamic::DynFile, path::Path, DynFs};
+    use fusio_dispatch::FsOptions;
     use fusio_parquet::writer::AsyncWriter;
     use futures_util::StreamExt;
     use parquet::{
@@ -157,7 +158,7 @@ pub(crate) mod tests {
     {
         SsTable::open(
             store
-                .open_options(path, default_open_options())
+                .open_options(path, default_open_options(false))
                 .await
                 .unwrap(),
         )
@@ -180,7 +181,7 @@ pub(crate) mod tests {
         let table_path = Path::from_filesystem_path(table_path).unwrap();
 
         let file = base_fs
-            .open_options(&table_path, default_open_options())
+            .open_options(&table_path, default_open_options(false))
             .await
             .unwrap();
         write_record_batch(file, &record_batch).await.unwrap();
@@ -255,7 +256,7 @@ pub(crate) mod tests {
         let table_path = Path::from_filesystem_path(table_path).unwrap();
 
         let file = base_fs
-            .open_options(&table_path, default_open_options())
+            .open_options(&table_path, default_open_options(false))
             .await
             .unwrap();
         write_record_batch(file, &record_batch).await.unwrap();

--- a/src/ondisk/sstable.rs
+++ b/src/ondisk/sstable.rs
@@ -118,7 +118,7 @@ pub(crate) mod tests {
     use super::SsTable;
     use crate::{
         executor::tokio::TokioExecutor,
-        fs::{default_open_options, manager::StoreManager},
+        fs::{manager::StoreManager, FileType},
         record::Record,
         tests::{get_test_record_batch, Test},
         timestamp::Timestamped,
@@ -158,7 +158,7 @@ pub(crate) mod tests {
     {
         SsTable::open(
             store
-                .open_options(path, default_open_options(false))
+                .open_options(path, FileType::Parquet.open_options(true))
                 .await
                 .unwrap(),
         )
@@ -181,7 +181,7 @@ pub(crate) mod tests {
         let table_path = Path::from_filesystem_path(table_path).unwrap();
 
         let file = base_fs
-            .open_options(&table_path, default_open_options(false))
+            .open_options(&table_path, FileType::Parquet.open_options(false))
             .await
             .unwrap();
         write_record_batch(file, &record_batch).await.unwrap();
@@ -256,7 +256,7 @@ pub(crate) mod tests {
         let table_path = Path::from_filesystem_path(table_path).unwrap();
 
         let file = base_fs
-            .open_options(&table_path, default_open_options(false))
+            .open_options(&table_path, FileType::Parquet.open_options(false))
             .await
             .unwrap();
         write_record_batch(file, &record_batch).await.unwrap();

--- a/src/option.rs
+++ b/src/option.rs
@@ -3,7 +3,7 @@ use std::{
     marker::PhantomData,
 };
 
-use fusio::{path::Path};
+use fusio::path::Path;
 use fusio_dispatch::FsOptions;
 use parquet::{
     basic::Compression,
@@ -239,12 +239,11 @@ where
     R: Record,
 {
     pub(crate) fn table_path(&self, gen: &FileId, level: usize) -> Path {
-        let path = self.level_paths[level]
+        self.level_paths[level]
             .as_ref()
             .map(|(path, _)| path)
             .unwrap_or(&self.base_path)
-            .child(format!("{}.{}", gen, FileType::Parquet));
-        path
+            .child(format!("{}.{}", gen, FileType::Parquet))
     }
 
     pub(crate) fn wal_dir_path(&self) -> Path {

--- a/src/option.rs
+++ b/src/option.rs
@@ -237,8 +237,11 @@ impl<R> DbOption<R>
 where
     R: Record,
 {
-    pub(crate) fn table_path(&self, gen: &FileId) -> Path {
-        self.base_path
+    pub(crate) fn table_path(&self, gen: &FileId, level: usize) -> Path {
+        self.level_paths[level]
+            .as_ref()
+            .map(|(path, _)| path)
+            .unwrap_or(&self.base_path)
             .child(format!("{}.{}", gen, FileType::Parquet))
     }
 

--- a/src/option.rs
+++ b/src/option.rs
@@ -3,7 +3,8 @@ use std::{
     marker::PhantomData,
 };
 
-use fusio::{options::FsOptions, path::Path};
+use fusio::{path::Path};
+use fusio_dispatch::FsOptions;
 use parquet::{
     basic::Compression,
     file::properties::{EnabledStatistics, WriterProperties},
@@ -238,11 +239,12 @@ where
     R: Record,
 {
     pub(crate) fn table_path(&self, gen: &FileId, level: usize) -> Path {
-        self.level_paths[level]
+        let path = self.level_paths[level]
             .as_ref()
             .map(|(path, _)| path)
             .unwrap_or(&self.base_path)
-            .child(format!("{}.{}", gen, FileType::Parquet))
+            .child(format!("{}.{}", gen, FileType::Parquet));
+        path
     }
 
     pub(crate) fn wal_dir_path(&self) -> Path {

--- a/src/stream/level.rs
+++ b/src/stream/level.rs
@@ -15,7 +15,7 @@ use futures_core::Stream;
 use parquet::{arrow::ProjectionMask, errors::ParquetError};
 
 use crate::{
-    fs::{default_open_options, FileId},
+    fs::{FileId, FileType},
     ondisk::{scan::SsTableScan, sstable::SsTable},
     record::Record,
     scope::Scope,
@@ -109,9 +109,10 @@ where
                     let gen = *gen;
                     self.path = Some(self.option.table_path(&gen, self.level));
 
-                    let reader = self
-                        .fs
-                        .open_options(self.path.as_ref().unwrap(), default_open_options(false));
+                    let reader = self.fs.open_options(
+                        self.path.as_ref().unwrap(),
+                        FileType::Parquet.open_options(true),
+                    );
                     #[allow(clippy::missing_transmute_annotations)]
                     let reader = unsafe {
                         std::mem::transmute::<
@@ -135,7 +136,7 @@ where
 
                             let reader = self.fs.open_options(
                                 self.path.as_ref().unwrap(),
-                                default_open_options(false),
+                                FileType::Parquet.open_options(true),
                             );
                             #[allow(clippy::missing_transmute_annotations)]
                             let reader = unsafe {

--- a/src/stream/level.rs
+++ b/src/stream/level.rs
@@ -111,7 +111,7 @@ where
 
                     let reader = self
                         .fs
-                        .open_options(self.path.as_ref().unwrap(), default_open_options());
+                        .open_options(self.path.as_ref().unwrap(), default_open_options(false));
                     #[allow(clippy::missing_transmute_annotations)]
                     let reader = unsafe {
                         std::mem::transmute::<
@@ -133,9 +133,10 @@ where
                         Some(gen) => {
                             self.path = Some(self.option.table_path(&gen, self.level));
 
-                            let reader = self
-                                .fs
-                                .open_options(self.path.as_ref().unwrap(), default_open_options());
+                            let reader = self.fs.open_options(
+                                self.path.as_ref().unwrap(),
+                                default_open_options(false),
+                            );
                             #[allow(clippy::missing_transmute_annotations)]
                             let reader = unsafe {
                                 std::mem::transmute::<
@@ -203,7 +204,8 @@ where
 mod tests {
     use std::{collections::Bound, sync::Arc};
 
-    use fusio::{options::FsOptions, path::Path};
+    use fusio::{path::Path};
+    use fusio_dispatch::FsOptions;
     use futures_util::StreamExt;
     use parquet::arrow::{arrow_to_parquet_schema, ProjectionMask};
     use tempfile::TempDir;
@@ -222,10 +224,12 @@ mod tests {
         ));
 
         manager
+            .base_fs()
             .create_dir_all(&option.version_log_dir_path())
             .await
             .unwrap();
         manager
+            .base_fs()
             .create_dir_all(&option.wal_dir_path())
             .await
             .unwrap();

--- a/src/stream/level.rs
+++ b/src/stream/level.rs
@@ -45,6 +45,7 @@ where
     lower: Bound<&'level R::Key>,
     upper: Bound<&'level R::Key>,
     ts: Timestamp,
+    level: usize,
     option: Arc<DbOption<R>>,
     gens: VecDeque<FileId>,
     limit: Option<usize>,
@@ -83,6 +84,7 @@ where
             lower,
             upper,
             ts,
+            level,
             option: version.option().clone(),
             gens,
             limit,
@@ -105,7 +107,7 @@ where
             return match &mut self.status {
                 FutureStatus::Init(gen) => {
                     let gen = *gen;
-                    self.path = Some(self.option.table_path(&gen));
+                    self.path = Some(self.option.table_path(&gen, self.level));
 
                     let reader = self
                         .fs
@@ -129,7 +131,7 @@ where
                     Poll::Ready(None) => match self.gens.pop_front() {
                         None => Poll::Ready(None),
                         Some(gen) => {
-                            self.path = Some(self.option.table_path(&gen));
+                            self.path = Some(self.option.table_path(&gen, self.level));
 
                             let reader = self
                                 .fs

--- a/src/stream/level.rs
+++ b/src/stream/level.rs
@@ -204,7 +204,7 @@ where
 mod tests {
     use std::{collections::Bound, sync::Arc};
 
-    use fusio::{path::Path};
+    use fusio::path::Path;
     use fusio_dispatch::FsOptions;
     use futures_util::StreamExt;
     use parquet::arrow::{arrow_to_parquet_schema, ProjectionMask};

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -253,7 +253,7 @@ where
 mod tests {
     use std::{collections::Bound, sync::Arc};
 
-    use fusio::{path::Path};
+    use fusio::path::Path;
     use fusio_dispatch::FsOptions;
     use futures_util::StreamExt;
     use tempfile::TempDir;

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -253,7 +253,8 @@ where
 mod tests {
     use std::{collections::Bound, sync::Arc};
 
-    use fusio::{options::FsOptions, path::Path};
+    use fusio::{path::Path};
+    use fusio_dispatch::FsOptions;
     use futures_util::StreamExt;
     use tempfile::TempDir;
 
@@ -316,10 +317,12 @@ mod tests {
         ));
 
         manager
+            .base_fs()
             .create_dir_all(&option.version_log_dir_path())
             .await
             .unwrap();
         manager
+            .base_fs()
             .create_dir_all(&option.wal_dir_path())
             .await
             .unwrap();
@@ -465,10 +468,12 @@ mod tests {
         ));
 
         manager
+            .base_fs()
             .create_dir_all(&option.version_log_dir_path())
             .await
             .unwrap();
         manager
+            .base_fs()
             .create_dir_all(&option.wal_dir_path())
             .await
             .unwrap();
@@ -558,10 +563,12 @@ mod tests {
         ));
 
         manager
+            .base_fs()
             .create_dir_all(&option.version_log_dir_path())
             .await
             .unwrap();
         manager
+            .base_fs()
             .create_dir_all(&option.wal_dir_path())
             .await
             .unwrap();
@@ -732,10 +739,12 @@ mod tests {
         ));
 
         manager
+            .base_fs()
             .create_dir_all(&option.version_log_dir_path())
             .await
             .unwrap();
         manager
+            .base_fs()
             .create_dir_all(&option.wal_dir_path())
             .await
             .unwrap();

--- a/src/version/cleaner.rs
+++ b/src/version/cleaner.rs
@@ -98,9 +98,7 @@ where
 pub(crate) mod tests {
     use std::{sync::Arc, time::Duration};
 
-    use fusio::{
-        path::{path_to_local, Path},
-    };
+    use fusio::path::{path_to_local, Path};
     use fusio_dispatch::FsOptions;
     use tempfile::TempDir;
     use tokio::time::sleep;

--- a/src/version/cleaner.rs
+++ b/src/version/cleaner.rs
@@ -74,7 +74,7 @@ where
                                 .level_fs_path(level)
                                 .map(|path| self.manager.get_fs(path))
                                 .unwrap_or(self.manager.base_fs());
-                            fs.remove(&self.option.table_path(&gen)).await?;
+                            fs.remove(&self.option.table_path(&gen, level)).await?;
                         }
                     }
                 }
@@ -84,7 +84,7 @@ where
                         .level_fs_path(0)
                         .map(|path| self.manager.get_fs(path))
                         .unwrap_or(self.manager.base_fs());
-                    fs.remove(&self.option.table_path(&gen)).await?;
+                    fs.remove(&self.option.table_path(&gen, 0)).await?;
                 }
             }
         }
@@ -130,16 +130,16 @@ pub(crate) mod tests {
             .map(|path| manager.get_fs(path))
             .unwrap_or(manager.base_fs());
         {
-            fs.open_options(&option.table_path(&gen_0), default_open_options())
+            fs.open_options(&option.table_path(&gen_0, 0), default_open_options())
                 .await
                 .unwrap();
-            fs.open_options(&option.table_path(&gen_1), default_open_options())
+            fs.open_options(&option.table_path(&gen_1, 0), default_open_options())
                 .await
                 .unwrap();
-            fs.open_options(&option.table_path(&gen_2), default_open_options())
+            fs.open_options(&option.table_path(&gen_2, 0), default_open_options())
                 .await
                 .unwrap();
-            fs.open_options(&option.table_path(&gen_3), default_open_options())
+            fs.open_options(&option.table_path(&gen_3, 0), default_open_options())
                 .await
                 .unwrap();
         }
@@ -178,32 +178,32 @@ pub(crate) mod tests {
             .unwrap();
 
         // FIXME
-        assert!(path_to_local(&option.table_path(&gen_0)).unwrap().exists());
-        assert!(path_to_local(&option.table_path(&gen_1)).unwrap().exists());
-        assert!(path_to_local(&option.table_path(&gen_2)).unwrap().exists());
-        assert!(path_to_local(&option.table_path(&gen_3)).unwrap().exists());
+        assert!(path_to_local(&option.table_path(&gen_0, 0)).unwrap().exists());
+        assert!(path_to_local(&option.table_path(&gen_1, 0)).unwrap().exists());
+        assert!(path_to_local(&option.table_path(&gen_2, 0)).unwrap().exists());
+        assert!(path_to_local(&option.table_path(&gen_3, 0)).unwrap().exists());
 
         tx.send_async(CleanTag::Clean { ts: 0.into() })
             .await
             .unwrap();
         sleep(Duration::from_millis(10)).await;
-        assert!(!path_to_local(&option.table_path(&gen_0)).unwrap().exists());
-        assert!(path_to_local(&option.table_path(&gen_1)).unwrap().exists());
-        assert!(path_to_local(&option.table_path(&gen_2)).unwrap().exists());
-        assert!(path_to_local(&option.table_path(&gen_3)).unwrap().exists());
+        assert!(!path_to_local(&option.table_path(&gen_0, 0)).unwrap().exists());
+        assert!(path_to_local(&option.table_path(&gen_1, 0)).unwrap().exists());
+        assert!(path_to_local(&option.table_path(&gen_2, 0)).unwrap().exists());
+        assert!(path_to_local(&option.table_path(&gen_3, 0)).unwrap().exists());
 
         tx.send_async(CleanTag::Clean { ts: 1.into() })
             .await
             .unwrap();
         sleep(Duration::from_millis(10)).await;
-        assert!(!path_to_local(&option.table_path(&gen_1)).unwrap().exists());
-        assert!(!path_to_local(&option.table_path(&gen_2)).unwrap().exists());
-        assert!(path_to_local(&option.table_path(&gen_3)).unwrap().exists());
+        assert!(!path_to_local(&option.table_path(&gen_1, 0)).unwrap().exists());
+        assert!(!path_to_local(&option.table_path(&gen_2, 0)).unwrap().exists());
+        assert!(path_to_local(&option.table_path(&gen_3, 0)).unwrap().exists());
 
         tx.send_async(CleanTag::RecoverClean { wal_id: gen_3 })
             .await
             .unwrap();
         sleep(Duration::from_millis(10)).await;
-        assert!(!path_to_local(&option.table_path(&gen_3)).unwrap().exists());
+        assert!(!path_to_local(&option.table_path(&gen_3, 0)).unwrap().exists());
     }
 }

--- a/src/version/cleaner.rs
+++ b/src/version/cleaner.rs
@@ -106,7 +106,7 @@ pub(crate) mod tests {
 
     use crate::{
         executor::{tokio::TokioExecutor, Executor},
-        fs::{default_open_options, manager::StoreManager, FileId},
+        fs::{manager::StoreManager, FileId, FileType},
         tests::Test,
         version::cleaner::{CleanTag, Cleaner},
         DbOption,
@@ -129,18 +129,30 @@ pub(crate) mod tests {
             .map(|path| manager.get_fs(path))
             .unwrap_or(manager.base_fs());
         {
-            fs.open_options(&option.table_path(&gen_0, 0), default_open_options(false))
-                .await
-                .unwrap();
-            fs.open_options(&option.table_path(&gen_1, 0), default_open_options(false))
-                .await
-                .unwrap();
-            fs.open_options(&option.table_path(&gen_2, 0), default_open_options(false))
-                .await
-                .unwrap();
-            fs.open_options(&option.table_path(&gen_3, 0), default_open_options(false))
-                .await
-                .unwrap();
+            fs.open_options(
+                &option.table_path(&gen_0, 0),
+                FileType::Parquet.open_options(false),
+            )
+            .await
+            .unwrap();
+            fs.open_options(
+                &option.table_path(&gen_1, 0),
+                FileType::Parquet.open_options(false),
+            )
+            .await
+            .unwrap();
+            fs.open_options(
+                &option.table_path(&gen_2, 0),
+                FileType::Parquet.open_options(false),
+            )
+            .await
+            .unwrap();
+            fs.open_options(
+                &option.table_path(&gen_3, 0),
+                FileType::Parquet.open_options(false),
+            )
+            .await
+            .unwrap();
         }
 
         let (mut cleaner, tx) = Cleaner::<Test>::new(option.clone(), manager.clone());

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -177,7 +177,10 @@ where
         projection_mask: ProjectionMask,
     ) -> Result<Option<RecordBatchEntry<R>>, VersionError<R>> {
         let file = store
-            .open_options(&self.option.table_path(gen, level), default_open_options())
+            .open_options(
+                &self.option.table_path(gen, level),
+                default_open_options(false),
+            )
             .await
             .map_err(VersionError::Fusio)?;
         SsTable::<R>::open(file)
@@ -215,10 +218,17 @@ where
             if !scope.meets_range(range) {
                 continue;
             }
-            let file = level_0_fs
-                .open_options(&self.option.table_path(&scope.gen, 0), default_open_options())
+            let result = level_0_fs
+                .open_options(
+                    &self.option.table_path(&scope.gen, 0),
+                    default_open_options(false),
+                )
                 .await
-                .map_err(VersionError::Fusio)?;
+                .map_err(VersionError::Fusio);
+            if result.is_err() {
+                println!("WWWWWWWWWWWWW");
+            }
+            let file = result?;
             let table = SsTable::open(file).await?;
 
             streams.push(ScanStream::SsTable {

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -131,16 +131,17 @@ where
                 continue;
             }
             if let Some(entry) = self
-                .table_query(level_0_fs, key, &scope.gen, projection_mask.clone())
+                .table_query(level_0_fs, key, 0, &scope.gen, projection_mask.clone())
                 .await?
             {
                 return Ok(Some(entry));
             }
         }
         for (i, sort_runs) in self.level_slice[1..MAX_LEVEL].iter().enumerate() {
+            let leve = i + 1;
             let level_path = self
                 .option
-                .level_fs_path(i + 1)
+                .level_fs_path(leve)
                 .unwrap_or(&self.option.base_path);
             let level_fs = manager.get_fs(level_path);
             if sort_runs.is_empty() {
@@ -154,6 +155,7 @@ where
                 .table_query(
                     level_fs,
                     key,
+                    leve,
                     &sort_runs[index].gen,
                     projection_mask.clone(),
                 )
@@ -170,11 +172,12 @@ where
         &self,
         store: &Arc<dyn DynFs>,
         key: &TimestampedRef<<R as Record>::Key>,
+        level: usize,
         gen: &FileId,
         projection_mask: ProjectionMask,
     ) -> Result<Option<RecordBatchEntry<R>>, VersionError<R>> {
         let file = store
-            .open_options(&self.option.table_path(gen), default_open_options())
+            .open_options(&self.option.table_path(gen, level), default_open_options())
             .await
             .map_err(VersionError::Fusio)?;
         SsTable::<R>::open(file)
@@ -213,7 +216,7 @@ where
                 continue;
             }
             let file = level_0_fs
-                .open_options(&self.option.table_path(&scope.gen), default_open_options())
+                .open_options(&self.option.table_path(&scope.gen, 0), default_open_options())
                 .await
                 .map_err(VersionError::Fusio)?;
             let table = SsTable::open(file).await?;

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -218,17 +218,13 @@ where
             if !scope.meets_range(range) {
                 continue;
             }
-            let result = level_0_fs
+            let file = level_0_fs
                 .open_options(
                     &self.option.table_path(&scope.gen, 0),
                     default_open_options(false),
                 )
                 .await
-                .map_err(VersionError::Fusio);
-            if result.is_err() {
-                println!("WWWWWWWWWWWWW");
-            }
-            let file = result?;
+                .map_err(VersionError::Fusio)?;
             let table = SsTable::open(file).await?;
 
             streams.push(ScanStream::SsTable {

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -17,7 +17,7 @@ use thiserror::Error;
 use tracing::error;
 
 use crate::{
-    fs::{default_open_options, manager::StoreManager, FileId},
+    fs::{manager::StoreManager, FileId, FileType},
     ondisk::sstable::SsTable,
     record::Record,
     scope::Scope,
@@ -179,7 +179,7 @@ where
         let file = store
             .open_options(
                 &self.option.table_path(gen, level),
-                default_open_options(false),
+                FileType::Parquet.open_options(true),
             )
             .await
             .map_err(VersionError::Fusio)?;
@@ -221,7 +221,7 @@ where
             let file = level_0_fs
                 .open_options(
                     &self.option.table_path(&scope.gen, 0),
-                    default_open_options(false),
+                    FileType::Parquet.open_options(true),
                 )
                 .await
                 .map_err(VersionError::Fusio)?;

--- a/src/version/set.rs
+++ b/src/version/set.rs
@@ -288,7 +288,7 @@ pub(crate) mod tests {
 
     use async_lock::RwLock;
     use flume::{bounded, Sender};
-    use fusio::{path::Path};
+    use fusio::path::Path;
     use fusio_dispatch::FsOptions;
     use futures_util::StreamExt;
     use tempfile::TempDir;

--- a/src/version/set.rs
+++ b/src/version/set.rs
@@ -14,7 +14,7 @@ use futures_util::StreamExt;
 
 use super::{TransactionTs, MAX_LEVEL};
 use crate::{
-    fs::{default_open_options, manager::StoreManager, parse_file_id, FileId, FileType},
+    fs::{manager::StoreManager, parse_file_id, FileId, FileType},
     record::Record,
     serdes::Encode,
     timestamp::Timestamp,
@@ -139,7 +139,7 @@ where
         let mut log = fs
             .open_options(
                 &option.version_log_path(&log_id),
-                default_open_options(true),
+                FileType::Log.open_options(false),
             )
             .await?;
 
@@ -265,7 +265,10 @@ where
             let fs = self.manager.base_fs();
             let old_log_id = mem::replace(log_id, FileId::new());
             let new_log = fs
-                .open_options(&option.version_log_path(log_id), default_open_options(true))
+                .open_options(
+                    &option.version_log_path(log_id),
+                    FileType::Log.open_options(false),
+                )
                 .await?;
             let mut old_log = mem::replace(log, new_log);
             old_log.close().await?;
@@ -294,7 +297,7 @@ pub(crate) mod tests {
     use tempfile::TempDir;
 
     use crate::{
-        fs::{default_open_options, manager::StoreManager, FileId},
+        fs::{manager::StoreManager, FileId, FileType},
         record::Record,
         scope::Scope,
         version::{
@@ -320,7 +323,7 @@ pub(crate) mod tests {
             .base_fs()
             .open_options(
                 &option.version_log_path(&log_id),
-                default_open_options(true),
+                FileType::Log.open_options(false),
             )
             .await?;
         let timestamp = version.timestamp.clone();
@@ -479,7 +482,7 @@ pub(crate) mod tests {
 
         let mut log = manager
             .base_fs()
-            .open_options(&logs.pop().unwrap().path, default_open_options(true))
+            .open_options(&logs.pop().unwrap().path, FileType::Log.open_options(false))
             .await
             .unwrap();
         let edits = VersionEdit::<String>::recover(&mut log).await;


### PR DESCRIPTION
bug: 
- Compaction triggered by flush will not return tx after an error occurs.
- SSTable does not enable `append` when opening a file
- Fix level inconsistency in `Compactor::build_tables`
- Remove the meaningless `StoreManger::create_dir_all`

todo:
- [x] When level 0 is turned on to enable independent table_path, the file will not be found during recover clean (DbOptions does not have any level paths)
  - S3 remote connection writing performance is slow
- [x] When Benchmark Level 0 specifies S3 as the level path, there is only one file.
  - The problem occurs in Cleaner's RecoverClean. Already deleted Tables may be deleted repeatedly (redundant deletion). This is expected.




