### PR TITLE
Isolate range param lifetime from scan lifetime

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -617,14 +617,15 @@ where
 }
 
 /// scan configuration intermediate structure
-pub struct Scan<'scan, R>
+pub struct Scan<'scan, 'range, R>
 where
     R: Record,
+    'range: 'scan,
 {
     schema: &'scan Schema<R>,
     manager: &'scan StoreManager,
-    lower: Bound<&'scan R::Key>,
-    upper: Bound<&'scan R::Key>,
+    lower: Bound<&'range R::Key>,
+    upper: Bound<&'range R::Key>,
     ts: Timestamp,
 
     version: &'scan Version<R>,
@@ -636,14 +637,14 @@ where
     projection: ProjectionMask,
 }
 
-impl<'scan, R> Scan<'scan, R>
+impl<'scan, 'range, R> Scan<'scan, 'range, R>
 where
     R: Record + Send,
 {
     fn new(
         schema: &'scan Schema<R>,
         manager: &'scan StoreManager,
-        (lower, upper): (Bound<&'scan R::Key>, Bound<&'scan R::Key>),
+        (lower, upper): (Bound<&'range R::Key>, Bound<&'range R::Key>),
         ts: Timestamp,
         version: &'scan Version<R>,
         fn_pre_stream: Box<

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -39,10 +39,10 @@ impl<'s, R: Record> Snapshot<'s, R> {
             }))
     }
 
-    pub fn scan<'scan>(
+    pub fn scan<'scan, 'range>(
         &'scan self,
-        range: (Bound<&'scan R::Key>, Bound<&'scan R::Key>),
-    ) -> Scan<'scan, R> {
+        range: (Bound<&'range R::Key>, Bound<&'range R::Key>),
+    ) -> Scan<'scan, 'range, R> {
         Scan::new(
             &self.share,
             &self.manager,
@@ -78,13 +78,13 @@ impl<'s, R: Record> Snapshot<'s, R> {
         &self.share
     }
 
-    pub(crate) fn _scan<'scan>(
+    pub(crate) fn _scan<'scan, 'range>(
         &'scan self,
-        range: (Bound<&'scan R::Key>, Bound<&'scan R::Key>),
+        range: (Bound<&'range R::Key>, Bound<&'range R::Key>),
         fn_pre_stream: Box<
             dyn FnOnce(Option<ProjectionMask>) -> Option<ScanStream<'scan, R>> + Send + 'scan,
         >,
-    ) -> Scan<'scan, R> {
+    ) -> Scan<'scan, 'range, R> {
         Scan::new(
             &self.share,
             &self.manager,
@@ -152,7 +152,7 @@ mod tests {
             // to increase timestamps to 1 because the data ts built in advance is 1
             db.version_set.increase_ts();
         }
-        let mut snapshot = db.snapshot().await;
+        let snapshot = db.snapshot().await;
 
         let mut stream = snapshot
             .scan((Bound::Unbounded, Bound::Unbounded))

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -81,10 +81,10 @@ where
     }
 
     /// scan records with primary keys in the `range`
-    pub fn scan<'scan>(
+    pub fn scan<'scan, 'range>(
         &'scan self,
-        range: (Bound<&'scan R::Key>, Bound<&'scan R::Key>),
-    ) -> Scan<'scan, R> {
+        range: (Bound<&'range R::Key>, Bound<&'range R::Key>),
+    ) -> Scan<'scan, 'range, R> {
         self.snapshot._scan(
             range,
             Box::new(move |projection_mask: Option<ProjectionMask>| {


### PR DESCRIPTION
Related issue: https://github.com/tonbo-io/tonbo/issues/135

Also fixed a small warning by removing the unnecessary `mut`