### PR TITLE
add wal record buffer

### DIFF
--- a/src/wal/buffer.rs
+++ b/src/wal/buffer.rs
@@ -1,0 +1,37 @@
+use fusio::{Error, IoBuf, Write};
+use tokio_util::bytes::BufMut;
+
+pub(crate) struct BufferWriter {
+    buf: Vec<u8>,
+}
+
+impl BufferWriter {
+    pub(crate) fn new() -> Self {
+        Self { buf: Vec::new() }
+    }
+}
+
+impl Write for BufferWriter {
+    async fn write_all<B: IoBuf>(&mut self, buf: B) -> (Result<(), Error>, B) {
+        self.buf.put_slice(buf.as_slice());
+        (Ok(()), buf)
+    }
+
+    async fn sync_data(&self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    async fn sync_all(&self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    async fn close(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+impl BufferWriter {
+    pub(crate) fn as_slice(&self) -> &[u8] {
+        self.buf.as_slice()
+    }
+}


### PR DESCRIPTION
#189

Now data wiil be appended to file every time encoding. This PR add a simple buffer to cache record encoded  data when write WAL. 

Here are the results of  a test on my machine(macbook  pro 18) with 10000 `DynRecord`s inserted

| without buffer | with buffer | wal disabled
| ----- | ----- | ----- |
| 7.747s | 0.714s  | 0.160s 

