### PR TITLE
add write benchmark

### DIFF
--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -15,6 +15,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 test = ["pytest", "pytest-asyncio"]
+bench = ["pytest", "pytest-asyncio", "pytest-benchmark", "duckdb"]
 docs = ["pdoc"]
 
 [tool.maturin]

--- a/bindings/python/tests/conftest.py
+++ b/bindings/python/tests/conftest.py
@@ -1,5 +1,21 @@
 import asyncio
+import random
+
 import pytest_asyncio
+
+
+def gen_string(max_size):
+    size = gen_int(0, max_size)
+    charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+    return ''.join(random.choices(charset, k=size))
+
+
+def gen_bytes(max_size):
+    return gen_string(max_size).encode("utf-8")
+
+
+def gen_int(lower, high):
+    return random.randint(lower, high)
 
 
 # async support for pytest-benchmark

--- a/bindings/python/tests/conftest.py
+++ b/bindings/python/tests/conftest.py
@@ -1,0 +1,18 @@
+import asyncio
+import pytest_asyncio
+
+
+# async support for pytest-benchmark
+# https://github.com/ionelmc/pytest-benchmark/issues/66#issuecomment-1137005280
+@pytest_asyncio.fixture
+def aio_benchmark(benchmark, event_loop):
+    def _wrapper(func, *args, **kwargs):
+        if asyncio.iscoroutinefunction(func):
+
+            @benchmark
+            def _():
+                return event_loop.run_until_complete(func(*args, **kwargs))
+        else:
+            benchmark(func, *args, **kwargs)
+
+    return _wrapper

--- a/bindings/python/tests/test_write_async_benchmark.py
+++ b/bindings/python/tests/test_write_async_benchmark.py
@@ -1,0 +1,160 @@
+import asyncio
+import os
+import tempfile
+import duckdb
+import sqlite3
+import pytest
+
+from conftest import gen_int, gen_string, gen_bytes
+from tonbo import Record, Column, DataType, TonboDB, DbOption
+from tonbo.fs import from_filesystem_path
+
+WRITE_TIME = 500000
+
+
+@Record
+class User:
+    id = Column(DataType.Int64, name="id", primary_key=True)
+    name = Column(DataType.String, name="name")
+    email = Column(DataType.String, name="email", nullable=True)
+    age = Column(DataType.UInt16, name="age")
+    data = Column(DataType.Bytes, name="data")
+
+
+async def duckdb_write(threads: int):
+    con = duckdb.connect(config={"threads": threads})
+    con.sql(
+        "CREATE TABLE user (id INTEGER, name VARCHAR(20), email VARCHAR(20), age INTEGER, data VARCHAR(200))"
+    )
+
+    async def insert_task(start: int, end: int):
+        txn = con.begin()
+        for j in range(start, end):
+            txn.execute(
+                "INSERT INTO user VALUES (?, ?, ?, ?, ?)",
+                [i, gen_string(20), gen_string(20), gen_int(0, 0xffff), gen_bytes(200)],
+            )
+        txn.commit()
+
+    tasks = []
+    for i in range(0, threads):
+        tasks.append(insert_task(i * WRITE_TIME // threads, (i + 1) * WRITE_TIME // threads))
+
+    await asyncio.gather(*tasks)
+    con.commit()
+    con.close()
+
+
+async def tonbo_write(threads: int):
+    temp_dir = tempfile.TemporaryDirectory()
+
+    option = DbOption(from_filesystem_path(temp_dir.name))
+
+    db = TonboDB(option, User())
+    tasks = []
+
+    async def insert_task(start: int, end: int):
+        txn = await db.transaction()
+        for j in range(start, end):
+            txn.insert(
+                User(
+                    id=j,
+                    age=gen_int(0, 0xffff),
+                    name=gen_string(20),
+                    email=gen_string(20),
+                    data=gen_bytes(200),
+                )
+            )
+        await txn.commit()
+
+    for i in range(0, threads):
+        tasks.append(insert_task((i + 1) * WRITE_TIME // threads, (i + 1) * WRITE_TIME // threads))
+
+    await asyncio.gather(*tasks)
+    await db.flush_wal()
+
+
+async def sqlite_write(threads: int):
+    file = tempfile.NamedTemporaryFile()
+    con = sqlite3.connect(file.name, check_same_thread=False)
+    con.execute(
+        "CREATE TABLE user (id INTEGER, name VARCHAR(20), email VARCHAR(20), age INTEGER, data VARCHAR(200))"
+    )
+
+    async def insert_task(start: int, end: int):
+        for j in range(start, end):
+            con.execute(
+                "INSERT INTO user VALUES (?, ?, ?, ?, ?)",
+                [j, gen_string(20), gen_string(20), gen_int(0, 0xffff), gen_bytes(200)],
+            )
+        con.commit()
+
+    tasks = []
+    for i in range(0, threads):
+        tasks.append(insert_task(i * WRITE_TIME // threads, (i + 1) * WRITE_TIME // threads))
+    await asyncio.gather(*tasks)
+    con.commit()
+    con.close()
+
+
+@pytest.mark.parametrize("threads", [1])
+@pytest.mark.benchmark(group="1 async task")
+@pytest.mark.skipif("BENCH" not in os.environ, reason="benchmark")
+def test_duckdb_one_task(aio_benchmark, threads):
+    aio_benchmark(duckdb_write, threads)
+
+
+@pytest.mark.parametrize("threads", [1])
+@pytest.mark.benchmark(group="1 async task")
+@pytest.mark.skipif("BENCH" not in os.environ, reason="benchmark")
+def test_tonbo_one_task(aio_benchmark, threads):
+    aio_benchmark(tonbo_write, threads)
+
+
+@pytest.mark.parametrize("threads", [1])
+@pytest.mark.benchmark(group="1 async task")
+@pytest.mark.skipif("BENCH" not in os.environ, reason="benchmark")
+def test_sqlite_one_task(aio_benchmark, threads):
+    aio_benchmark(sqlite_write, threads)
+
+
+@pytest.mark.parametrize("threads", [4])
+@pytest.mark.benchmark(group="4 async task")
+@pytest.mark.skipif("BENCH" not in os.environ, reason="benchmark")
+def test_duckdb_four_task(aio_benchmark, threads):
+    aio_benchmark(duckdb_write, threads)
+
+
+@pytest.mark.parametrize("threads", [4])
+@pytest.mark.benchmark(group="4 async task")
+@pytest.mark.skipif("BENCH" not in os.environ, reason="benchmark")
+def test_tonbo_four_task(aio_benchmark, threads):
+    aio_benchmark(tonbo_write, threads)
+
+
+@pytest.mark.parametrize("threads", [4])
+@pytest.mark.benchmark(group="4 async task")
+@pytest.mark.skipif("BENCH" not in os.environ, reason="benchmark")
+def test_sqlite_four_task(aio_benchmark, threads):
+    aio_benchmark(sqlite_write, threads)
+
+
+@pytest.mark.parametrize("threads", [8])
+@pytest.mark.benchmark(group="8 async task")
+@pytest.mark.skipif("BENCH" not in os.environ, reason="benchmark")
+def test_duckdb_eight_task(aio_benchmark, threads):
+    aio_benchmark(duckdb_write, threads)
+
+
+@pytest.mark.parametrize("threads", [8])
+@pytest.mark.benchmark(group="8 async task")
+@pytest.mark.skipif("BENCH" not in os.environ, reason="benchmark")
+def test_tonbo_eight_task(aio_benchmark, threads):
+    aio_benchmark(tonbo_write, threads)
+
+
+@pytest.mark.parametrize("threads", [8])
+@pytest.mark.benchmark(group="8 async task")
+@pytest.mark.skipif("BENCH" not in os.environ, reason="benchmark")
+def test_sqlite_eight_task(aio_benchmark, threads):
+    aio_benchmark(sqlite_write, threads)

--- a/bindings/python/tests/test_write_benchmark.py
+++ b/bindings/python/tests/test_write_benchmark.py
@@ -1,0 +1,96 @@
+import os
+import random
+import tempfile
+import duckdb
+import sqlite3
+import pytest
+
+from tonbo import Record, Column, DataType, TonboDB, DbOption
+from tonbo.fs import from_filesystem_path
+
+WRITE_TIMEs = 500000
+
+
+@Record
+class User:
+    id = Column(DataType.Int64, name="id", primary_key=True)
+    name = Column(DataType.String, name="name")
+    email = Column(DataType.String, name="email", nullable=True)
+    age = Column(DataType.UInt16, name="age")
+    data = Column(DataType.Bytes, name="data")
+
+
+def gen_string(max_size):
+    size = gen_int(0, max_size)
+    charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+    return ''.join(random.choices(charset, k=size))
+
+
+def gen_bytes(max_size):
+    return gen_string(max_size).encode("utf-8")
+
+
+def gen_int(lower, high):
+    return random.randint(lower, high)
+
+
+def duckdb_write():
+    con = duckdb.connect()
+    con.sql(
+        "CREATE TABLE user (id INTEGER, name VARCHAR(20), email VARCHAR(20), age INTEGER, data VARCHAR(200))"
+    )
+    for i in range(0, WRITE_TIMEs):
+        con.execute(
+            "INSERT INTO user VALUES (?, ?, ?, ?, ?)",
+            [i, gen_string(20), gen_string(20), gen_int(0, 0xffff), gen_bytes(200)],
+        )
+    con.close()
+
+
+async def tonbo_write():
+    temp_dir = tempfile.TemporaryDirectory()
+
+    option = DbOption(from_filesystem_path(temp_dir.name))
+
+    db = TonboDB(option, User())
+    txn = await db.transaction()
+    for i in range(0, WRITE_TIMEs):
+        txn.insert(
+            User(
+                id=i,
+                age=gen_int(0, 0xffff),
+                name=gen_string(20),
+                email=gen_string(20),
+                data=gen_bytes(200),
+            )
+        )
+    await txn.commit()
+    await db.flush_wal()
+
+
+def sqlite_write():
+    file = tempfile.NamedTemporaryFile()
+    con = sqlite3.connect(file.name)
+    con.execute(
+        "CREATE TABLE user (id INTEGER, name VARCHAR(20), email VARCHAR(20), age INTEGER, data VARCHAR(200))"
+    )
+    for i in range(0, WRITE_TIMEs):
+        con.execute(
+            "INSERT INTO user VALUES (?, ?, ?, ?, ?)",
+            [i, gen_string(20), gen_string(20), gen_int(0, 0xffff), gen_bytes(200)],
+        )
+
+
+@pytest.mark.skipif("BENCH" not in os.environ, reason="benchmark")
+def test_duckdb(benchmark):
+    benchmark(duckdb_write)
+
+
+@pytest.mark.skipif("BENCH" not in os.environ, reason="benchmark")
+def test_tonbo(benchmark):
+    benchmark(tonbo_write)
+
+
+@pytest.mark.skipif("BENCH" not in os.environ, reason="benchmark")
+def test_sqlite(benchmark):
+    benchmark(sqlite_write)

--- a/bindings/python/tests/test_write_benchmark.py
+++ b/bindings/python/tests/test_write_benchmark.py
@@ -87,8 +87,8 @@ def test_duckdb(benchmark):
 
 
 @pytest.mark.skipif("BENCH" not in os.environ, reason="benchmark")
-def test_tonbo(benchmark):
-    benchmark(tonbo_write)
+def test_tonbo(aio_benchmark):
+    aio_benchmark(tonbo_write)
 
 
 @pytest.mark.skipif("BENCH" not in os.environ, reason="benchmark")

--- a/bindings/python/tests/test_write_benchmark.py
+++ b/bindings/python/tests/test_write_benchmark.py
@@ -39,11 +39,13 @@ def duckdb_write():
     con.sql(
         "CREATE TABLE user (id INTEGER, name VARCHAR(20), email VARCHAR(20), age INTEGER, data VARCHAR(200))"
     )
+    txn = con.begin()
     for i in range(0, WRITE_TIMEs):
-        con.execute(
+        txn.execute(
             "INSERT INTO user VALUES (?, ?, ?, ?, ?)",
             [i, gen_string(20), gen_string(20), gen_int(0, 0xffff), gen_bytes(200)],
         )
+    txn.commit()
     con.close()
 
 
@@ -79,6 +81,8 @@ def sqlite_write():
             "INSERT INTO user VALUES (?, ?, ?, ?, ?)",
             [i, gen_string(20), gen_string(20), gen_int(0, 0xffff), gen_bytes(200)],
         )
+    con.commit()
+    con.close()
 
 
 @pytest.mark.skipif("BENCH" not in os.environ, reason="benchmark")


### PR DESCRIPTION
Add write test for python binding

Here are the results of the writing tests in my machine:

write 10000 records:
```
DuckDB took 20.72643 seconds to insert 10000 records
SQLite took 0.02475 seconds to insert 10000 records
SQLite with autocommit took 5.43819 seconds to insert 10000 records
Tonbo took 0.89315 seconds to insert 10000 records
Tonbo without transaction took 1.68304 seconds to insert 10000 records
Tonbo without transaction write batch took 0.75287 seconds to insert 10000 records
```

benchmark for 10000 inserts(compare mode):
```bash
BENCH=true pytest tests/test_write_benchmark.py --benchmark-compare
```

```

------------------------------------------------------------------------------- benchmark 'autocommit': 3 tests -------------------------------------------------------------------------------
Name (time in s)                     Min                Max               Mean            StdDev             Median               IQR            Outliers     OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_tonbo_no_txn[True]           2.7148 (1.0)       2.8385 (1.0)       2.7607 (1.0)      0.0466 (1.06)      2.7492 (1.0)      0.0452 (1.0)           1;0  0.3622 (1.0)           5           1
test_sqlite_autocommit[True]      5.5469 (2.04)      7.0150 (2.47)      6.0955 (2.21)     0.5977 (13.58)     6.0006 (2.18)     0.8815 (19.48)         1;0  0.1641 (0.45)          5           1
test_duckdb_autocommit[True]     17.6864 (6.51)     17.7931 (6.27)     17.7252 (6.42)     0.0440 (1.0)      17.7087 (6.44)     0.0647 (1.43)          1;0  0.0564 (0.16)          5           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--------------------------------------------------------------------------------------- benchmark 'txn': 3 tests ---------------------------------------------------------------------------------------
Name (time in ms)              Min                    Max                   Mean             StdDev                 Median                 IQR            Outliers     OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_sqlite[False]        209.4384 (1.0)         216.4901 (1.0)         213.1646 (1.0)       2.5988 (1.0)         213.5285 (1.0)        3.2399 (1.0)           2;0  4.6912 (1.0)           5           1
test_tonbo[False]       1,185.6245 (5.66)      1,205.6479 (5.57)      1,196.3573 (5.61)      7.5267 (2.90)      1,196.6798 (5.60)      10.2414 (3.16)          2;0  0.8359 (0.18)          5           1
test_duckdb[False]     17,305.8920 (82.63)    17,542.0705 (81.03)    17,375.8318 (81.51)    97.2371 (37.42)    17,348.8095 (81.25)    108.3791 (33.45)         1;0  0.0576 (0.01)          5           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
```

benchmark for async(normal mode)
```bash
BENCH=true pytest tests/test_write_async_benchmark.py
```

```
------------------------------------------------------------------------------------------ benchmark '1 async task': 4 tests ------------------------------------------------------------------------------------------
Name (time in ms)                              Min                    Max                   Mean             StdDev                 Median                IQR            Outliers     OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_sqlite_one_task[1]                   182.0578 (1.0)         217.4159 (1.0)         191.4590 (1.0)      13.1612 (4.59)        186.0564 (1.0)       7.5507 (1.76)          1;1  5.2231 (1.0)           6           1
test_tonbo_disable_wal_one_task[1]        796.8536 (4.38)        804.0866 (3.70)        799.9534 (4.18)      2.8689 (1.0)         799.0795 (4.29)      4.2852 (1.0)           2;0  1.2501 (0.24)          5           1
test_tonbo_one_task[1]                  1,227.5543 (6.74)      1,261.9408 (5.80)      1,247.1690 (6.51)     12.3587 (4.31)      1,248.7901 (6.71)      9.0597 (2.11)          2;1  0.8018 (0.15)          5           1
test_duckdb_one_task[1]                16,310.7241 (89.59)    16,485.9345 (75.83)    16,387.5184 (85.59)    64.1768 (22.37)    16,369.9616 (87.98)    69.2377 (16.16)         2;0  0.0610 (0.01)          5           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

------------------------------------------------------------------------------------------- benchmark '4 async task': 4 tests -------------------------------------------------------------------------------------------
Name (time in ms)                               Min                    Max                   Mean             StdDev                 Median                 IQR            Outliers     OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_sqlite_four_task[4]                   197.8323 (1.0)         248.1988 (1.0)         218.8520 (1.0)      22.2879 (6.28)        216.3441 (1.0)       35.7736 (11.12)         1;0  4.5693 (1.0)           6           1
test_tonbo_disable_wal_four_task[4]        717.8889 (3.63)        726.9563 (2.93)        723.9934 (3.31)      3.5478 (1.0)         724.6637 (3.35)       3.2160 (1.0)           1;1  1.3812 (0.30)          5           1
test_tonbo_four_task[4]                    828.1453 (4.19)        851.2807 (3.43)        835.4349 (3.82)      9.4134 (2.65)        834.1583 (3.86)      10.7695 (3.35)          1;0  1.1970 (0.26)          5           1
test_duckdb_four_task[4]                16,860.2662 (85.23)    17,039.4894 (68.65)    16,924.7830 (77.33)    72.5923 (20.46)    16,908.2101 (78.15)    102.1100 (31.75)         1;0  0.0591 (0.01)          5           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

------------------------------------------------------------------------------------------- benchmark '8 async task': 4 tests -------------------------------------------------------------------------------------------
Name (time in ms)                                Min                    Max                   Mean             StdDev                 Median                IQR            Outliers     OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_sqlite_eight_task[8]                   223.5105 (1.0)         371.0482 (1.0)         273.6408 (1.0)      63.4304 (20.28)       235.5098 (1.0)      90.9326 (16.06)         1;0  3.6544 (1.0)           5           1
test_tonbo_disable_wal_eight_task[8]        715.9489 (3.20)        722.9558 (1.95)        719.4189 (2.63)      3.1279 (1.0)         718.5793 (3.05)      5.6605 (1.0)           2;0  1.3900 (0.38)          5           1
test_tonbo_eight_task[8]                    771.7515 (3.45)        792.1555 (2.13)        779.6061 (2.85)      7.6349 (2.44)        777.4425 (3.30)      7.7205 (1.36)          2;0  1.2827 (0.35)          5           1
test_duckdb_eight_task[8]                17,291.9178 (77.37)    17,409.6344 (46.92)    17,339.4274 (63.37)    47.1919 (15.09)    17,319.2801 (73.54)    67.8616 (11.99)         2;0  0.0577 (0.02)          5           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
```