### PR TITLE
add macros to simplify the usage of `DynRecord`

### DIFF
--- a/examples/dynamic.rs
+++ b/examples/dynamic.rs
@@ -2,8 +2,9 @@ use std::{fs, sync::Arc};
 
 use fusio::path::Path;
 use tonbo::{
+    dyn_record, dyn_schema,
     executor::tokio::TokioExecutor,
-    record::{DataType, DynRecord, DynSchema, Value, ValueDesc},
+    record::{DataType, Value},
     DbOption, DB,
 };
 
@@ -11,13 +12,7 @@ use tonbo::{
 async fn main() {
     fs::create_dir_all("./db_path/users").unwrap();
 
-    let schema = DynSchema::new(
-        vec![
-            ValueDesc::new("foo".into(), DataType::String, false),
-            ValueDesc::new("bar".into(), DataType::Int32, true),
-        ],
-        0,
-    );
+    let schema = dyn_schema!(("foo", String, false), ("bar", Int32, true), 0);
 
     let options = DbOption::new(
         Path::from_filesystem_path("./db_path/users").unwrap(),
@@ -29,17 +24,10 @@ async fn main() {
 
     {
         let mut txn = db.transaction().await;
-        txn.insert(DynRecord::new(
-            vec![
-                Value::new(
-                    DataType::String,
-                    "foo".into(),
-                    Arc::new("hello".to_owned()),
-                    false,
-                ),
-                Value::new(DataType::Int32, "bar".into(), Arc::new(1), true),
-            ],
-            0,
+        txn.insert(dyn_record!(
+            ("foo", String, false, "hello".to_owned()),
+            ("bar", Int32, true, 1),
+            0
         ));
 
         txn.commit().await.unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1009,6 +1009,7 @@ pub(crate) mod tests {
     use tracing::error;
 
     use crate::{
+        cast_arc_value,
         compaction::{CompactTask, CompactionError, Compactor},
         context::Context,
         executor::{tokio::TokioExecutor, Executor},
@@ -1846,82 +1847,33 @@ pub(crate) mod tests {
                 let record_ref = entry.get();
 
                 assert_eq!(
-                    *record_ref
-                        .columns
-                        .first()
-                        .unwrap()
-                        .value
-                        .as_ref()
-                        .downcast_ref::<i64>()
-                        .unwrap(),
+                    *cast_arc_value!(record_ref.columns.first().unwrap().value, i64),
                     i as i64
                 );
-                let height = record_ref
-                    .columns
-                    .get(2)
-                    .unwrap()
-                    .value
-                    .as_ref()
-                    .downcast_ref::<Option<i16>>()
-                    .unwrap();
+                let height = cast_arc_value!(record_ref.columns.get(2).unwrap().value, Option<i16>);
                 if i < 45 {
                     assert_eq!(*height, Some(20 * i as i16),);
                 } else {
                     assert!(height.is_none());
                 }
                 assert_eq!(
-                    *record_ref
-                        .columns
-                        .get(3)
-                        .unwrap()
-                        .value
-                        .as_ref()
-                        .downcast_ref::<Option<i32>>()
-                        .unwrap(),
+                    *cast_arc_value!(record_ref.columns.get(3).unwrap().value, Option<i32>),
                     Some(200 * i),
                 );
                 assert_eq!(
-                    *record_ref
-                        .columns
-                        .get(4)
-                        .unwrap()
-                        .value
-                        .as_ref()
-                        .downcast_ref::<Option<String>>()
-                        .unwrap(),
+                    *cast_arc_value!(record_ref.columns.get(4).unwrap().value, Option<String>),
                     Some(i.to_string()),
                 );
                 assert_eq!(
-                    *record_ref
-                        .columns
-                        .get(5)
-                        .unwrap()
-                        .value
-                        .as_ref()
-                        .downcast_ref::<Option<String>>()
-                        .unwrap(),
+                    *cast_arc_value!(record_ref.columns.get(5).unwrap().value, Option<String>),
                     Some(format!("{}@tonbo.io", i)),
                 );
                 assert_eq!(
-                    *record_ref
-                        .columns
-                        .get(6)
-                        .unwrap()
-                        .value
-                        .as_ref()
-                        .downcast_ref::<Option<bool>>()
-                        .unwrap(),
+                    *cast_arc_value!(record_ref.columns.get(6).unwrap().value, Option<bool>),
                     Some(i % 2 == 0),
                 );
                 assert_eq!(
-                    *record_ref
-                        .columns
-                        .get(7)
-                        .unwrap()
-                        .value
-                        .as_ref()
-                        .downcast_ref::<Option<Vec<u8>>>()
-                        .unwrap(),
+                    *cast_arc_value!(record_ref.columns.get(7).unwrap().value, Option<Vec<u8>>),
                     Some(i.to_le_bytes().to_vec()),
                 );
             }
@@ -2094,36 +2046,15 @@ pub(crate) mod tests {
                 let record_ref = entry.get();
 
                 assert_eq!(
-                    *record_ref
-                        .columns
-                        .first()
-                        .unwrap()
-                        .value
-                        .as_ref()
-                        .downcast_ref::<i64>()
-                        .unwrap(),
+                    *cast_arc_value!(record_ref.columns.first().unwrap().value, i64),
                     i as i64
                 );
                 assert_eq!(
-                    *record_ref
-                        .columns
-                        .get(3)
-                        .unwrap()
-                        .value
-                        .as_ref()
-                        .downcast_ref::<Option<i32>>()
-                        .unwrap(),
+                    *cast_arc_value!(record_ref.columns.get(3).unwrap().value, Option<i32>),
                     Some(200 * i),
                 );
                 assert_eq!(
-                    *record_ref
-                        .columns
-                        .get(4)
-                        .unwrap()
-                        .value
-                        .as_ref()
-                        .downcast_ref::<Option<String>>()
-                        .unwrap(),
+                    *cast_arc_value!(record_ref.columns.get(4).unwrap().value, Option<String>),
                     Some(i.to_string()),
                 );
             }
@@ -2148,14 +2079,7 @@ pub(crate) mod tests {
                 let primary_key_col = columns.first().unwrap();
                 assert_eq!(primary_key_col.datatype(), DataType::Int64);
                 assert_eq!(primary_key_col.desc.name, "id".to_string());
-                assert_eq!(
-                    *primary_key_col
-                        .value
-                        .as_ref()
-                        .downcast_ref::<i64>()
-                        .unwrap(),
-                    i
-                );
+                assert_eq!(*cast_arc_value!(primary_key_col.value, i64), i);
 
                 i += 2
             }
@@ -2175,14 +2099,7 @@ pub(crate) mod tests {
                 let primary_key_col = columns.first().unwrap();
                 assert_eq!(primary_key_col.datatype(), DataType::Int64);
                 assert_eq!(primary_key_col.desc.name, "id".to_string());
-                assert_eq!(
-                    *primary_key_col
-                        .value
-                        .as_ref()
-                        .downcast_ref::<i64>()
-                        .unwrap(),
-                    i
-                );
+                assert_eq!(*cast_arc_value!(primary_key_col.value, i64), i);
 
                 i += 2
             }
@@ -2202,14 +2119,7 @@ pub(crate) mod tests {
                 let primary_key_col = columns.first().unwrap();
                 assert_eq!(primary_key_col.datatype(), DataType::Int64);
                 assert_eq!(primary_key_col.desc.name, "id".to_string());
-                assert_eq!(
-                    *primary_key_col
-                        .value
-                        .as_ref()
-                        .downcast_ref::<i64>()
-                        .unwrap(),
-                    i
-                );
+                assert_eq!(*cast_arc_value!(primary_key_col.value, i64), i);
 
                 i += 1
             }

--- a/src/record/runtime/array.rs
+++ b/src/record/runtime/array.rs
@@ -14,6 +14,7 @@ use arrow::{
 
 use super::{record::DynRecord, record_ref::DynRecordRef, value::Value, DataType};
 use crate::{
+    cast_arc_value,
     inmem::immutable::{ArrowArrays, Builder},
     magic::USER_COLUMN_OFFSET,
     record::{Key, Record, Schema},
@@ -131,25 +132,15 @@ impl ArrowArrays for DynRecordImmutableArrays {
                     DataType::Int32 => Arc::new(Self::primitive_value::<Int32Type>(col, offset)),
                     DataType::Int64 => Arc::new(Self::primitive_value::<Int64Type>(col, offset)),
                     DataType::String => Arc::new(
-                        col.value
-                            .as_ref()
-                            .downcast_ref::<StringArray>()
-                            .unwrap()
+                        cast_arc_value!(col.value, StringArray)
                             .value(offset)
                             .to_owned(),
                     ),
-                    DataType::Boolean => Arc::new(
-                        col.value
-                            .as_ref()
-                            .downcast_ref::<BooleanArray>()
-                            .unwrap()
-                            .value(offset),
-                    ),
+                    DataType::Boolean => {
+                        Arc::new(cast_arc_value!(col.value, BooleanArray).value(offset))
+                    }
                     DataType::Bytes => Arc::new(
-                        col.value
-                            .as_ref()
-                            .downcast_ref::<GenericBinaryArray<i32>>()
-                            .unwrap()
+                        cast_arc_value!(col.value, GenericBinaryArray<i32>)
                             .value(offset)
                             .to_owned(),
                     ),
@@ -171,11 +162,7 @@ impl DynRecordImmutableArrays {
     where
         T: ArrowPrimitiveType,
     {
-        col.value
-            .as_ref()
-            .downcast_ref::<PrimitiveArray<T>>()
-            .unwrap()
-            .value(offset)
+        cast_arc_value!(col.value, PrimitiveArray<T>).value(offset)
     }
 }
 
@@ -219,8 +206,7 @@ impl Builder<DynRecordImmutableArrays> for DynRecordBuilder {
                             let bd = Self::as_builder_mut::<PrimitiveBuilder<UInt8Type>>(
                                 builder.as_mut(),
                             );
-                            let value = col.value.as_ref().downcast_ref::<Option<u8>>().unwrap();
-                            match value {
+                            match cast_arc_value!(col.value, Option<u8>) {
                                 Some(value) => bd.append_value(*value),
                                 None if col.is_nullable() => bd.append_null(),
                                 None => bd.append_value(Default::default()),
@@ -230,8 +216,7 @@ impl Builder<DynRecordImmutableArrays> for DynRecordBuilder {
                             let bd = Self::as_builder_mut::<PrimitiveBuilder<UInt16Type>>(
                                 builder.as_mut(),
                             );
-                            let value = col.value.as_ref().downcast_ref::<Option<u16>>().unwrap();
-                            match value {
+                            match cast_arc_value!(col.value, Option<u16>) {
                                 Some(value) => bd.append_value(*value),
                                 None if col.is_nullable() => bd.append_null(),
                                 None => bd.append_value(Default::default()),
@@ -241,8 +226,7 @@ impl Builder<DynRecordImmutableArrays> for DynRecordBuilder {
                             let bd = Self::as_builder_mut::<PrimitiveBuilder<UInt32Type>>(
                                 builder.as_mut(),
                             );
-                            let value = col.value.as_ref().downcast_ref::<Option<u32>>().unwrap();
-                            match value {
+                            match cast_arc_value!(col.value, Option<u32>) {
                                 Some(value) => bd.append_value(*value),
                                 None if col.is_nullable() => bd.append_null(),
                                 None => bd.append_value(Default::default()),
@@ -252,8 +236,7 @@ impl Builder<DynRecordImmutableArrays> for DynRecordBuilder {
                             let bd = Self::as_builder_mut::<PrimitiveBuilder<UInt64Type>>(
                                 builder.as_mut(),
                             );
-                            let value = col.value.as_ref().downcast_ref::<Option<u64>>().unwrap();
-                            match value {
+                            match cast_arc_value!(col.value, Option<u64>) {
                                 Some(value) => bd.append_value(*value),
                                 None if col.is_nullable() => bd.append_null(),
                                 None => bd.append_value(Default::default()),
@@ -263,8 +246,7 @@ impl Builder<DynRecordImmutableArrays> for DynRecordBuilder {
                             let bd = Self::as_builder_mut::<PrimitiveBuilder<Int8Type>>(
                                 builder.as_mut(),
                             );
-                            let value = col.value.as_ref().downcast_ref::<Option<i8>>().unwrap();
-                            match value {
+                            match cast_arc_value!(col.value, Option<i8>) {
                                 Some(value) => bd.append_value(*value),
                                 None if col.is_nullable() => bd.append_null(),
                                 None => bd.append_value(Default::default()),
@@ -274,8 +256,7 @@ impl Builder<DynRecordImmutableArrays> for DynRecordBuilder {
                             let bd = Self::as_builder_mut::<PrimitiveBuilder<Int16Type>>(
                                 builder.as_mut(),
                             );
-                            let value = col.value.as_ref().downcast_ref::<Option<i16>>().unwrap();
-                            match value {
+                            match cast_arc_value!(col.value, Option<i16>) {
                                 Some(value) => bd.append_value(*value),
                                 None if col.is_nullable() => bd.append_null(),
                                 None => bd.append_value(Default::default()),
@@ -285,8 +266,7 @@ impl Builder<DynRecordImmutableArrays> for DynRecordBuilder {
                             let bd = Self::as_builder_mut::<PrimitiveBuilder<Int32Type>>(
                                 builder.as_mut(),
                             );
-                            let value = col.value.as_ref().downcast_ref::<Option<i32>>().unwrap();
-                            match value {
+                            match cast_arc_value!(col.value, Option<i32>) {
                                 Some(value) => bd.append_value(*value),
                                 None if col.is_nullable() => bd.append_null(),
                                 None => bd.append_value(Default::default()),
@@ -296,8 +276,7 @@ impl Builder<DynRecordImmutableArrays> for DynRecordBuilder {
                             let bd = Self::as_builder_mut::<PrimitiveBuilder<Int64Type>>(
                                 builder.as_mut(),
                             );
-                            let value = col.value.as_ref().downcast_ref::<Option<i64>>().unwrap();
-                            match value {
+                            match cast_arc_value!(col.value, Option<i64>) {
                                 Some(value) => bd.append_value(*value),
                                 None if col.is_nullable() => bd.append_null(),
                                 None => bd.append_value(Default::default()),
@@ -305,9 +284,7 @@ impl Builder<DynRecordImmutableArrays> for DynRecordBuilder {
                         }
                         DataType::String => {
                             let bd = Self::as_builder_mut::<StringBuilder>(builder.as_mut());
-                            let value =
-                                col.value.as_ref().downcast_ref::<Option<String>>().unwrap();
-                            match value {
+                            match cast_arc_value!(col.value, Option<String>) {
                                 Some(value) => bd.append_value(value),
                                 None if col.is_nullable() => bd.append_null(),
                                 None => bd.append_value(""),
@@ -315,8 +292,7 @@ impl Builder<DynRecordImmutableArrays> for DynRecordBuilder {
                         }
                         DataType::Boolean => {
                             let bd = Self::as_builder_mut::<BooleanBuilder>(builder.as_mut());
-                            let value = col.value.as_ref().downcast_ref::<Option<bool>>().unwrap();
-                            match value {
+                            match cast_arc_value!(col.value, Option<bool>) {
                                 Some(value) => bd.append_value(*value),
                                 None if col.is_nullable() => bd.append_null(),
                                 None => bd.append_value(Default::default()),
@@ -325,12 +301,7 @@ impl Builder<DynRecordImmutableArrays> for DynRecordBuilder {
                         DataType::Bytes => {
                             let bd =
                                 Self::as_builder_mut::<GenericBinaryBuilder<i32>>(builder.as_mut());
-                            let value = col
-                                .value
-                                .as_ref()
-                                .downcast_ref::<Option<Vec<u8>>>()
-                                .unwrap();
-                            match value {
+                            match cast_arc_value!(col.value, Option<Vec<u8>>) {
                                 Some(value) => bd.append_value(value),
                                 None if col.is_nullable() => bd.append_null(),
                                 None => bd.append_value(vec![]),
@@ -640,40 +611,40 @@ impl DynRecordBuilder {
         match datatype {
             DataType::UInt8 => {
                 Self::as_builder_mut::<PrimitiveBuilder<UInt8Type>>(builder.as_mut())
-                    .append_value(*col.value.as_ref().downcast_ref::<u8>().unwrap())
+                    .append_value(*cast_arc_value!(col.value, u8))
             }
             DataType::UInt16 => {
                 Self::as_builder_mut::<PrimitiveBuilder<UInt16Type>>(builder.as_mut())
-                    .append_value(*col.value.as_ref().downcast_ref::<u16>().unwrap())
+                    .append_value(*cast_arc_value!(col.value, u16))
             }
             DataType::UInt32 => {
                 Self::as_builder_mut::<PrimitiveBuilder<UInt32Type>>(builder.as_mut())
-                    .append_value(*col.value.as_ref().downcast_ref::<u32>().unwrap())
+                    .append_value(*cast_arc_value!(col.value, u32))
             }
             DataType::UInt64 => {
                 Self::as_builder_mut::<PrimitiveBuilder<UInt64Type>>(builder.as_mut())
-                    .append_value(*col.value.as_ref().downcast_ref::<u64>().unwrap())
+                    .append_value(*cast_arc_value!(col.value, u64))
             }
             DataType::Int8 => Self::as_builder_mut::<PrimitiveBuilder<Int8Type>>(builder.as_mut())
-                .append_value(*col.value.as_ref().downcast_ref::<i8>().unwrap()),
+                .append_value(*cast_arc_value!(col.value, i8)),
             DataType::Int16 => {
                 Self::as_builder_mut::<PrimitiveBuilder<Int16Type>>(builder.as_mut())
-                    .append_value(*col.value.as_ref().downcast_ref::<i16>().unwrap())
+                    .append_value(*cast_arc_value!(col.value, i16))
             }
             DataType::Int32 => {
                 Self::as_builder_mut::<PrimitiveBuilder<Int32Type>>(builder.as_mut())
-                    .append_value(*col.value.as_ref().downcast_ref::<i32>().unwrap())
+                    .append_value(*cast_arc_value!(col.value, i32))
             }
             DataType::Int64 => {
                 Self::as_builder_mut::<PrimitiveBuilder<Int64Type>>(builder.as_mut())
-                    .append_value(*col.value.as_ref().downcast_ref::<i64>().unwrap())
+                    .append_value(*cast_arc_value!(col.value, i64))
             }
             DataType::String => Self::as_builder_mut::<StringBuilder>(builder.as_mut())
-                .append_value(col.value.as_ref().downcast_ref::<String>().unwrap()),
+                .append_value(cast_arc_value!(col.value, String)),
             DataType::Boolean => Self::as_builder_mut::<BooleanBuilder>(builder.as_mut())
-                .append_value(*col.value.as_ref().downcast_ref::<bool>().unwrap()),
+                .append_value(*cast_arc_value!(col.value, bool)),
             DataType::Bytes => Self::as_builder_mut::<GenericBinaryBuilder<i32>>(builder.as_mut())
-                .append_value(col.value.as_ref().downcast_ref::<Vec<u8>>().unwrap()),
+                .append_value(cast_arc_value!(col.value, Vec<u8>)),
         };
     }
 

--- a/src/record/runtime/mod.rs
+++ b/src/record/runtime/mod.rs
@@ -44,3 +44,11 @@ impl From<&ArrowDataType> for DataType {
         }
     }
 }
+
+/// Cast the `Arc<dyn Any>` to the value of given type.
+#[macro_export]
+macro_rules! cast_arc_value {
+    ($value:expr, $type:ty) => {
+        $value.as_ref().downcast_ref::<$type>().unwrap()
+    };
+}

--- a/src/record/runtime/schema.rs
+++ b/src/record/runtime/schema.rs
@@ -63,3 +63,40 @@ impl Schema for DynSchema {
         )
     }
 }
+
+/// Creates a [`DynSchema`] from literal slice of values and primary key index, suitable for rapid
+/// testing and development.
+///
+/// ## Example:
+///
+/// ```no_run
+/// // dyn_schema!(
+/// //      (name, type, nullable),
+/// //         ......
+/// //      (name, type, nullable),
+/// //      primary_key_index
+/// // );
+/// use tonbo::dyn_schema;
+///
+/// let schema = dyn_schema!(
+///     ("foo", String, false),
+///     ("bar", Int32, true),
+///     ("baz", UInt64, true),
+///     0
+/// );
+/// ```
+#[macro_export]
+macro_rules! dyn_schema {
+    ($(($name: expr, $type: ident, $nullable: expr )),*, $primary: literal) => {
+        {
+            $crate::record::DynSchema::new(
+                vec![
+                    $(
+                        $crate::record::ValueDesc::new($name.into(), $crate::record::DataType::$type, $nullable),
+                    )*
+                ],
+                $primary,
+            )
+        }
+    }
+}


### PR DESCRIPTION
use macros to simplify the usage of  `DynSchema` and `DynRecord`:

```rust
let schema = dyn_schema!(
    ("foo", String, false),
    ("bar", Int32, true),
    ("baz", UInt64, false),
    0
);

let record = dyn_record!(
     ("foo", String, false, "hello".to_owned()),
     ("bar", Int32, true, 1_i32),
     ("baz", UInt64, false, 2_u64),
     0
);
```