### PR TITLE
chore: replace FileId::new

### DIFF
--- a/src/compaction/mod.rs
+++ b/src/compaction/mod.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 use tokio::sync::oneshot;
 
 use crate::{
-    fs::{manager::StoreManager, FileId, FileType},
+    fs::{generate_file_id, manager::StoreManager, FileId, FileType},
     inmem::{
         immutable::{ArrowArrays, Builder, Immutable},
         mutable::Mutable,
@@ -144,7 +144,7 @@ where
             let mut min = None;
             let mut max = None;
 
-            let gen = FileId::new();
+            let gen = generate_file_id();
             let mut wal_ids = Vec::with_capacity(batches.len());
 
             let mut writer = AsyncArrowWriter::try_new(
@@ -461,7 +461,7 @@ where
         debug_assert!(min.is_some());
         debug_assert!(max.is_some());
 
-        let gen = FileId::new();
+        let gen = generate_file_id();
         let columns = builder.finish(None);
         let mut writer = AsyncArrowWriter::try_new(
             AsyncWriter::new(
@@ -525,7 +525,7 @@ pub(crate) mod tests {
     use crate::{
         compaction::Compactor,
         executor::tokio::TokioExecutor,
-        fs::{manager::StoreManager, FileId, FileType},
+        fs::{generate_file_id, manager::StoreManager, FileId, FileType},
         inmem::{immutable::Immutable, mutable::Mutable},
         record::{Column, ColumnDesc, Datatype, DynRecord, Record, RecordInstance},
         scope::Scope,
@@ -683,8 +683,8 @@ pub(crate) mod tests {
             &option,
             None,
             &vec![
-                (Some(FileId::new()), batch_1),
-                (Some(FileId::new()), batch_2),
+                (Some(generate_file_id()), batch_1),
+                (Some(generate_file_id()), batch_2),
             ],
             &RecordInstance::Normal,
             &manager,
@@ -747,8 +747,8 @@ pub(crate) mod tests {
             &option,
             None,
             &vec![
-                (Some(FileId::new()), batch_1),
-                (Some(FileId::new()), batch_2),
+                (Some(generate_file_id()), batch_1),
+                (Some(generate_file_id()), batch_2),
             ],
             &instance,
             &manager,
@@ -864,8 +864,8 @@ pub(crate) mod tests {
             .unwrap_or(manager.base_fs());
 
         // level 0
-        let table_gen_1 = FileId::new();
-        let table_gen_2 = FileId::new();
+        let table_gen_1 = generate_file_id();
+        let table_gen_2 = generate_file_id();
         build_parquet_table::<Test>(
             option,
             table_gen_1,
@@ -944,9 +944,9 @@ pub(crate) mod tests {
         .unwrap();
 
         // level 1
-        let table_gen_3 = FileId::new();
-        let table_gen_4 = FileId::new();
-        let table_gen_5 = FileId::new();
+        let table_gen_3 = generate_file_id();
+        let table_gen_4 = generate_file_id();
+        let table_gen_5 = generate_file_id();
         build_parquet_table::<Test>(
             option,
             table_gen_3,
@@ -1138,8 +1138,8 @@ pub(crate) mod tests {
             .map(|path| manager.get_fs(path))
             .unwrap_or(manager.base_fs());
 
-        let table_gen0 = FileId::new();
-        let table_gen1 = FileId::new();
+        let table_gen0 = generate_file_id();
+        let table_gen1 = generate_file_id();
         let mut records0 = vec![];
         let mut records1 = vec![];
         for i in 0..10 {

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -6,9 +6,23 @@ use std::{
 };
 
 use fusio::{fs::OpenOptions, path::Path};
+use once_cell::sync::OnceCell;
 use ulid::{DecodeError, Ulid};
 
 pub type FileId = Ulid;
+
+static GENERATOR: OnceCell<std::sync::Mutex<ulid::Generator>> = OnceCell::new();
+
+#[inline]
+pub fn generate_file_id() -> FileId {
+    // init
+    let m = GENERATOR.get_or_init(|| std::sync::Mutex::new(ulid::Generator::new()));
+    let mut guard = m
+        .lock()
+        .expect("global file id generator lock should not fail");
+
+    guard.generate().expect("generator should not fail")
+}
 
 pub enum FileType {
     Wal,

--- a/src/inmem/mutable.rs
+++ b/src/inmem/mutable.rs
@@ -8,7 +8,7 @@ use crossbeam_skiplist::{
 use fusio::{buffered::BufWriter, DynFs, DynWrite};
 
 use crate::{
-    fs::{FileId, FileType},
+    fs::{generate_file_id, FileId, FileType},
     inmem::immutable::Immutable,
     record::{Key, KeyRef, Record, RecordInstance},
     timestamp::{
@@ -51,7 +51,7 @@ where
     ) -> Result<Self, fusio::Error> {
         let mut wal = None;
         if option.use_wal {
-            let file_id = FileId::new();
+            let file_id = generate_file_id();
 
             let file = Box::new(BufWriter::new(
                 fs.open_options(&option.wal_path(file_id), FileType::Wal.open_options(false))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -907,7 +907,7 @@ pub(crate) mod tests {
     use crate::{
         compaction::{CompactTask, CompactionError, Compactor},
         executor::{tokio::TokioExecutor, Executor},
-        fs::{manager::StoreManager, FileId},
+        fs::{generate_file_id, manager::StoreManager},
         inmem::{immutable::tests::TestImmutableArrays, mutable::Mutable},
         record::{
             internal::InternalRecordRef,
@@ -1265,7 +1265,7 @@ pub(crate) mod tests {
                 .unwrap();
 
             vec![(
-                Some(FileId::new()),
+                Some(generate_file_id()),
                 Immutable::from((mutable.data, &RecordInstance::Normal)),
             )]
         };

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -161,14 +161,14 @@ mod test {
     use std::ops::Bound;
 
     use super::Scope;
-    use crate::fs::FileId;
+    use crate::fs::generate_file_id;
 
     #[tokio::test]
     async fn test_meets_range() {
         let scope = Scope {
             min: 100,
             max: 200,
-            gen: FileId::new(),
+            gen: generate_file_id(),
             wal_ids: None,
         };
 

--- a/src/version/cleaner.rs
+++ b/src/version/cleaner.rs
@@ -106,7 +106,7 @@ pub(crate) mod tests {
 
     use crate::{
         executor::{tokio::TokioExecutor, Executor},
-        fs::{manager::StoreManager, FileId, FileType},
+        fs::{generate_file_id, manager::StoreManager, FileType},
         tests::Test,
         version::cleaner::{CleanTag, Cleaner},
         DbOption,
@@ -120,10 +120,10 @@ pub(crate) mod tests {
             Path::from_filesystem_path(temp_dir.path()).unwrap(),
         ));
 
-        let gen_0 = FileId::new();
-        let gen_1 = FileId::new();
-        let gen_2 = FileId::new();
-        let gen_3 = FileId::new();
+        let gen_0 = generate_file_id();
+        let gen_1 = generate_file_id();
+        let gen_2 = generate_file_id();
+        let gen_3 = generate_file_id();
         let fs = option
             .level_fs_path(0)
             .map(|path| manager.get_fs(path))

--- a/src/version/edit.rs
+++ b/src/version/edit.rs
@@ -123,12 +123,7 @@ mod tests {
 
     use tokio::io::AsyncSeekExt;
 
-    use crate::{
-        fs::generate_file_id,
-        scope::Scope,
-        serdes::Encode,
-        version::edit::VersionEdit,
-    };
+    use crate::{fs::generate_file_id, scope::Scope, serdes::Encode, version::edit::VersionEdit};
 
     #[tokio::test]
     async fn encode_and_decode() {

--- a/src/version/edit.rs
+++ b/src/version/edit.rs
@@ -123,7 +123,12 @@ mod tests {
 
     use tokio::io::AsyncSeekExt;
 
-    use crate::{fs::FileId, scope::Scope, serdes::Encode, version::edit::VersionEdit};
+    use crate::{
+        fs::generate_file_id,
+        scope::Scope,
+        serdes::Encode,
+        version::edit::VersionEdit,
+    };
 
     #[tokio::test]
     async fn encode_and_decode() {
@@ -134,7 +139,7 @@ mod tests {
                     min: "Min".to_string(),
                     max: "Max".to_string(),
                     gen: Default::default(),
-                    wal_ids: Some(vec![FileId::new(), FileId::new()]),
+                    wal_ids: Some(vec![generate_file_id(), generate_file_id()]),
                 },
             },
             VersionEdit::Remove {

--- a/src/version/set.rs
+++ b/src/version/set.rs
@@ -15,7 +15,7 @@ use futures_util::StreamExt;
 
 use super::{TransactionTs, MAX_LEVEL};
 use crate::{
-    fs::{manager::StoreManager, parse_file_id, FileId, FileType},
+    fs::{generate_file_id, manager::StoreManager, parse_file_id, FileId, FileType},
     record::Record,
     serdes::Encode,
     timestamp::Timestamp,
@@ -135,7 +135,7 @@ where
             .map(|file_meta| parse_file_id(&file_meta.0.path, FileType::Log))
             .transpose()?
             .flatten()
-            .unwrap_or_else(FileId::new);
+            .unwrap_or_else(generate_file_id);
 
         let mut log = fs
             .open_options(
@@ -263,7 +263,7 @@ where
         log.close().await?;
         if edit_len >= option.version_log_snapshot_threshold {
             let fs = self.manager.base_fs();
-            let old_log_id = mem::replace(log_id, FileId::new());
+            let old_log_id = mem::replace(log_id, generate_file_id());
             let new_log = fs
                 .open_options(
                     &option.version_log_path(*log_id),
@@ -296,7 +296,7 @@ pub(crate) mod tests {
     use tempfile::TempDir;
 
     use crate::{
-        fs::{manager::StoreManager, FileId, FileType},
+        fs::{generate_file_id, manager::StoreManager, FileType},
         record::Record,
         scope::Scope,
         version::{
@@ -317,7 +317,7 @@ pub(crate) mod tests {
     where
         R: Record,
     {
-        let log_id = FileId::new();
+        let log_id = generate_file_id();
         let log = manager
             .base_fs()
             .open_options(
@@ -395,9 +395,9 @@ pub(crate) mod tests {
             VersionSet::new(sender.clone(), option.clone(), manager.clone())
                 .await
                 .unwrap();
-        let gen_0 = FileId::new();
-        let gen_1 = FileId::new();
-        let gen_2 = FileId::new();
+        let gen_0 = generate_file_id();
+        let gen_1 = generate_file_id();
+        let gen_2 = generate_file_id();
 
         version_set
             .apply_edits(
@@ -523,10 +523,10 @@ pub(crate) mod tests {
             VersionSet::new(sender.clone(), option.clone(), manager)
                 .await
                 .unwrap();
-        let gen_0 = FileId::new();
-        let gen_1 = FileId::new();
-        let gen_2 = FileId::new();
-        let gen_3 = FileId::new();
+        let gen_0 = generate_file_id();
+        let gen_1 = generate_file_id();
+        let gen_2 = generate_file_id();
+        let gen_3 = generate_file_id();
         version_set
             .apply_edits(
                 vec![VersionEdit::Add {

--- a/src/wal/mod.rs
+++ b/src/wal/mod.rs
@@ -118,15 +118,15 @@ mod tests {
     use futures_util::StreamExt;
     use tokio::io::AsyncSeekExt;
 
-    use super::{log::LogType, FileId, WalFile};
-    use crate::timestamp::Timestamped;
+    use super::{log::LogType, WalFile};
+    use crate::{fs::generate_file_id, timestamp::Timestamped};
 
     #[tokio::test]
     async fn write_and_recover() {
         let mut bytes = Vec::new();
         let mut file = Cursor::new(&mut bytes);
         {
-            let mut wal = WalFile::<_, String>::new(&mut file, FileId::new());
+            let mut wal = WalFile::<_, String>::new(&mut file, generate_file_id());
             wal.write(
                 LogType::Full,
                 Timestamped::new("hello", 0.into()),
@@ -138,7 +138,7 @@ mod tests {
         }
         {
             file.seek(std::io::SeekFrom::Start(0)).await.unwrap();
-            let mut wal = WalFile::<_, String>::new(&mut file, FileId::new());
+            let mut wal = WalFile::<_, String>::new(&mut file, generate_file_id());
 
             {
                 let mut stream = pin!(wal.recover());
@@ -147,7 +147,7 @@ mod tests {
                 assert_eq!(value, Some("hello".to_string()));
             }
 
-            let mut wal = WalFile::<_, String>::new(&mut file, FileId::new());
+            let mut wal = WalFile::<_, String>::new(&mut file, generate_file_id());
 
             wal.write(
                 LogType::Full,
@@ -160,7 +160,7 @@ mod tests {
 
         {
             file.seek(std::io::SeekFrom::Start(0)).await.unwrap();
-            let mut wal = WalFile::<_, String>::new(&mut file, FileId::new());
+            let mut wal = WalFile::<_, String>::new(&mut file, generate_file_id());
 
             {
                 let mut stream = pin!(wal.recover());


### PR DESCRIPTION
Replaces all `FileId::new` with `generate_file_id`.

Fixes: #146 