### PR TITLE
Refactor: remove log in VersionInner

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,13 +83,13 @@ crc32fast = "1"
 crossbeam-skiplist = "0.1"
 datafusion = { version = "42.2.0", optional = true }
 flume = { version = "0.11", features = ["async"] }
-fusio = { git = "https://github.com/tonbo-io/fusio", rev = "1fb503916a4945e5ff5fcc136f3d65e56375fb3d", version = "0.3.4", package = "fusio", features = [
+fusio = { git = "https://github.com/tonbo-io/fusio", rev = "92fd436b75f7cc496ec16d1e2be62481fce52e45", version = "0.3.4", package = "fusio", features = [
     "dyn",
     "fs",
 ] }
-fusio-dispatch = { git = "https://github.com/tonbo-io/fusio", rev = "1fb503916a4945e5ff5fcc136f3d65e56375fb3d", version = "0.3.4", package = "fusio-dispatch" }
-fusio-log = { git = "https://github.com/tonbo-io/fusio", rev = "1fb503916a4945e5ff5fcc136f3d65e56375fb3d", version = "0.3.4", package = "fusio-log" , default-features = false, features = ["bytes"] }
-fusio-parquet = { git = "https://github.com/tonbo-io/fusio", rev = "1fb503916a4945e5ff5fcc136f3d65e56375fb3d", version = "0.3.4", package = "fusio-parquet" }
+fusio-dispatch = { git = "https://github.com/tonbo-io/fusio", rev = "92fd436b75f7cc496ec16d1e2be62481fce52e45", version = "0.3.4", package = "fusio-dispatch" }
+fusio-log = { git = "https://github.com/tonbo-io/fusio", rev = "92fd436b75f7cc496ec16d1e2be62481fce52e45", version = "0.3.4", package = "fusio-log" , default-features = false, features = ["bytes"] }
+fusio-parquet = { git = "https://github.com/tonbo-io/fusio", rev = "92fd436b75f7cc496ec16d1e2be62481fce52e45", version = "0.3.4", package = "fusio-parquet" }
 futures-core = "0.3"
 futures-io = "0.3"
 futures-util = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,13 +83,13 @@ crc32fast = "1"
 crossbeam-skiplist = "0.1"
 datafusion = { version = "42.2.0", optional = true }
 flume = { version = "0.11", features = ["async"] }
-fusio = { git = "https://github.com/tonbo-io/fusio", rev = "92fd436b75f7cc496ec16d1e2be62481fce52e45", version = "0.3.4", package = "fusio", features = [
+fusio = { version = "0.3.5", package = "fusio", features = [
     "dyn",
     "fs",
 ] }
-fusio-dispatch = { git = "https://github.com/tonbo-io/fusio", rev = "92fd436b75f7cc496ec16d1e2be62481fce52e45", version = "0.3.4", package = "fusio-dispatch" }
-fusio-log = { git = "https://github.com/tonbo-io/fusio", rev = "92fd436b75f7cc496ec16d1e2be62481fce52e45", version = "0.3.4", package = "fusio-log" , default-features = false, features = ["bytes"] }
-fusio-parquet = { git = "https://github.com/tonbo-io/fusio", rev = "92fd436b75f7cc496ec16d1e2be62481fce52e45", version = "0.3.4", package = "fusio-parquet" }
+fusio-dispatch = { version = "0.3.5", package = "fusio-dispatch" }
+fusio-log = { version = "0.3.5", package = "fusio-log" , default-features = false, features = ["bytes"] }
+fusio-parquet = { version = "0.3.5", package = "fusio-parquet" }
 futures-core = "0.3"
 futures-io = "0.3"
 futures-util = "0.3"

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -9,11 +9,11 @@ crate-type = ["cdylib"]
 [workspace]
 
 [dependencies]
-fusio = { git = "https://github.com/tonbo-io/fusio", rev = "92fd436b75f7cc496ec16d1e2be62481fce52e45", version = "0.3.4", package = "fusio", features = [
+fusio = { version = "0.3.5", package = "fusio", features = [
     "aws",
     "tokio",
 ] }
-fusio-dispatch = { git = "https://github.com/tonbo-io/fusio", rev = "92fd436b75f7cc496ec16d1e2be62481fce52e45", version = "0.3.4", package = "fusio-dispatch", features = [
+fusio-dispatch = { version = "0.3.5", package = "fusio-dispatch", features = [
     "aws",
     "tokio",
 ] }

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -9,11 +9,11 @@ crate-type = ["cdylib"]
 [workspace]
 
 [dependencies]
-fusio = { git = "https://github.com/tonbo-io/fusio", rev = "1fb503916a4945e5ff5fcc136f3d65e56375fb3d", version = "0.3.4", package = "fusio", features = [
+fusio = { git = "https://github.com/tonbo-io/fusio", rev = "92fd436b75f7cc496ec16d1e2be62481fce52e45", version = "0.3.4", package = "fusio", features = [
     "aws",
     "tokio",
 ] }
-fusio-dispatch = { git = "https://github.com/tonbo-io/fusio", rev = "1fb503916a4945e5ff5fcc136f3d65e56375fb3d", version = "0.3.4", package = "fusio-dispatch", features = [
+fusio-dispatch = { git = "https://github.com/tonbo-io/fusio", rev = "92fd436b75f7cc496ec16d1e2be62481fce52e45", version = "0.3.4", package = "fusio-dispatch", features = [
     "aws",
     "tokio",
 ] }

--- a/src/version/set.rs
+++ b/src/version/set.rs
@@ -49,7 +49,6 @@ where
     R: Record,
 {
     current: VersionRef<R>,
-    // log_with_id: (Logger<VersionEdit<<R::Schema as Schema>::Key>>, FileId),
     log_id: FileId,
 }
 

--- a/src/version/set.rs
+++ b/src/version/set.rs
@@ -49,7 +49,8 @@ where
     R: Record,
 {
     current: VersionRef<R>,
-    log_with_id: (Logger<VersionEdit<<R::Schema as Schema>::Key>>, FileId),
+    // log_with_id: (Logger<VersionEdit<<R::Schema as Schema>::Key>>, FileId),
+    log_id: FileId,
 }
 
 pub(crate) struct VersionSet<R>
@@ -148,8 +149,6 @@ where
             None => generate_file_id(),
         };
 
-        let log = Self::open_version_log(&option, fs.clone(), log_id).await?;
-
         let timestamp = Arc::new(AtomicU32::default());
         drop(log_stream);
         let set = VersionSet::<R> {
@@ -162,7 +161,7 @@ where
                     timestamp: timestamp.clone(),
                     log_length: 0,
                 }),
-                log_with_id: (log, log_id),
+                log_id,
             })),
             clean_sender,
             timestamp,
@@ -188,8 +187,11 @@ where
         let option = &self.option;
         let mut guard = self.inner.write().await;
         let mut new_version = Version::clone(&guard.current);
-        let (log, log_id) = &mut guard.log_with_id;
+        let log_id = &mut guard.log_id;
         let edit_len = new_version.log_length + version_edits.len() as u32;
+
+        let mut log =
+            Self::open_version_log(&self.option, self.manager.base_fs().clone(), *log_id).await?;
 
         if !is_recover {
             version_edits.push(VersionEdit::NewLogLength { len: edit_len });
@@ -266,8 +268,8 @@ where
         if edit_len >= option.version_log_snapshot_threshold {
             let fs = self.manager.base_fs();
             let old_log_id = mem::replace(log_id, generate_file_id());
-            let new_log = Self::open_version_log(option, fs.clone(), *log_id).await?;
-            let _old_log = mem::replace(log, new_log);
+            let mut log = Self::open_version_log(option, fs.clone(), *log_id).await?;
+            // let _old_log = mem::replace(log, new_log);
 
             new_version.log_length = 0;
             log.write_batch(new_version.to_edits().iter())
@@ -300,13 +302,12 @@ pub(crate) mod tests {
     use flume::{bounded, Sender};
     use fusio::path::Path;
     use fusio_dispatch::FsOptions;
-    use fusio_log::Options;
     use futures_util::StreamExt;
     use tempfile::TempDir;
 
     use crate::{
         fs::{generate_file_id, manager::StoreManager},
-        record::{test::StringSchema, Record, Schema},
+        record::{test::StringSchema, Record},
         scope::Scope,
         version::{
             cleaner::CleanTag,
@@ -328,17 +329,12 @@ pub(crate) mod tests {
     {
         let log_id = generate_file_id();
 
-        let log = Options::new(option.version_log_path(log_id))
-            .disable_buf()
-            .build_with_fs::<VersionEdit<<R::Schema as Schema>::Key>>(manager.base_fs().clone())
-            .await
-            .map_err(VersionError::Logger)?;
         let timestamp = version.timestamp.clone();
 
         Ok(VersionSet::<R> {
             inner: Arc::new(RwLock::new(VersionSetInner {
                 current: Arc::new(version),
-                log_with_id: (log, log_id),
+                log_id,
             })),
             clean_sender,
             timestamp,
@@ -458,8 +454,7 @@ pub(crate) mod tests {
 
         let guard = version_set.inner.write().await;
 
-        let edits =
-            VersionEdit::<String>::recover(option.version_log_path(guard.log_with_id.1)).await;
+        let edits = VersionEdit::<String>::recover(option.version_log_path(guard.log_id)).await;
 
         assert_eq!(edits.len(), 3);
         assert_eq!(

--- a/src/wal/mod.rs
+++ b/src/wal/mod.rs
@@ -52,7 +52,7 @@ where
     }
 
     pub(crate) async fn flush(&mut self) -> Result<(), LogError> {
-        self.file.close().await
+        self.file.flush().await
     }
 }
 

--- a/src/wal/mod.rs
+++ b/src/wal/mod.rs
@@ -15,8 +15,11 @@ pub(crate) struct WalFile<R>
 where
     R: Record,
 {
-    file: Logger<Log<R>>,
+    file: Option<Logger<Log<R>>>,
     file_id: FileId,
+    path: Path,
+    wal_buffer_size: usize,
+    fs: Arc<dyn DynFs>,
 }
 
 impl<R> WalFile<R>
@@ -29,13 +32,19 @@ where
         wal_buffer_size: usize,
         file_id: FileId,
     ) -> Self {
-        let file = Options::new(path)
+        let file = Options::new(path.clone())
             .buf_size(wal_buffer_size)
-            .build_with_fs::<Log<R>>(fs)
+            .build_with_fs::<Log<R>>(fs.clone())
             .await
             .unwrap();
 
-        Self { file, file_id }
+        Self {
+            file: Some(file),
+            file_id,
+            path,
+            wal_buffer_size,
+            fs,
+        }
     }
 
     pub(crate) fn file_id(&self) -> FileId {
@@ -48,11 +57,23 @@ where
     R: Record,
 {
     pub(crate) async fn write<'r>(&mut self, data: &Log<R>) -> Result<(), LogError> {
-        self.file.write(data).await
+        if self.file.is_none() {
+            self.file = Some(
+                Options::new(self.path.clone())
+                    .buf_size(self.wal_buffer_size)
+                    .build_with_fs::<Log<R>>(self.fs.clone())
+                    .await?,
+            );
+        }
+
+        self.file.as_mut().unwrap().write(data).await
     }
 
     pub(crate) async fn flush(&mut self) -> Result<(), LogError> {
-        self.file.flush().await
+        match self.file.take() {
+            Some(mut file) => file.close().await,
+            None => Ok(()),
+        }
     }
 }
 

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -274,6 +274,7 @@ mod tests {
                 }
             }
         }
+        db.flush_wal().await.unwrap();
         drop(db);
         remove("opfs_dir").await;
     }


### PR DESCRIPTION
Since fusio has changed close semantics, tonbo should change, too.

- remove log in VersionInner
- open log file before using