### PR TITLE
feat: support float type

### DIFF
--- a/bindings/js/src/utils.rs
+++ b/bindings/js/src/utils.rs
@@ -21,6 +21,8 @@ fn none_value(datatype: DataType) -> Arc<dyn Any + Send + Sync> {
         DataType::Int16 => Arc::new(Option::<i16>::None),
         DataType::Int32 => Arc::new(Option::<i32>::None),
         DataType::Int64 => Arc::new(Option::<i64>::None),
+        DataType::Float32 => unimplemented!(),
+        DataType::Float64 => unimplemented!(),
         DataType::String => Arc::new(Option::<String>::None),
         DataType::Boolean => Arc::new(Option::<bool>::None),
         DataType::Bytes => Arc::new(Option::<Vec<u8>>::None),
@@ -49,6 +51,8 @@ pub(crate) fn parse_key(desc: &ValueDesc, key: JsValue, primary: bool) -> Result
         DataType::Int8 => to_col_value::<i8>(key.as_f64().unwrap().round() as i8, primary),
         DataType::Int16 => to_col_value::<i16>(key.as_f64().unwrap().round() as i16, primary),
         DataType::Int32 => to_col_value::<i32>(key.as_f64().unwrap().round() as i32, primary),
+        DataType::Float32 => unimplemented!(),
+        DataType::Float64 => unimplemented!(),
         DataType::Int64 => to_col_value::<i64>(key.as_f64().unwrap().round() as i64, primary),
         DataType::String => to_col_value::<String>(key.as_string().unwrap(), primary),
         DataType::Boolean => to_col_value::<bool>(key.as_bool().unwrap(), primary),
@@ -114,6 +118,14 @@ pub(crate) fn to_record(cols: &Vec<Value>, primary_key_index: usize) -> JsValue 
             DataType::Int64 => match idx == primary_key_index {
                 true => (*col.value.as_ref().downcast_ref::<i64>().unwrap()).into(),
                 false => (*col.value.as_ref().downcast_ref::<Option<i64>>().unwrap()).into(),
+            },
+            DataType::Float32 => match idx == primary_key_index {
+                true => unimplemented!(),
+                false => unimplemented!(),
+            },
+            DataType::Float64 => match idx == primary_key_index {
+                true => unimplemented!(),
+                false => unimplemented!(),
             },
             DataType::String => match idx == primary_key_index {
                 true => (col.value.as_ref().downcast_ref::<String>().unwrap()).into(),

--- a/bindings/python/src/utils.rs
+++ b/bindings/python/src/utils.rs
@@ -85,6 +85,12 @@ pub(crate) fn to_dict(py: Python, primary_key_index: usize, record: Vec<Value>) 
                     dict.set_item(name, value).unwrap();
                 }
             }
+            TonboDataType::Float32 => {
+                unimplemented!()
+            }
+            TonboDataType::Float64 => {
+                unimplemented!()
+            }
             TonboDataType::String => {
                 if idx == primary_key_index {
                     dict.set_item(name, col.value.as_ref().downcast_ref::<String>())

--- a/examples/declare.rs
+++ b/examples/declare.rs
@@ -4,7 +4,7 @@ use bytes::Bytes;
 use fusio::path::Path;
 use futures_util::stream::StreamExt;
 use tokio::fs;
-use tonbo::{executor::tokio::TokioExecutor, DbOption, Projection, Record, DB};
+use tonbo::{executor::tokio::TokioExecutor, record::F32, DbOption, Projection, Record, DB};
 
 /// Use macro to define schema of column family just like ORM
 /// It provides type-safe read & write API
@@ -15,6 +15,7 @@ pub struct User {
     email: Option<String>,
     age: u8,
     bytes: Bytes,
+    grade: F32,
 }
 
 #[tokio::main]
@@ -37,6 +38,7 @@ async fn main() {
         email: Some("alice@gmail.com".into()),
         age: 22,
         bytes: Bytes::from(vec![0, 1, 2]),
+        grade: 96.5.into(),
     })
     .await
     .unwrap();
@@ -66,7 +68,7 @@ async fn main() {
             let mut scan = txn
                 .scan((Bound::Included(&name), Bound::Excluded(&upper)))
                 // tonbo supports pushing down projection
-                .projection(&["email", "bytes"])
+                .projection(&["email", "bytes", "grade"])
                 // push down limitation
                 .limit(1)
                 .take()
@@ -80,6 +82,7 @@ async fn main() {
                         email: Some("alice@gmail.com"),
                         age: None,
                         bytes: Some(&[0, 1, 2]),
+                        grade: Some(96.5.into()),
                     })
                 );
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1019,7 +1019,7 @@ pub(crate) mod tests {
             option::OptionRecordRef,
             runtime::test::{test_dyn_item_schema, test_dyn_items},
             DataType, DynRecord, Key, RecordDecodeError, RecordEncodeError, RecordRef,
-            Schema as RecordSchema, Value,
+            Schema as RecordSchema, Value, F32, F64,
         },
         trigger::{TriggerFactory, TriggerType},
         version::{cleaner::Cleaner, set::tests::build_version_set, Version},
@@ -1876,6 +1876,14 @@ pub(crate) mod tests {
                     *cast_arc_value!(record_ref.columns.get(7).unwrap().value, Option<Vec<u8>>),
                     Some(i.to_le_bytes().to_vec()),
                 );
+                assert_eq!(
+                    *cast_arc_value!(record_ref.columns.get(8).unwrap().value, Option<F32>),
+                    Some(F32::from(i as f32 * 1.11)),
+                );
+                assert_eq!(
+                    *cast_arc_value!(record_ref.columns.get(9).unwrap().value, Option<F64>),
+                    Some(F64::from(i as f64 * 1.01)),
+                );
             }
             tx.commit().await.unwrap();
         }
@@ -1886,7 +1894,7 @@ pub(crate) mod tests {
             let upper = Value::new(DataType::Int64, "id".to_owned(), Arc::new(49_i64), false);
             let mut scan = tx
                 .scan((Bound::Included(&lower), Bound::Included(&upper)))
-                .projection(&["id", "height", "bytes"])
+                .projection(&["id", "height", "bytes", "grade", "price"])
                 .take()
                 .await
                 .unwrap();
@@ -1954,6 +1962,18 @@ pub(crate) mod tests {
                 let bytes = col.value.as_ref().downcast_ref::<Option<Vec<u8>>>();
                 assert!(bytes.is_some());
                 assert_eq!(bytes.unwrap(), &Some((i as i32).to_le_bytes().to_vec()));
+
+                let col = columns.get(8).unwrap();
+                assert_eq!(col.datatype(), DataType::Float32);
+                let v = col.value.as_ref().downcast_ref::<Option<F32>>();
+                assert!(v.is_some());
+                assert_eq!(v.unwrap(), &Some(F32::from(i as f32 * 1.11)));
+
+                let col = columns.get(9).unwrap();
+                assert_eq!(col.datatype(), DataType::Float64);
+                let v = col.value.as_ref().downcast_ref::<Option<F64>>();
+                assert!(v.is_some());
+                assert_eq!(v.unwrap(), &Some(F64::from(i as f64 * 1.01)));
                 i += 1
             }
         }

--- a/src/record/key/mod.rs
+++ b/src/record/key/mod.rs
@@ -5,6 +5,7 @@ use std::{hash::Hash, sync::Arc};
 
 use arrow::array::Datum;
 use fusio_log::{Decode, Encode};
+pub use num::*;
 
 pub trait Key:
     'static + Encode + Decode + Ord + Clone + Send + Sync + Hash + std::fmt::Debug

--- a/src/record/key/num.rs
+++ b/src/record/key/num.rs
@@ -1,9 +1,11 @@
-use std::sync::Arc;
+use std::{hash::Hash, ops::Deref, sync::Arc};
 
 use arrow::array::{
-    Datum, Int16Array, Int32Array, Int64Array, Int8Array, UInt16Array, UInt32Array, UInt64Array,
-    UInt8Array,
+    Datum, Float32Array, Float64Array, Int16Array, Int32Array, Int64Array, Int8Array, UInt16Array,
+    UInt32Array, UInt64Array, UInt8Array,
 };
+use fusio::{SeqRead, Write};
+use fusio_log::{Decode, Encode};
 
 use crate::record::{Key, KeyRef};
 
@@ -40,3 +42,174 @@ implement_key!(u8, UInt8Array);
 implement_key!(u16, UInt16Array);
 implement_key!(u32, UInt32Array);
 implement_key!(u64, UInt64Array);
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct FloatType<T>(pub T);
+
+pub type F32 = FloatType<f32>;
+pub type F64 = FloatType<f64>;
+
+#[macro_export]
+macro_rules! implement_float_encode_decode {
+    ($ty:ident) => {
+        impl Encode for FloatType<$ty> {
+            type Error = fusio::Error;
+
+            async fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Self::Error> {
+                let (result, _) = writer.write_all(&self.to_le_bytes()[..]).await;
+                result?;
+
+                Ok(())
+            }
+
+            fn size(&self) -> usize {
+                size_of::<Self>()
+            }
+        }
+
+        impl Decode for FloatType<$ty> {
+            type Error = fusio::Error;
+
+            async fn decode<R: SeqRead>(reader: &mut R) -> Result<Self, Self::Error> {
+                let mut bytes = [0u8; size_of::<Self>()];
+                let (result, _) = reader.read_exact(&mut bytes[..]).await;
+                result?;
+
+                Ok(FloatType::<$ty>::from($ty::from_le_bytes(bytes)))
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! implement_float_key {
+    ($ty:ty, $array_name:ident) => {
+        impl Ord for FloatType<$ty> {
+            fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+                self.0.total_cmp(&other.0)
+            }
+        }
+
+        impl PartialEq for FloatType<$ty> {
+            fn eq(&self, other: &Self) -> bool {
+                self.0.to_bits() == other.0.to_bits()
+            }
+        }
+
+        impl PartialOrd for FloatType<$ty> {
+            fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+                Some(self.cmp(other))
+            }
+        }
+        impl Eq for FloatType<$ty> {}
+
+        impl Hash for FloatType<$ty> {
+            fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+                state.write(&<$ty>::from_le_bytes(self.0.to_le_bytes()).to_le_bytes())
+            }
+        }
+
+        impl From<$ty> for FloatType<$ty> {
+            fn from(value: $ty) -> Self {
+                Self(value)
+            }
+        }
+
+        impl From<FloatType<$ty>> for $ty {
+            fn from(value: FloatType<$ty>) -> Self {
+                value.0
+            }
+        }
+
+        impl Deref for FloatType<$ty> {
+            type Target = $ty;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        impl Key for FloatType<$ty> {
+            type Ref<'r> = FloatType<$ty>;
+
+            fn as_key_ref(&self) -> Self::Ref<'_> {
+                *self
+            }
+
+            fn to_arrow_datum(&self) -> Arc<dyn Datum> {
+                Arc::new($array_name::new_scalar(self.0))
+            }
+        }
+
+        impl<'a> KeyRef<'a> for FloatType<$ty> {
+            type Key = FloatType<$ty>;
+
+            fn to_key(self) -> Self::Key {
+                self
+            }
+        }
+    };
+}
+
+implement_float_encode_decode!(f32);
+implement_float_encode_decode!(f64);
+
+implement_float_key!(f32, Float32Array);
+implement_float_key!(f64, Float64Array);
+
+#[cfg(test)]
+mod tests {
+    use core::f32;
+
+    use arrow::array::ArrowNativeTypeOp;
+
+    use crate::record::key::num::F32;
+
+    #[tokio::test]
+    async fn test_zero() {
+        let f1 = F32::from(0_f32);
+        let f2 = F32::from(-0_f32);
+        // +0 should be greater than -0
+        assert_eq!(f1.cmp(&f2), f1.0.compare(f2.0));
+        assert!(f1 > f2);
+    }
+
+    #[tokio::test]
+    async fn test_eq() {
+        let f1 = F32::from(1.01_f32);
+        let f2 = F32::from(1.01_f32);
+        assert!(f1 == f2);
+    }
+
+    #[tokio::test]
+    async fn test_nan_cmp() {
+        let f1 = F32::from(f32::NAN);
+        let f2 = F32::from(f32::NAN);
+        let f3 = F32::from(-f32::NAN);
+        let inf = F32::from(f32::INFINITY);
+        let neg_inf = F32::from(f32::NEG_INFINITY);
+
+        // This is not consistent with the IEEE
+        // assert_eq!(f32::NAN, f32::NAN);
+        assert_eq!(f1.cmp(&f2), f1.0.compare(f2.0));
+        assert_eq!(f1, f2);
+
+        assert_eq!(f1.cmp(&f3), f1.0.compare(f3.0));
+        assert_eq!(f1, f2);
+
+        // positive NAN should be greater than positive infinity
+        assert_eq!(f1.cmp(&inf), f1.0.compare(inf.0));
+        assert!(f1 > inf);
+
+        // negative NAN should be less than negative infinity
+        assert_eq!(f3.cmp(&neg_inf), f3.0.compare(neg_inf.0));
+        assert!(f3 < neg_inf);
+
+        let f4 = F32::from(1.0_f32);
+        assert_eq!(f1.cmp(&f4), f1.0.compare(f4.0));
+        assert!(f1 > f4);
+
+        assert_eq!(f3.cmp(&f4), f3.0.compare(f4.0));
+        assert!(f3 < f4);
+    }
+}

--- a/src/record/key/num.rs
+++ b/src/record/key/num.rs
@@ -121,6 +121,12 @@ macro_rules! implement_float_key {
             }
         }
 
+        impl From<&FloatType<$ty>> for $ty {
+            fn from(value: &FloatType<$ty>) -> Self {
+                value.0
+            }
+        }
+
         impl Deref for FloatType<$ty> {
             type Target = $ty;
 

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -1,4 +1,4 @@
-mod key;
+pub mod key;
 pub mod option;
 pub mod runtime;
 #[cfg(test)]
@@ -8,7 +8,7 @@ use std::{error::Error, fmt::Debug, io, sync::Arc};
 
 use arrow::{array::RecordBatch, datatypes::Schema as ArrowSchema};
 use fusio_log::{Decode, Encode};
-pub use key::{Key, KeyRef};
+pub use key::*;
 use option::OptionRecordRef;
 use parquet::{arrow::ProjectionMask, format::SortingColumn, schema::types::ColumnPath};
 pub use runtime::*;

--- a/src/record/runtime/mod.rs
+++ b/src/record/runtime/mod.rs
@@ -24,6 +24,8 @@ pub enum DataType {
     String,
     Boolean,
     Bytes,
+    Float32,
+    Float64,
 }
 
 impl From<&ArrowDataType> for DataType {
@@ -37,6 +39,8 @@ impl From<&ArrowDataType> for DataType {
             ArrowDataType::Int16 => DataType::Int16,
             ArrowDataType::Int32 => DataType::Int32,
             ArrowDataType::Int64 => DataType::Int64,
+            ArrowDataType::Float32 => DataType::Float32,
+            ArrowDataType::Float64 => DataType::Float64,
             ArrowDataType::Utf8 => DataType::String,
             ArrowDataType::Boolean => DataType::Boolean,
             ArrowDataType::Binary => DataType::Bytes,

--- a/src/record/runtime/record.rs
+++ b/src/record/runtime/record.rs
@@ -6,7 +6,7 @@ use fusio_log::{Decode, Encode};
 use super::{schema::DynSchema, DataType, DynRecordRef, Value};
 use crate::{
     cast_arc_value,
-    record::{Record, RecordDecodeError},
+    record::{Record, RecordDecodeError, F32, F64},
 };
 
 #[derive(Debug)]
@@ -48,6 +48,8 @@ impl Decode for DynRecord {
                     DataType::Int16 => Arc::new(cast_arc_value!(col.value, Option<i16>).unwrap()),
                     DataType::Int32 => Arc::new(cast_arc_value!(col.value, Option<i32>).unwrap()),
                     DataType::Int64 => Arc::new(cast_arc_value!(col.value, Option<i64>).unwrap()),
+                    DataType::Float32 => Arc::new(cast_arc_value!(col.value, Option<F32>).unwrap()),
+                    DataType::Float64 => Arc::new(cast_arc_value!(col.value, Option<F64>).unwrap()),
                     DataType::String => {
                         Arc::new(cast_arc_value!(col.value, Option<String>).clone().unwrap())
                     }
@@ -90,6 +92,8 @@ impl Record for DynRecord {
                     DataType::Int16 => Arc::new(Some(*cast_arc_value!(col.value, i16))),
                     DataType::Int32 => Arc::new(Some(*cast_arc_value!(col.value, i32))),
                     DataType::Int64 => Arc::new(Some(*cast_arc_value!(col.value, i64))),
+                    DataType::Float32 => Arc::new(Some(*cast_arc_value!(col.value, F32))),
+                    DataType::Float64 => Arc::new(Some(*cast_arc_value!(col.value, F64))),
                     DataType::String => {
                         Arc::new(Some(cast_arc_value!(col.value, String).to_owned()))
                     }
@@ -162,7 +166,10 @@ pub(crate) mod test {
     use std::sync::Arc;
 
     use super::{DynRecord, DynSchema};
-    use crate::dyn_schema;
+    use crate::{
+        dyn_schema,
+        record::{F32, F64},
+    };
 
     #[allow(unused)]
     pub(crate) fn test_dyn_item_schema() -> DynSchema {
@@ -175,6 +182,8 @@ pub(crate) mod test {
             ("email", String, true),
             ("enabled", Boolean, false),
             ("bytes", Bytes, true),
+            ("grade", Float32, false),
+            ("price", Float64, true),
             0
         )
     }
@@ -192,6 +201,8 @@ pub(crate) mod test {
                 ("email", String, true, Some(format!("{}@tonbo.io", i))),
                 ("enabled", Boolean, false, i % 2 == 0),
                 ("bytes", Bytes, true, Some(i.to_le_bytes().to_vec())),
+                ("grade", Float32, false, F32::from(i as f32 * 1.11)),
+                ("price", Float64, true, Some(F64::from(i as f64 * 1.01))),
                 0
             );
             if i >= 45 {

--- a/tonbo_macros/src/data_type.rs
+++ b/tonbo_macros/src/data_type.rs
@@ -13,6 +13,8 @@ pub(crate) enum DataType {
     String,
     Boolean,
     Bytes,
+    Float32,
+    Float64,
 }
 
 impl DataType {
@@ -39,6 +41,10 @@ impl DataType {
             DataType::Boolean
         } else if path.is_ident("Bytes") {
             DataType::Bytes
+        } else if path.is_ident("F32") {
+            DataType::Float32
+        } else if path.is_ident("F64") {
+            DataType::Float64
         } else {
             todo!()
         }
@@ -79,6 +85,12 @@ impl DataType {
             DataType::Bytes => {
                 quote!(bytes::Bytes)
             }
+            DataType::Float32 => {
+                quote!(::tonbo::record::F32)
+            }
+            DataType::Float64 => {
+                quote!(::tonbo::record::F64)
+            }
         }
     }
 
@@ -116,6 +128,12 @@ impl DataType {
             }
             DataType::Bytes => {
                 quote!(::tonbo::arrow::datatypes::DataType::Binary)
+            }
+            DataType::Float32 => {
+                quote!(::tonbo::arrow::datatypes::DataType::Float32)
+            }
+            DataType::Float64 => {
+                quote!(::tonbo::arrow::datatypes::DataType::Float64)
             }
         }
     }
@@ -159,6 +177,12 @@ impl DataType {
                     >
                 )
             }
+            DataType::Float32 => {
+                quote!(::tonbo::arrow::array::Float32Array)
+            }
+            DataType::Float64 => {
+                quote!(::tonbo::arrow::array::Float64Array)
+            }
         }
     }
 
@@ -196,6 +220,12 @@ impl DataType {
             }
             DataType::Bytes => {
                 quote!(as_bytes::<::tonbo::arrow::datatypes::GenericBinaryType<i32>>())
+            }
+            DataType::Float32 => {
+                quote!(as_primitive::<::tonbo::arrow::datatypes::Float32Type>())
+            }
+            DataType::Float64 => {
+                quote!(as_primitive::<::tonbo::arrow::datatypes::Float64Type>())
             }
         }
     }
@@ -256,6 +286,16 @@ impl DataType {
                 quote!(::tonbo::arrow::array::GenericByteBuilder::<
                     ::tonbo::arrow::datatypes::GenericBinaryType<i32>,
                 >::with_capacity(capacity, 0))
+            }
+            DataType::Float32 => {
+                quote!(::tonbo::arrow::array::PrimitiveBuilder::<
+                    ::tonbo::arrow::datatypes::Float32Type,
+                >::with_capacity(capacity))
+            }
+            DataType::Float64 => {
+                quote!(::tonbo::arrow::array::PrimitiveBuilder::<
+                    ::tonbo::arrow::datatypes::Float64Type,
+                >::with_capacity(capacity))
             }
         }
     }
@@ -331,6 +371,20 @@ impl DataType {
                     >
                 )
             }
+            DataType::Float32 => {
+                quote!(
+                    ::tonbo::arrow::array::PrimitiveBuilder<
+                        ::tonbo::arrow::datatypes::Float32Type,
+                    >
+                )
+            }
+            DataType::Float64 => {
+                quote!(
+                    ::tonbo::arrow::array::PrimitiveBuilder<
+                        ::tonbo::arrow::datatypes::Float64Type,
+                    >
+                )
+            }
         }
     }
     pub(crate) fn to_size_method(&self, field_name: &Ident) -> proc_macro2::TokenStream {
@@ -367,6 +421,12 @@ impl DataType {
             }
             DataType::Bytes => {
                 quote!(self.#field_name.values_slice().len())
+            }
+            DataType::Float32 => {
+                quote!(std::mem::size_of_val(self.#field_name.values_slice()))
+            }
+            DataType::Float64 => {
+                quote!(std::mem::size_of_val(self.#field_name.values_slice()))
             }
         }
     }
@@ -416,6 +476,12 @@ impl DataType {
                 } else {
                     quote!(self.#field_name.len())
                 }
+            }
+            DataType::Float32 => {
+                quote! {std::mem::size_of::<::tonbo::record::F32>()}
+            }
+            DataType::Float64 => {
+                quote! {std::mem::size_of::<::tonbo::record::F64>()}
             }
         }
     }


### PR DESCRIPTION
Introduce `F32`/`F64` type to support float type. The behaviors are aligned to arrow.

**Note**: 
- In IEEE, `NAN !=  NAN`, but in arrow `NAN == NAN`. Our behavior is aligned to arrow
- Python and WASM bindings are not implemented