### PR TITLE
feat: add reverse in transaction scan

### DIFF
--- a/src/compaction/leveled.rs
+++ b/src/compaction/leveled.rs
@@ -236,6 +236,7 @@ where
                                 u32::MAX.into(),
                                 None,
                                 ProjectionMask::all(),
+                                false
                             )
                             .await?,
                     });
@@ -253,6 +254,7 @@ where
                     ProjectionMask::all(),
                     level_fs.clone(),
                     ctx.parquet_lru.clone(),
+                    false,
                 )
                 .ok_or(CompactionError::EmptyLevel)?;
 
@@ -274,6 +276,7 @@ where
                     ProjectionMask::all(),
                     level_fs.clone(),
                     ctx.parquet_lru.clone(),
+                    false,
                 )
                 .ok_or(CompactionError::EmptyLevel)?;
 

--- a/src/compaction/mod.rs
+++ b/src/compaction/mod.rs
@@ -54,7 +54,7 @@ where
         schema: &R::Schema,
         fs: &Arc<dyn DynFs>,
     ) -> Result<(), CompactionError<R>> {
-        let mut stream = MergeStream::<R>::from_vec(streams, u32::MAX.into()).await?;
+        let mut stream = MergeStream::<R>::from_vec(streams, u32::MAX.into(), false).await?;
 
         // Kould: is the capacity parameter necessary?
         let mut builder =

--- a/src/ondisk/scan.rs
+++ b/src/ondisk/scan.rs
@@ -14,33 +14,50 @@ use parquet::arrow::{
 use pin_project_lite::pin_project;
 
 use crate::{
-    record::Record,
+    record::{Record, RecordRef},
     stream::record_batch::{RecordBatchEntry, RecordBatchIterator},
 };
 
 pin_project! {
     #[derive(Debug)]
-    pub struct SsTableScan<'scan, R> {
+    pub struct SsTableScan<'scan, R>
+    where
+        R: Record,
+    {
         #[pin]
         stream: ParquetRecordBatchStream<Box<dyn AsyncFileReader>>,
         iter: Option<RecordBatchIterator<R>>,
         projection_mask: ProjectionMask,
         full_schema: Arc<Schema>,
+        reverse: bool,
+        batches: Option<Vec<arrow::array::RecordBatch>>,
+        current_batch_index: Option<usize>,
+        current_row_index: Option<usize>,
+        collection_complete: bool,
         _marker: PhantomData<&'scan ()>
     }
 }
 
-impl<R> SsTableScan<'_, R> {
+impl<R> SsTableScan<'_, R>
+where
+    R: Record,
+{
     pub fn new(
         stream: ParquetRecordBatchStream<Box<dyn AsyncFileReader>>,
         projection_mask: ProjectionMask,
         full_schema: Arc<Schema>,
+        reverse: bool,
     ) -> Self {
         SsTableScan {
             stream,
             iter: None,
             projection_mask,
             full_schema,
+            reverse,
+            batches: None,
+            current_batch_index: None,
+            current_row_index: None,
+            collection_complete: false,
             _marker: PhantomData,
         }
     }
@@ -54,25 +71,115 @@ where
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut this = self.project();
-        loop {
-            match this.iter {
-                Some(iter) => {
-                    if let Some(entry) = iter.next() {
+        
+        if *this.reverse {
+            if !*this.collection_complete {
+                if this.batches.is_none() {
+                    *this.batches = Some(Vec::new());
+                }
+                loop {
+                    match this.stream.as_mut().poll_next(cx) {
+                        Poll::Ready(Some(Ok(batch))) => {
+                            this.batches.as_mut().unwrap().push(batch);
+                        }
+                        Poll::Ready(Some(Err(e))) => {
+                            return Poll::Ready(Some(Err(e)));
+                        }
+                        Poll::Ready(None) => {
+                            let all_batches = this.batches.as_ref().unwrap();
+                            
+                            if all_batches.is_empty() {
+                                *this.current_batch_index = None;
+                                *this.current_row_index = None;
+                            } else {
+                                let mut batch_idx = all_batches.len() - 1;
+                                while batch_idx > 0 && all_batches[batch_idx].num_rows() == 0 {
+                                    batch_idx -= 1;
+                                }
+                                
+                                if all_batches[batch_idx].num_rows() > 0 {
+                                    let row_idx = all_batches[batch_idx].num_rows() - 1;
+                                    *this.current_batch_index = Some(batch_idx);
+                                    *this.current_row_index = Some(row_idx);
+                                } else {
+                                    *this.current_batch_index = None;
+                                    *this.current_row_index = None;
+                                }
+                            }
+                            *this.collection_complete = true;
+                            break;
+                        }
+                        Poll::Pending => {
+                            return Poll::Pending;
+                        }
+                    }
+                }
+            }
+            // Return in reverse order
+            if let (Some(batches), Some(batch_idx), Some(row_idx)) = 
+                (this.batches.as_ref(), *this.current_batch_index, *this.current_row_index) 
+            {
+                if batch_idx < batches.len() {
+                    let batch = &batches[batch_idx];
+                    if row_idx < batch.num_rows() {
+                        let record = R::Ref::from_record_batch(
+                            batch,
+                            row_idx,
+                            this.projection_mask,
+                            this.full_schema,
+                        );
+                        let entry = RecordBatchEntry::new(batch.clone(), unsafe {
+                            std::mem::transmute::<crate::record::option::OptionRecordRef<'_, R::Ref<'_>>, crate::record::option::OptionRecordRef<'static, R::Ref<'static>>>(
+                                record,
+                            )
+                        });
+                        
+                        if row_idx == 0 {
+                            if batch_idx == 0 {
+                                *this.current_batch_index = None;
+                                *this.current_row_index = None;
+                            } else {
+                                let prev_batch_idx = batch_idx - 1;
+                                let prev_row_idx = if batches[prev_batch_idx].num_rows() > 0 {
+                                    batches[prev_batch_idx].num_rows() - 1
+                                } else {
+                                    0
+                                };
+                                *this.current_batch_index = Some(prev_batch_idx);
+                                *this.current_row_index = Some(prev_row_idx);
+                            }
+                        } else {
+                            *this.current_row_index = Some(row_idx - 1);
+                        }
+                        
                         return Poll::Ready(Some(Ok(entry)));
                     }
-                    *this.iter = None;
                 }
-                None => {
-                    let record_batch = ready!(this.stream.as_mut().poll_next(cx)).transpose()?;
-                    let record_batch = match record_batch {
-                        Some(record_batch) => record_batch,
-                        None => return Poll::Ready(None),
-                    };
-                    *this.iter = Some(RecordBatchIterator::new(
-                        record_batch,
-                        this.projection_mask.clone(),
-                        this.full_schema.clone(),
-                    ));
+                return Poll::Ready(None);
+            } else {
+                return Poll::Ready(None);
+            }
+        } else {
+            loop {
+                match this.iter {
+                    Some(iter) => {
+                        if let Some(entry) = iter.next() {
+                            return Poll::Ready(Some(Ok(entry)));
+                        }
+                        *this.iter = None;
+                    }
+                    None => {
+                        let record_batch = ready!(this.stream.as_mut().poll_next(cx)).transpose()?;
+                        let record_batch = match record_batch {
+                            Some(record_batch) => record_batch,
+                            None => return Poll::Ready(None),
+                        };
+                        *this.iter = Some(RecordBatchIterator::new(
+                            record_batch,
+                            this.projection_mask.clone(),
+                            this.full_schema.clone(),
+                        ));
+                    }
                 }
             }
         }

--- a/src/ondisk/sstable.rs
+++ b/src/ondisk/sstable.rs
@@ -78,6 +78,7 @@ where
             key.ts(),
             Some(1),
             projection_mask,
+            false,
         )
         .await?
         .next()
@@ -94,6 +95,7 @@ where
         ts: Timestamp,
         limit: Option<usize>,
         projection_mask: ProjectionMask,
+        reverse: bool,
     ) -> Result<SsTableScan<'scan, R>, parquet::errors::ParquetError> {
         let builder = self
             .into_parquet_builder(limit, projection_mask.clone())
@@ -110,6 +112,7 @@ where
             builder.with_row_filter(filter).build()?,
             projection_mask,
             full_schema,
+            reverse,
         ))
     }
 }
@@ -307,6 +310,7 @@ pub(crate) mod tests {
                             .unwrap(),
                         [0, 1, 2, 3],
                     ),
+                    false,
                 )
                 .await
                 .unwrap();
@@ -334,6 +338,7 @@ pub(crate) mod tests {
                             .unwrap(),
                         [0, 1, 2, 4],
                     ),
+                    false,
                 )
                 .await
                 .unwrap();
@@ -361,6 +366,7 @@ pub(crate) mod tests {
                             .unwrap(),
                         [0, 1, 2],
                     ),
+                    false,
                 )
                 .await
                 .unwrap();

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -56,8 +56,9 @@ where
             range,
             self.ts,
             &self.version,
-            Box::new(move |_: Option<ProjectionMask>| None),
+            Box::new(move |_: Option<ProjectionMask>, _: bool| None),
             self.ctx.clone(),
+            false // Not reversed by default
         )
     }
 
@@ -93,8 +94,9 @@ where
             Bound<&'range <R::Schema as RecordSchema>::Key>,
         ),
         fn_pre_stream: Box<
-            dyn FnOnce(Option<ProjectionMask>) -> Option<ScanStream<'scan, R>> + Send + 'scan,
+            dyn FnOnce(Option<ProjectionMask>, bool) -> Option<ScanStream<'scan, R>> + Send + 'scan,
         >,
+        reverse: bool,
     ) -> Scan<'scan, 'range, R> {
         Scan::new(
             &self.share,
@@ -103,6 +105,7 @@ where
             &self.version,
             fn_pre_stream,
             self.ctx.clone(),
+            reverse
         )
     }
 }

--- a/src/stream/mem_projection.rs
+++ b/src/stream/mem_projection.rs
@@ -136,7 +136,7 @@ mod tests {
 
         let mut stream = MemProjectionStream::<Test>::new(
             mutable
-                .scan((Bound::Unbounded, Bound::Unbounded), 6.into())
+                .scan((Bound::Unbounded, Bound::Unbounded), 6.into(), false)
                 .into(),
             mask,
         );

--- a/src/stream/package.rs
+++ b/src/stream/package.rs
@@ -189,9 +189,10 @@ mod tests {
 
         let merge = MergeStream::<Test>::from_vec(
             vec![m1
-                .scan((Bound::Unbounded, Bound::Unbounded), 6.into())
+                .scan((Bound::Unbounded, Bound::Unbounded), 6.into(), false)
                 .into()],
             6.into(),
+            false
         )
         .await
         .unwrap();


### PR DESCRIPTION
Added Scan in transaction
had to make changes in 
MergeStream
MutableScan
ImmutableScan
SSTableScan
Levels -- to also reorder files

I have not added DB Scan, @ethe are you expecting builder pattern for that as well?
Currently we pass data and a closure to implement transformations on it, right? What are your thoughts on this?

Partially Implements #109 