### PR TITLE
Minor refactor: replace Ulid to FileId

### DIFF
--- a/src/compaction/mod.rs
+++ b/src/compaction/mod.rs
@@ -7,7 +7,6 @@ use futures_util::StreamExt;
 use parquet::arrow::{AsyncArrowWriter, ProjectionMask};
 use thiserror::Error;
 use tokio::sync::oneshot;
-use ulid::Ulid;
 
 use crate::{
     fs::{manager::StoreManager, FileId, FileType},
@@ -455,7 +454,7 @@ where
         debug_assert!(min.is_some());
         debug_assert!(max.is_some());
 
-        let gen = Ulid::new();
+        let gen = FileId::new();
         let columns = builder.finish(None);
         let mut writer = AsyncArrowWriter::try_new(
             AsyncWriter::new(

--- a/src/inmem/mutable.rs
+++ b/src/inmem/mutable.rs
@@ -6,7 +6,6 @@ use crossbeam_skiplist::{
     SkipMap,
 };
 use fusio::{buffered::BufWriter, DynFs, DynWrite};
-use ulid::Ulid;
 
 use crate::{
     fs::{FileId, FileType},
@@ -52,7 +51,7 @@ where
     ) -> Result<Self, fusio::Error> {
         let mut wal = None;
         if option.use_wal {
-            let file_id = Ulid::new();
+            let file_id = FileId::new();
 
             let file = Box::new(BufWriter::new(
                 fs.open_options(

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -160,7 +160,7 @@ where
 mod test {
     use std::ops::Bound;
 
-    use ulid::Ulid;
+    use crate::fs::FileId;
 
     use super::Scope;
 
@@ -169,7 +169,7 @@ mod test {
         let scope = Scope {
             min: 100,
             max: 200,
-            gen: Ulid::new(),
+            gen: FileId::new(),
             wal_ids: None,
         };
 

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -160,9 +160,8 @@ where
 mod test {
     use std::ops::Bound;
 
-    use crate::fs::FileId;
-
     use super::Scope;
+    use crate::fs::FileId;
 
     #[tokio::test]
     async fn test_meets_range() {


### PR DESCRIPTION
Related issue: https://github.com/tonbo-io/tonbo/issues/212

Minor refactor to replace the Ulid to FileId