### PR TITLE
refactor: project by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ async fn main() {
                 .scan((Bound::Included(&name), Bound::Excluded(&upper)))
                 .await
                 // tonbo supports pushing down projection
-                .projection(vec![1])
+                .projection(&["email"])
                 .take()
                 .await
                 .unwrap();

--- a/bindings/js/src/transaction.rs
+++ b/bindings/js/src/transaction.rs
@@ -135,7 +135,7 @@ impl Transaction {
                     >(high.as_ref())
                 },
             ))
-            .projection(projection);
+            .projection_with_index(projection);
 
         if let Some(limit) = limit {
             scan = scan.limit(limit);

--- a/bindings/python/src/transaction.rs
+++ b/bindings/python/src/transaction.rs
@@ -198,7 +198,7 @@ impl Transaction {
             if let Some(limit) = limit {
                 scan = scan.limit(limit);
             }
-            scan = scan.projection(projection);
+            scan = scan.projection_with_index(projection);
             let stream = scan.take().await.map_err(DbError::from)?;
 
             let stream = ScanStream::new(stream);

--- a/examples/datafusion.rs
+++ b/examples/datafusion.rs
@@ -211,7 +211,7 @@ impl ExecutionPlan for MusicExec {
                     scan = scan.limit(limit);
                 }
                 if let Some(projection) = projection {
-                    scan = scan.projection(projection.clone());
+                    scan = scan.projection_with_index(projection.clone());
                 }
                 let mut scan = scan.package(8192).await.map_err(|err| DataFusionError::Internal(err.to_string()))?;
 

--- a/examples/declare.rs
+++ b/examples/declare.rs
@@ -66,7 +66,7 @@ async fn main() {
             let mut scan = txn
                 .scan((Bound::Included(&name), Bound::Excluded(&upper)))
                 // tonbo supports pushing down projection
-                .projection(vec![1, 3])
+                .projection(&["email", "bytes"])
                 // push down limitation
                 .limit(1)
                 .take()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@
 //!             let mut scan = txn
 //!                 .scan((Bound::Included(&name), Bound::Excluded(&upper)))
 //!                 // tonbo supports pushing down projection
-//!                 .projection(vec![1])
+//!                 .projection(&["email"])
 //!                 .take()
 //!                 .await
 //!                 .unwrap();
@@ -754,7 +754,35 @@ where
     }
 
     /// fields in projection Record by field indices
-    pub fn projection(self, mut projection: Vec<usize>) -> Self {
+    pub fn projection(self, projection: &[&str]) -> Self {
+        let schema = self.schema.record_schema.arrow_schema();
+        let mut projection = projection
+            .iter()
+            .map(|name| {
+                schema
+                    .index_of(name)
+                    .unwrap_or_else(|_| panic!("unexpected field {}", name))
+            })
+            .collect::<Vec<usize>>();
+        let primary_key_index = self.schema.record_schema.primary_key_index();
+        let mut fixed_projection = vec![0, 1, primary_key_index];
+        fixed_projection.append(&mut projection);
+        fixed_projection.dedup();
+
+        let mask = ProjectionMask::roots(
+            &ArrowSchemaConverter::new().convert(schema).unwrap(),
+            fixed_projection.clone(),
+        );
+
+        Self {
+            projection: mask,
+            projection_indices: Some(fixed_projection),
+            ..self
+        }
+    }
+
+    /// fields in projection Record by field indices
+    pub fn projection_with_index(self, mut projection: Vec<usize>) -> Self {
         // skip two columns: _null and _ts
         for p in &mut projection {
             *p += USER_COLUMN_OFFSET;
@@ -1605,7 +1633,7 @@ pub(crate) mod tests {
             let tx = db.transaction().await;
             let mut scan = tx
                 .scan((Bound::Unbounded, Bound::Unbounded))
-                .projection(vec![0, 1, 2])
+                .projection(&["id", "age", "height"])
                 .take()
                 .await
                 .unwrap();
@@ -1794,7 +1822,7 @@ pub(crate) mod tests {
             let upper = Value::new(DataType::Int64, "id".to_owned(), Arc::new(49_i64), false);
             let mut scan = tx
                 .scan((Bound::Included(&lower), Bound::Included(&upper)))
-                .projection(vec![0, 2, 7])
+                .projection(&["id", "height", "bytes"])
                 .take()
                 .await
                 .unwrap();
@@ -1996,7 +2024,7 @@ pub(crate) mod tests {
             let upper = Value::new(DataType::Int64, "id".to_owned(), Arc::new(43_i64), false);
             let mut scan = tx1
                 .scan((Bound::Included(&lower), Bound::Included(&upper)))
-                .projection(vec![0, 1])
+                .projection(&["id", "age"])
                 .take()
                 .await
                 .unwrap();
@@ -2023,7 +2051,7 @@ pub(crate) mod tests {
             let tx2 = db2.transaction().await;
             let mut scan = tx2
                 .scan((Bound::Included(&lower), Bound::Included(&upper)))
-                .projection(vec![0, 1])
+                .projection(&["id", "age"])
                 .take()
                 .await
                 .unwrap();
@@ -2050,7 +2078,7 @@ pub(crate) mod tests {
             let tx3 = db3.transaction().await;
             let mut scan = tx3
                 .scan((Bound::Included(&lower), Bound::Included(&upper)))
-                .projection(vec![0, 1])
+                .projection(&["id", "age"])
                 .take()
                 .await
                 .unwrap();

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -183,7 +183,7 @@ mod tests {
 
         let mut stream = snapshot
             .scan((Bound::Unbounded, Bound::Unbounded))
-            .projection(vec![1])
+            .projection(&["vu32"])
             .take()
             .await
             .unwrap();

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -523,7 +523,7 @@ mod tests {
 
         let mut stream = txn
             .scan((Bound::Unbounded, Bound::Unbounded))
-            .projection(vec![1])
+            .projection(&["vu32"])
             .take()
             .await
             .unwrap();
@@ -623,7 +623,7 @@ mod tests {
             {
                 let mut stream = txn2
                     .scan((Bound::Included(&lower), Bound::Included(&upper)))
-                    .projection(vec![1])
+                    .projection(&["vu32"])
                     .take()
                     .await
                     .unwrap();
@@ -640,7 +640,7 @@ mod tests {
             {
                 let mut stream = txn2
                     .scan((Bound::Included(&lower), Bound::Excluded(&upper)))
-                    .projection(vec![1])
+                    .projection(&["vu32"])
                     .take()
                     .await
                     .unwrap();
@@ -654,7 +654,7 @@ mod tests {
             {
                 let mut stream = txn2
                     .scan((Bound::Excluded(&lower), Bound::Included(&upper)))
-                    .projection(vec![1])
+                    .projection(&["vu32"])
                     .take()
                     .await
                     .unwrap();
@@ -667,7 +667,7 @@ mod tests {
             {
                 let mut stream = txn2
                     .scan((Bound::Excluded(&lower), Bound::Excluded(&upper)))
-                    .projection(vec![1])
+                    .projection(&["vu32"])
                     .take()
                     .await
                     .unwrap();
@@ -684,7 +684,7 @@ mod tests {
             {
                 let mut stream = txn3
                     .scan((Bound::Included(&lower), Bound::Included(&upper)))
-                    .projection(vec![1])
+                    .projection(&["vu32"])
                     .take()
                     .await
                     .unwrap();
@@ -700,7 +700,7 @@ mod tests {
             {
                 let mut stream = txn3
                     .scan((Bound::Included(&lower), Bound::Excluded(&upper)))
-                    .projection(vec![1])
+                    .projection(&["vu32"])
                     .take()
                     .await
                     .unwrap();
@@ -713,7 +713,7 @@ mod tests {
             {
                 let mut stream = txn3
                     .scan((Bound::Excluded(&lower), Bound::Included(&upper)))
-                    .projection(vec![1])
+                    .projection(&["vu32"])
                     .take()
                     .await
                     .unwrap();
@@ -726,7 +726,7 @@ mod tests {
             {
                 let mut stream = txn3
                     .scan((Bound::Excluded(&lower), Bound::Excluded(&upper)))
-                    .projection(vec![1])
+                    .projection(&["vu32"])
                     .take()
                     .await
                     .unwrap();
@@ -736,7 +736,7 @@ mod tests {
             {
                 let mut stream = txn3
                     .scan((Bound::Unbounded, Bound::Excluded(&upper)))
-                    .projection(vec![1])
+                    .projection(&["vu32"])
                     .take()
                     .await
                     .unwrap();
@@ -876,7 +876,7 @@ mod tests {
         {
             let mut scan = txn
                 .scan((Bound::Unbounded, Bound::Unbounded))
-                .projection(vec![0, 1, 2])
+                .projection(&["id", "age", "height"])
                 .take()
                 .await
                 .unwrap();

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -173,7 +173,7 @@ mod tests {
             let upper = Value::new(DataType::Int64, "id".to_owned(), Arc::new(47_i64), false);
             let mut scan = txn
                 .scan((Bound::Included(&lower), Bound::Included(&upper)))
-                .projection(vec![0, 2, 4])
+                .projection(&["id", "name", "bytes"])
                 .take()
                 .await
                 .unwrap();
@@ -258,7 +258,7 @@ mod tests {
             let tx = db.transaction().await;
             let mut scan = tx
                 .scan((Bound::Unbounded, Bound::Unbounded))
-                .projection(vec![0, 1, 2])
+                .projection(&["id", "age", "name"])
                 .take()
                 .await
                 .unwrap();
@@ -340,7 +340,7 @@ mod tests {
 
             let mut scan = tx
                 .scan((Bound::Unbounded, Bound::Unbounded))
-                .projection(vec![0, 1, 2])
+                .projection(&["id", "age", "name"])
                 .take()
                 .await
                 .unwrap();


### PR DESCRIPTION
ref #133 

Use field names for projection instead of using indices
```rust
let name = "Alice".into();
let upper = "Bob".into();
let mut scan = txn
    .scan((Bound::Included(&name), Bound::Excluded(&upper)))
    .projection(vec!["name, "age"])
    .take()
    .await
    .unwrap();
```