### PR TITLE
fix: replace null with default in record builder

### DIFF
--- a/src/record/runtime/array.rs
+++ b/src/record/runtime/array.rs
@@ -227,7 +227,7 @@ impl Builder<DynRecordImmutableArrays> for DynRecordBuilder {
                             let value = col.value.as_ref().downcast_ref::<Option<u8>>().unwrap();
                             match value {
                                 Some(value) => bd.append_value(*value),
-                                None => bd.append_null(),
+                                None => bd.append_value(Default::default()),
                             }
                         }
                         DataType::UInt16 => {
@@ -237,7 +237,7 @@ impl Builder<DynRecordImmutableArrays> for DynRecordBuilder {
                             let value = col.value.as_ref().downcast_ref::<Option<u16>>().unwrap();
                             match value {
                                 Some(value) => bd.append_value(*value),
-                                None => bd.append_null(),
+                                None => bd.append_value(Default::default()),
                             }
                         }
                         DataType::UInt32 => {
@@ -247,7 +247,7 @@ impl Builder<DynRecordImmutableArrays> for DynRecordBuilder {
                             let value = col.value.as_ref().downcast_ref::<Option<u32>>().unwrap();
                             match value {
                                 Some(value) => bd.append_value(*value),
-                                None => bd.append_null(),
+                                None => bd.append_value(Default::default()),
                             }
                         }
                         DataType::UInt64 => {
@@ -257,7 +257,7 @@ impl Builder<DynRecordImmutableArrays> for DynRecordBuilder {
                             let value = col.value.as_ref().downcast_ref::<Option<u64>>().unwrap();
                             match value {
                                 Some(value) => bd.append_value(*value),
-                                None => bd.append_null(),
+                                None => bd.append_value(Default::default()),
                             }
                         }
                         DataType::Int8 => {
@@ -267,7 +267,7 @@ impl Builder<DynRecordImmutableArrays> for DynRecordBuilder {
                             let value = col.value.as_ref().downcast_ref::<Option<i8>>().unwrap();
                             match value {
                                 Some(value) => bd.append_value(*value),
-                                None => bd.append_null(),
+                                None => bd.append_value(Default::default()),
                             }
                         }
                         DataType::Int16 => {
@@ -277,7 +277,7 @@ impl Builder<DynRecordImmutableArrays> for DynRecordBuilder {
                             let value = col.value.as_ref().downcast_ref::<Option<i16>>().unwrap();
                             match value {
                                 Some(value) => bd.append_value(*value),
-                                None => bd.append_null(),
+                                None => bd.append_value(Default::default()),
                             }
                         }
                         DataType::Int32 => {
@@ -287,7 +287,7 @@ impl Builder<DynRecordImmutableArrays> for DynRecordBuilder {
                             let value = col.value.as_ref().downcast_ref::<Option<i32>>().unwrap();
                             match value {
                                 Some(value) => bd.append_value(*value),
-                                None => bd.append_null(),
+                                None => bd.append_value(Default::default()),
                             }
                         }
                         DataType::Int64 => {
@@ -297,7 +297,7 @@ impl Builder<DynRecordImmutableArrays> for DynRecordBuilder {
                             let value = col.value.as_ref().downcast_ref::<Option<i64>>().unwrap();
                             match value {
                                 Some(value) => bd.append_value(*value),
-                                None => bd.append_null(),
+                                None => bd.append_value(Default::default()),
                             }
                         }
                         DataType::String => {
@@ -306,7 +306,7 @@ impl Builder<DynRecordImmutableArrays> for DynRecordBuilder {
                                 col.value.as_ref().downcast_ref::<Option<String>>().unwrap();
                             match value {
                                 Some(value) => bd.append_value(value),
-                                None => bd.append_null(),
+                                None => bd.append_value(""),
                             }
                         }
                         DataType::Boolean => {
@@ -314,7 +314,7 @@ impl Builder<DynRecordImmutableArrays> for DynRecordBuilder {
                             let value = col.value.as_ref().downcast_ref::<Option<bool>>().unwrap();
                             match value {
                                 Some(value) => bd.append_value(*value),
-                                None => bd.append_null(),
+                                None => bd.append_value(Default::default()),
                             }
                         }
                         DataType::Bytes => {
@@ -327,7 +327,7 @@ impl Builder<DynRecordImmutableArrays> for DynRecordBuilder {
                                 .unwrap();
                             match value {
                                 Some(value) => bd.append_value(value),
-                                None => bd.append_null(),
+                                None => bd.append_value(vec![]),
                             }
                         }
                     }


### PR DESCRIPTION
In `PackageStream`, the record in`DynRecordImmutableArrays::push` has been projected, which may cause inconsistencies between the data and the schema. So, we should set the value to default value instead of `None`.