### PR TITLE
refactor: rename Timestamped to Ts, TimestampedRef to TsRef

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,7 @@ use parquet::{
 use parquet_lru::{DynLruCache, NoCache};
 use record::Record;
 use thiserror::Error;
-use timestamp::{Timestamp, TimestampedRef};
+use timestamp::{Timestamp, TsRef};
 use tokio::sync::oneshot;
 pub use tonbo_macros::{KeyAttributes, Record};
 use tracing::error;
@@ -687,7 +687,7 @@ where
         Ok(version
             .query(
                 ctx.storage_manager(),
-                TimestampedRef::new(key, ts),
+                TsRef::new(key, ts),
                 projection,
                 ctx.cache().clone(),
             )

--- a/src/ondisk/sstable.rs
+++ b/src/ondisk/sstable.rs
@@ -18,7 +18,7 @@ use super::{arrows::get_range_filter, scan::SsTableScan};
 use crate::{
     record::{Record, Schema},
     stream::record_batch::RecordBatchEntry,
-    timestamp::{Timestamp, TimestampedRef},
+    timestamp::{Timestamp, TsRef},
 };
 
 pub(crate) struct SsTable<R>
@@ -70,7 +70,7 @@ where
 
     pub(crate) async fn get(
         self,
-        key: &TimestampedRef<<R::Schema as Schema>::Key>,
+        key: &TsRef<<R::Schema as Schema>::Key>,
         projection_mask: ProjectionMask,
     ) -> ParquetResult<Option<RecordBatchEntry<R>>> {
         self.scan(
@@ -140,7 +140,7 @@ pub(crate) mod tests {
         inmem::immutable::tests::TestSchema,
         record::{Record, Schema},
         tests::{get_test_record_batch, Test},
-        timestamp::Timestamped,
+        timestamp::Ts,
         DbOption,
     };
 
@@ -210,7 +210,7 @@ pub(crate) mod tests {
             .unwrap();
         write_record_batch(file, &record_batch).await.unwrap();
 
-        let key = Timestamped::new("hello".to_owned(), 1.into());
+        let key = Ts::new("hello".to_owned(), 1.into());
 
         {
             let test_ref_1 = open_sstable::<Test>(base_fs, &table_path)

--- a/src/record/option.rs
+++ b/src/record/option.rs
@@ -1,14 +1,14 @@
 use std::{marker::PhantomData, mem::transmute};
 
 use super::{Key, Record, RecordRef, Schema};
-use crate::timestamp::{Timestamp, Timestamped};
+use crate::timestamp::{Timestamp, Ts};
 
 #[derive(Debug)]
 pub struct OptionRecordRef<'r, R>
 where
     R: RecordRef<'r>,
 {
-    record: Timestamped<R>,
+    record: Ts<R>,
     null: bool,
     _marker: PhantomData<&'r ()>,
 }
@@ -19,7 +19,7 @@ where
 {
     pub fn new(ts: Timestamp, record: R, null: bool) -> Self {
         Self {
-            record: Timestamped::new(record, ts),
+            record: Ts::new(record, ts),
             null,
             _marker: PhantomData,
         }
@@ -30,16 +30,9 @@ impl<'r, R> OptionRecordRef<'r, R>
 where
     R: RecordRef<'r>,
 {
-    pub fn key(
-        &self,
-    ) -> Timestamped<<<<R::Record as Record>::Schema as Schema>::Key as Key>::Ref<'_>> {
+    pub fn key(&self) -> Ts<<<<R::Record as Record>::Schema as Schema>::Key as Key>::Ref<'_>> {
         // Safety: shorter lifetime of the value must be safe
-        unsafe {
-            transmute(Timestamped::new(
-                self.record.value().clone().key(),
-                self.record.ts(),
-            ))
-        }
+        unsafe { transmute(Ts::new(self.record.value().clone().key(), self.record.ts())) }
     }
 
     pub fn get(&self) -> Option<R> {

--- a/src/record/runtime/array.rs
+++ b/src/record/runtime/array.rs
@@ -18,7 +18,7 @@ use crate::{
     inmem::immutable::{ArrowArrays, Builder},
     magic::USER_COLUMN_OFFSET,
     record::{Key, Record, Schema, F32, F64},
-    timestamp::Timestamped,
+    timestamp::Ts,
 };
 
 #[allow(unused)]
@@ -283,7 +283,7 @@ pub struct DynRecordBuilder {
 impl Builder<DynRecordImmutableArrays> for DynRecordBuilder {
     fn push(
         &mut self,
-        key: Timestamped<<<<DynRecord as Record>::Schema as Schema>::Key as Key>::Ref<'_>>,
+        key: Ts<<<<DynRecord as Record>::Schema as Schema>::Key as Key>::Ref<'_>>,
         row: Option<DynRecordRef>,
     ) {
         self._null.append(row.is_none());
@@ -770,7 +770,7 @@ impl Builder<DynRecordImmutableArrays> for DynRecordBuilder {
 impl DynRecordBuilder {
     fn push_primary_key(
         &mut self,
-        key: Timestamped<<<<DynRecord as Record>::Schema as Schema>::Key as Key>::Ref<'_>>,
+        key: Ts<<<<DynRecord as Record>::Schema as Schema>::Key as Key>::Ref<'_>>,
         primary_key_index: usize,
     ) {
         let builder = self.builders.get_mut(primary_key_index).unwrap();
@@ -875,7 +875,7 @@ mod tests {
         );
 
         let mut builder = DynRecordImmutableArrays::builder(schema.arrow_schema().clone(), 5);
-        let key = crate::timestamp::Timestamped {
+        let key = crate::timestamp::Ts {
             ts: 0.into(),
             value: record.key(),
         };

--- a/src/record/test.rs
+++ b/src/record/test.rs
@@ -14,7 +14,7 @@ use super::{option::OptionRecordRef, Key, Record, RecordRef, Schema};
 use crate::{
     inmem::immutable::{ArrowArrays, Builder},
     magic,
-    timestamp::Timestamped,
+    timestamp::Ts,
 };
 
 const PRIMARY_FIELD_NAME: &str = "vstring";
@@ -155,7 +155,7 @@ pub struct StringColumnsBuilder {
 }
 
 impl Builder<StringColumns> for StringColumnsBuilder {
-    fn push(&mut self, key: Timestamped<&str>, row: Option<&str>) {
+    fn push(&mut self, key: Ts<&str>, row: Option<&str>) {
         self._null.append(row.is_none());
         self._ts.append_value(key.ts.into());
         if let Some(row) = row {

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -23,7 +23,7 @@ use crate::{
     ondisk::scan::SsTableScan,
     record::{Key, Record, RecordRef, Schema},
     stream::{level::LevelStream, mem_projection::MemProjectionStream},
-    timestamp::Timestamped,
+    timestamp::Ts,
     transaction::TransactionScan,
 };
 
@@ -33,13 +33,11 @@ where
 {
     Transaction(
         (
-            Timestamped<<<R::Schema as Schema>::Key as Key>::Ref<'entry>>,
+            Ts<<<R::Schema as Schema>::Key as Key>::Ref<'entry>>,
             &'entry Option<R>,
         ),
     ),
-    Mutable(
-        crossbeam_skiplist::map::Entry<'entry, Timestamped<<R::Schema as Schema>::Key>, Option<R>>,
-    ),
+    Mutable(crossbeam_skiplist::map::Entry<'entry, Ts<<R::Schema as Schema>::Key>, Option<R>>),
     Projection((Box<Entry<'entry, R>>, Arc<ProjectionMask>)),
     RecordBatch(RecordBatchEntry<R>),
 }
@@ -48,14 +46,14 @@ impl<R> Entry<'_, R>
 where
     R: Record,
 {
-    pub(crate) fn key(&self) -> Timestamped<<<R::Schema as Schema>::Key as Key>::Ref<'_>> {
+    pub(crate) fn key(&self) -> Ts<<<R::Schema as Schema>::Key as Key>::Ref<'_>> {
         match self {
             Entry::Transaction((key, _)) => {
                 // Safety: shorter lifetime must be safe
                 unsafe {
                     transmute::<
-                        Timestamped<<<R::Schema as Schema>::Key as Key>::Ref<'_>>,
-                        Timestamped<<<R::Schema as Schema>::Key as Key>::Ref<'_>>,
+                        Ts<<<R::Schema as Schema>::Key as Key>::Ref<'_>>,
+                        Ts<<<R::Schema as Schema>::Key as Key>::Ref<'_>>,
                     >(key.clone())
                 }
             }

--- a/src/stream/record_batch.rs
+++ b/src/stream/record_batch.rs
@@ -10,7 +10,7 @@ use parquet::arrow::ProjectionMask;
 
 use crate::{
     record::{option::OptionRecordRef, Key, Record, RecordRef, Schema as RecordSchema},
-    timestamp::Timestamped,
+    timestamp::Ts,
 };
 
 pub struct RecordBatchEntry<R>
@@ -35,9 +35,7 @@ where
         }
     }
 
-    pub(crate) fn internal_key(
-        &self,
-    ) -> Timestamped<<<R::Schema as RecordSchema>::Key as Key>::Ref<'_>> {
+    pub(crate) fn internal_key(&self) -> Ts<<<R::Schema as RecordSchema>::Key as Key>::Ref<'_>> {
         self.record_ref.key()
     }
 

--- a/src/timestamp/mod.rs
+++ b/src/timestamp/mod.rs
@@ -7,7 +7,7 @@ use arrow::{
 use fusio::{SeqRead, Write};
 use fusio_log::{Decode, Encode};
 
-pub(crate) use self::timestamped::*;
+pub use self::timestamped::*;
 
 #[repr(transparent)]
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -20,7 +20,7 @@ use crate::{
     record::{Key, KeyRef, RecordRef, Schema as RecordSchema},
     snapshot::Snapshot,
     stream::{self, mem_projection::MemProjectionStream},
-    timestamp::{Timestamp, Timestamped},
+    timestamp::{Timestamp, Ts},
     wal::log::LogType,
     DbError, DbStorage, LockMap, Projection, Record, Scan,
 };
@@ -35,14 +35,14 @@ where
     R: Record,
 {
     type Item = (
-        Timestamped<<<R::Schema as RecordSchema>::Key as Key>::Ref<'scan>>,
+        Ts<<<R::Schema as RecordSchema>::Key as Key>::Ref<'scan>>,
         &'scan Option<R>,
     );
 
     fn next(&mut self) -> Option<Self::Item> {
         self.inner
             .next()
-            .map(|(key, value)| (Timestamped::new(key.as_key_ref(), self.ts), value))
+            .map(|(key, value)| (Ts::new(key.as_key_ref(), self.ts), value))
     }
 }
 /// optimistic ACID transaction, open with

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -24,7 +24,7 @@ use crate::{
     record::{Record, Schema},
     scope::Scope,
     stream::{level::LevelStream, record_batch::RecordBatchEntry, ScanStream},
-    timestamp::{Timestamp, TimestampedRef},
+    timestamp::{Timestamp, TsRef},
     version::{cleaner::CleanTag, edit::VersionEdit},
     DbOption, ParquetLru,
 };
@@ -120,7 +120,7 @@ where
     pub(crate) async fn query(
         &self,
         manager: &StoreManager,
-        key: &TimestampedRef<<R::Schema as Schema>::Key>,
+        key: &TsRef<<R::Schema as Schema>::Key>,
         projection_mask: ProjectionMask,
         parquet_lru: ParquetLru,
     ) -> Result<Option<RecordBatchEntry<R>>, VersionError<R>> {
@@ -182,7 +182,7 @@ where
     async fn table_query(
         &self,
         store: &Arc<dyn DynFs>,
-        key: &TimestampedRef<<R::Schema as Schema>::Key>,
+        key: &TsRef<<R::Schema as Schema>::Key>,
         level: usize,
         gen: FileId,
         projection_mask: ProjectionMask,

--- a/src/wal/log.rs
+++ b/src/wal/log.rs
@@ -3,7 +3,7 @@ use fusio_log::{Decode, Encode};
 
 use crate::{
     record::{Record, Schema},
-    timestamp::Timestamped,
+    timestamp::Ts,
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -31,7 +31,7 @@ pub(crate) struct Log<R>
 where
     R: Record,
 {
-    pub(crate) key: Timestamped<<R::Schema as Schema>::Key>,
+    pub(crate) key: Ts<<R::Schema as Schema>::Key>,
     pub(crate) value: Option<R>,
     pub(crate) log_type: Option<LogType>,
 }
@@ -41,7 +41,7 @@ where
     R: Record,
 {
     pub(crate) fn new(
-        ts: Timestamped<<R::Schema as Schema>::Key>,
+        ts: Ts<<R::Schema as Schema>::Key>,
         value: Option<R>,
         log_type: Option<LogType>,
     ) -> Self {
@@ -94,7 +94,7 @@ where
         R: SeqRead,
     {
         let log_type = LogType::from(u8::decode(reader).await?);
-        let key = Timestamped::<<Re::Schema as Schema>::Key>::decode(reader)
+        let key = Ts::<<Re::Schema as Schema>::Key>::decode(reader)
             .await
             .unwrap();
         let record = Option::<Re>::decode(reader).await.unwrap();
@@ -111,14 +111,14 @@ mod tests {
     use tokio::io::AsyncSeekExt;
 
     use crate::{
-        timestamp::Timestamped,
+        timestamp::Ts,
         wal::log::{Log, LogType},
     };
 
     #[tokio::test]
     async fn encode_and_decode() {
         let entry: Log<String> = Log::new(
-            Timestamped::new("hello".into(), 1.into()),
+            Ts::new("hello".into(), 1.into()),
             Some("hello".into()),
             Some(LogType::Middle),
         );

--- a/src/wal/mod.rs
+++ b/src/wal/mod.rs
@@ -158,7 +158,7 @@ mod tests {
     use super::{log::LogType, WalFile};
     use crate::{
         fs::{generate_file_id, FileType},
-        timestamp::Timestamped,
+        timestamp::Ts,
         wal::log::Log,
     };
 
@@ -174,7 +174,7 @@ mod tests {
 
         {
             wal.write(&Log::new(
-                Timestamped::new("hello".into(), 0.into()),
+                Ts::new("hello".into(), 0.into()),
                 Some("hello".into()),
                 Some(LogType::Full),
             ))
@@ -193,7 +193,7 @@ mod tests {
             }
 
             wal.write(&Log::new(
-                Timestamped::new("world".into(), 1.into()),
+                Ts::new("world".into(), 1.into()),
                 Some("world".into()),
                 Some(LogType::Full),
             ))

--- a/tests/macros_correctness.rs
+++ b/tests/macros_correctness.rs
@@ -28,7 +28,7 @@ mod tests {
         inmem::immutable::{ArrowArrays, Builder},
         magic,
         record::{Record, RecordRef, Schema},
-        timestamp::timestamped::Timestamped,
+        timestamp::Ts,
     };
 
     use crate::{User, UserImmutableArrays, UserRef, UserSchema};
@@ -158,7 +158,7 @@ mod tests {
             );
             assert_eq!(
                 record_ref.key(),
-                Timestamped {
+                Ts {
                     ts: 9.into(),
                     value: "cat",
                 }
@@ -204,7 +204,7 @@ mod tests {
             );
             assert_eq!(
                 record_ref.key(),
-                Timestamped {
+                Ts {
                     ts: 9.into(),
                     value: "cat",
                 }
@@ -258,21 +258,21 @@ mod tests {
         };
 
         builder.push(
-            Timestamped {
+            Ts {
                 ts: 0.into(),
                 value: "cat",
             },
             Some(cat.as_record_ref()),
         );
         builder.push(
-            Timestamped {
+            Ts {
                 ts: 1.into(),
                 value: "dog",
             },
             Some(dog.as_record_ref()),
         );
         builder.push(
-            Timestamped {
+            Ts {
                 ts: 2.into(),
                 value: "human",
             },
@@ -327,21 +327,21 @@ mod tests {
         };
 
         builder.push(
-            Timestamped {
+            Ts {
                 ts: 0.into(),
                 value: "cat",
             },
             Some(cat.as_record_ref()),
         );
         builder.push(
-            Timestamped {
+            Ts {
                 ts: 1.into(),
                 value: "dog",
             },
             Some(dog.as_record_ref()),
         );
         builder.push(
-            Timestamped {
+            Ts {
                 ts: 2.into(),
                 value: "human",
             },

--- a/tonbo_macros/src/record.rs
+++ b/tonbo_macros/src/record.rs
@@ -770,7 +770,7 @@ fn struct_builder_codegen(
         }
 
         impl ::tonbo::inmem::immutable::Builder<#struct_arrays_name> for #struct_builder_name {
-            fn push(&mut self, key: ::tonbo::timestamp::timestamped::Timestamped<<<<#struct_name as ::tonbo::record::Record>::Schema as ::tonbo::record::Schema>::Key as ::tonbo::record::Key>::Ref<'_>>, row: Option<#struct_ref_name>) {
+            fn push(&mut self, key: ::tonbo::timestamp::Ts<<<<#struct_name as ::tonbo::record::Record>::Schema as ::tonbo::record::Schema>::Key as ::tonbo::record::Key>::Ref<'_>>, row: Option<#struct_ref_name>) {
                 #builder_append_primary_key
                 match row {
                     Some(row) => {


### PR DESCRIPTION
As wrapper types, the name of `Timestamped` and `TimestampedRef` is too long, rename to make it shorter.