### PR TITLE
re-export fusio::FsOptions and AwsCredential

### DIFF
--- a/bindings/js/Cargo.toml
+++ b/bindings/js/Cargo.toml
@@ -9,17 +9,11 @@ crate-type = ["cdylib", "rlib"]
 [workspace]
 
 [dependencies]
-
-fusio = { version = "0.3.7", package = "fusio", features = ["aws", "opfs"] }
-fusio-dispatch = { version = "0.3.7", package = "fusio-dispatch", features = [
-  "aws",
-  "opfs",
-] }
 futures = { version = "0.3" }
 js-sys = { version = "0.3.72" }
 tonbo = { version = "0.3.1", path = "../../", default-features = false, features = [
-  "bytes",
-  "wasm",
+    "bytes",
+    "wasm",
 ] }
 
 wasm-bindgen = "0.2.95"

--- a/bindings/js/src/fs.rs
+++ b/bindings/js/src/fs.rs
@@ -1,4 +1,4 @@
-use fusio::path::Path;
+use tonbo::option::Path;
 use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
 
 #[wasm_bindgen]
@@ -12,9 +12,9 @@ pub struct AwsCredential {
     pub token: Option<String>,
 }
 
-impl From<AwsCredential> for fusio::remotes::aws::AwsCredential {
+impl From<AwsCredential> for tonbo::option::AwsCredential {
     fn from(cred: AwsCredential) -> Self {
-        fusio::remotes::aws::AwsCredential {
+        tonbo::option::AwsCredential {
             key_id: cred.key_id,
             secret_key: cred.secret_key,
             token: cred.token,
@@ -158,9 +158,9 @@ impl FsOptions {
 }
 
 impl FsOptions {
-    pub(crate) fn into_fs_options(self) -> fusio_dispatch::FsOptions {
+    pub(crate) fn into_fs_options(self) -> tonbo::option::FsOptions {
         match self.inner {
-            FsOptionsInner::Local => fusio_dispatch::FsOptions::Local,
+            FsOptionsInner::Local => tonbo::option::FsOptions::Local,
             FsOptionsInner::S3 {
                 bucket,
                 credential,
@@ -168,9 +168,9 @@ impl FsOptions {
                 sign_payload,
                 checksum,
                 endpoint,
-            } => fusio_dispatch::FsOptions::S3 {
+            } => tonbo::option::FsOptions::S3 {
                 bucket,
-                credential: credential.map(fusio::remotes::aws::AwsCredential::from),
+                credential: credential.map(tonbo::option::AwsCredential::from),
                 endpoint,
                 region,
                 sign_payload,

--- a/bindings/js/src/options.rs
+++ b/bindings/js/src/options.rs
@@ -1,5 +1,4 @@
-use fusio::path::Path;
-use tonbo::record::Schema;
+use tonbo::{option::Path, record::Schema};
 use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
 
 use crate::FsOptions;

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -12,11 +12,6 @@ crate-type = ["cdylib"]
 [workspace]
 
 [dependencies]
-fusio = { version = "0.3.7", package = "fusio", features = ["aws", "tokio"] }
-fusio-dispatch = { version = "0.3.7", package = "fusio-dispatch", features = [
-    "aws",
-    "tokio",
-] }
 futures = { version = "0.3" }
 pyo3 = { version = "0.21.2", features = [
     "abi3",

--- a/bindings/python/src/fs.rs
+++ b/bindings/python/src/fs.rs
@@ -1,5 +1,5 @@
-use fusio::path::Path;
 use pyo3::{pyclass, pyfunction, pymethods, types::PyString, Bound, PyResult, Python};
+use tonbo::option::Path;
 
 use crate::PathParseError;
 
@@ -11,9 +11,9 @@ pub struct AwsCredential {
     pub token: Option<String>,
 }
 
-impl From<AwsCredential> for fusio::remotes::aws::AwsCredential {
+impl From<AwsCredential> for tonbo::option::AwsCredential {
     fn from(cred: AwsCredential) -> Self {
-        fusio::remotes::aws::AwsCredential {
+        tonbo::option::AwsCredential {
             key_id: cred.key_id,
             secret_key: cred.secret_key,
             token: cred.token,
@@ -47,10 +47,10 @@ pub enum FsOptions {
     },
 }
 
-impl From<FsOptions> for fusio_dispatch::FsOptions {
+impl From<FsOptions> for tonbo::option::FsOptions {
     fn from(opt: FsOptions) -> Self {
         match opt {
-            FsOptions::Local {} => fusio_dispatch::FsOptions::Local,
+            FsOptions::Local {} => tonbo::option::FsOptions::Local,
             FsOptions::S3 {
                 bucket,
                 credential,
@@ -58,9 +58,9 @@ impl From<FsOptions> for fusio_dispatch::FsOptions {
                 sign_payload,
                 checksum,
                 endpoint,
-            } => fusio_dispatch::FsOptions::S3 {
+            } => tonbo::option::FsOptions::S3 {
                 bucket,
-                credential: credential.map(fusio::remotes::aws::AwsCredential::from),
+                credential: credential.map(tonbo::option::AwsCredential::from),
                 region,
                 sign_payload,
                 checksum,

--- a/bindings/python/src/options.rs
+++ b/bindings/python/src/options.rs
@@ -1,6 +1,5 @@
-use fusio::path::Path;
 use pyo3::{pyclass, pymethods, PyResult};
-use tonbo::record::Schema;
+use tonbo::{option::Path, record::Schema};
 
 use crate::{ExceedsMaxLevelError, FsOptions};
 
@@ -81,14 +80,14 @@ impl DbOption {
             .major_threshold_with_sst_size(self.major_threshold_with_sst_size)
             .max_sst_file_size(self.max_sst_file_size)
             .version_log_snapshot_threshold(self.version_log_snapshot_threshold)
-            .base_fs(fusio_dispatch::FsOptions::from(self.base_fs));
+            .base_fs(tonbo::option::FsOptions::from(self.base_fs));
         for (level, path) in self.level_paths.into_iter().enumerate() {
             if let Some((path, fs_options)) = path {
                 opt = opt
                     .level_path(
                         level,
                         Path::from(path),
-                        fusio_dispatch::FsOptions::from(fs_options),
+                        tonbo::option::FsOptions::from(fs_options),
                     )
                     .unwrap();
             }

--- a/src/option.rs
+++ b/src/option.rs
@@ -1,7 +1,9 @@
 use std::fmt::{Debug, Formatter};
 
 pub use fusio::path::Path;
-use fusio_dispatch::FsOptions;
+#[cfg(feature = "aws")]
+pub use fusio::remotes::aws::AwsCredential;
+pub use fusio_dispatch::FsOptions;
 use parquet::{
     basic::Compression,
     file::properties::{EnabledStatistics, WriterProperties},


### PR DESCRIPTION
If we want to use tonbo, we have to import fusio, too. This PR re-export fusio structures so that we can use tonbo like this:
```toml
tonbo = { version = "0.3.1",  features = [] }
```