### PR TITLE
refactor: re-export `fusio_log::Encode/Decode`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@ use async_lock::RwLock;
 use async_stream::stream;
 use flume::{bounded, Sender};
 use fs::FileId;
-use fusio_log::Decode;
+pub use fusio_log::{Decode, Encode};
 use futures_core::Stream;
 use futures_util::StreamExt;
 use inmem::{immutable::Immutable, mutable::Mutable};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,7 @@ use async_lock::RwLock;
 use async_stream::stream;
 use flume::{bounded, Sender};
 use fs::FileId;
+pub use fusio::{SeqRead, Write};
 pub use fusio_log::{Decode, Encode};
 use futures_core::Stream;
 use futures_util::StreamExt;

--- a/tonbo_macros/src/record.rs
+++ b/tonbo_macros/src/record.rs
@@ -278,7 +278,7 @@ fn trait_decode_codegen(struct_name: &Ident, fields: &[RecordStructFieldOpt]) ->
 
             async fn decode<R>(reader: &mut R) -> Result<Self, Self::Error>
             where
-                R: ::fusio::SeqRead,
+                R: ::tonbo::SeqRead,
             {
                 #(#decode_method_fields)*
 
@@ -532,7 +532,7 @@ fn trait_encode_codegen(struct_name: &Ident, fields: &[RecordStructFieldOpt]) ->
 
             async fn encode<W>(&self, writer: &mut W) -> Result<(), Self::Error>
             where
-                W: ::fusio::Write,
+                W: ::tonbo::Write,
             {
                 #(#encode_method_fields)*
 

--- a/tonbo_macros/src/record.rs
+++ b/tonbo_macros/src/record.rs
@@ -273,7 +273,7 @@ fn trait_decode_codegen(struct_name: &Ident, fields: &[RecordStructFieldOpt]) ->
     }
     quote! {
 
-        impl ::fusio_log::Decode for #struct_name {
+        impl ::tonbo::Decode for #struct_name {
             type Error = ::tonbo::record::RecordDecodeError;
 
             async fn decode<R>(reader: &mut R) -> Result<Self, Self::Error>
@@ -514,7 +514,7 @@ fn trait_encode_codegen(struct_name: &Ident, fields: &[RecordStructFieldOpt]) ->
         let field_name = field.ident.as_ref().unwrap();
 
         encode_method_fields.push(quote! {
-                    ::fusio_log::Encode::encode(&self.#field_name, writer).await.map_err(|err| ::tonbo::record::RecordEncodeError::Encode {
+                    ::tonbo::Encode::encode(&self.#field_name, writer).await.map_err(|err| ::tonbo::record::RecordEncodeError::Encode {
                         field_name: stringify!(#field_name).to_string(),
                         error: Box::new(err),
                     })?;
@@ -527,7 +527,7 @@ fn trait_encode_codegen(struct_name: &Ident, fields: &[RecordStructFieldOpt]) ->
     let struct_ref_name = struct_name.to_ref_ident();
 
     quote! {
-        impl<'r> ::fusio_log::Encode for #struct_ref_name<'r> {
+        impl<'r> ::tonbo::Encode for #struct_ref_name<'r> {
             type Error = ::tonbo::record::RecordEncodeError;
 
             async fn encode<W>(&self, writer: &mut W) -> Result<(), Self::Error>


### PR DESCRIPTION
re-export `fusio_log::Encode` and `fusio_log::Decode` to eliminate dependence on `fusio_log`

