### PR TITLE
chore: encode column name attribute

### DIFF
--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -10,17 +10,20 @@ Tonbo's Python bindings can be used to build data-intensive applications, includ
 from tonbo import DbOption, Column, DataType, Record, TonboDB, Bound
 from tonbo.fs import from_filesystem_path
 import asyncio
+import os
 
 # define a Tonbo record
 @Record
 class User:
-    age = Column(DataType.INT8, name="age", primary_key=True)
-    height = Column(DataType.INT16, name="height", nullable=True)
-    weight = Column(DataType.INT8, name="weight", nullable=False)
+    age = Column(DataType.Int8, name="age", primary_key=True)
+    height = Column(DataType.Int16, name="height", nullable=True)
+    weight = Column(DataType.Int8, name="weight", nullable=False)
 
 async def main():
 
-    db = TonboDB(DbOption(from_filesystem_path("./db_path/users")), User())
+    if not os.path.exists("db_path/users"):
+        os.makedirs("db_path/users")
+    db = TonboDB(DbOption(from_filesystem_path("db_path/users")), User())
 
     await db.insert(User(age=18, height=175, weight=60))
     record = await db.get(18)

--- a/bindings/python/tests/test_db.py
+++ b/bindings/python/tests/test_db.py
@@ -52,13 +52,31 @@ async def test_db_remove():
     for i in range(0, 100):
         if i % 2 == 0:
             await db.insert(User(age=i, height=i * 10, weight=i * 20))
-        # else:
-        #     await db.remove(i)
+        else:
+            await db.remove(i)
 
     for i in range(0, 100):
-        print(i)
         user = await db.get(i)
         if i % 2 == 0:
             assert user == {"age": i, "height": i * 10, "weight": i * 20}
         else:
             assert user is None
+
+
+@pytest.mark.asyncio
+async def test_db_recover():
+    temp_dir = tempfile.TemporaryDirectory()
+    db = TonboDB(DbOption(temp_dir.name), User())
+    for i in range(0, 100):
+        await db.insert(User(age=i, height=i * 10, weight=i * 20))
+
+    for i in range(0, 100):
+        user = await db.get(i)
+        assert user == {"age": i, "height": i * 10, "weight": i * 20}
+
+    await db.flush_wal()
+
+    db = TonboDB(DbOption(temp_dir.name), User())
+    for i in range(0, 100):
+        user = await db.get(i)
+        assert user == {"age": i, "height": i * 10, "weight": i * 20}

--- a/src/record/runtime/column.rs
+++ b/src/record/runtime/column.rs
@@ -253,10 +253,11 @@ macro_rules! implement_decode_col {
                             },
                         )*
                     };
+                let name = String::decode(reader).await?;
                 Ok(Column {
                     datatype,
                     is_nullable,
-                    name: "".to_owned(),
+                    name,
                     value,
                 })
             }
@@ -295,11 +296,12 @@ macro_rules! implement_encode_col {
                             }
                         )*
                 };
+                self.name.encode(writer).await?;
                 Ok(())
             }
 
             fn size(&self) -> usize {
-                3 + match self.datatype {
+                3 + self.name.size() + match self.datatype {
                     $(
                         Datatype::$Datatype => {
                             if let Some(value) = self.value.as_ref().downcast_ref::<$Type>() {


### PR DESCRIPTION
Now name attribute is not encoded into file, which will result in getting wrong answer after db recovery . This PR encode name attribute to file and add recovery test for python binding