### PR TITLE
feat: add timestamp without timezone type

### DIFF
--- a/bindings/js/src/utils.rs
+++ b/bindings/js/src/utils.rs
@@ -1,7 +1,10 @@
 use std::{any::Any, sync::Arc};
 
 use js_sys::{Object, Reflect, Uint8Array};
-use tonbo::{cast_arc_value, record::{DataType, DynRecord, Value, ValueDesc, F32, F64}};
+use tonbo::{
+    cast_arc_value,
+    record::{DataType, DynRecord, Value, ValueDesc, F32, F64},
+};
 use wasm_bindgen::{JsCast, JsValue};
 
 fn to_col_value<T: 'static + Send + Sync>(value: T, primary: bool) -> Arc<dyn Any + Send + Sync> {
@@ -22,10 +25,11 @@ fn none_value(datatype: DataType) -> Arc<dyn Any + Send + Sync> {
         DataType::Int32 => Arc::new(Option::<i32>::None),
         DataType::Int64 => Arc::new(Option::<i64>::None),
         DataType::Float32 => Arc::new(Option::<F32>::None),
-        DataType::Float64 =>  Arc::new(Option::<F64>::None),
+        DataType::Float64 => Arc::new(Option::<F64>::None),
         DataType::String => Arc::new(Option::<String>::None),
         DataType::Boolean => Arc::new(Option::<bool>::None),
         DataType::Bytes => Arc::new(Option::<Vec<u8>>::None),
+        DataType::Timestamp => unimplemented!(),
     }
 }
 
@@ -62,6 +66,7 @@ pub(crate) fn parse_key(desc: &ValueDesc, key: JsValue, primary: bool) -> Result
         DataType::Bytes => {
             to_col_value::<Vec<u8>>(key.dyn_into::<Uint8Array>().unwrap().to_vec(), primary)
         }
+        DataType::Timestamp => unimplemented!(),
     };
 
     Ok(Value::new(
@@ -89,7 +94,6 @@ pub(crate) fn parse_record(
 /// convert tonbo `DynRecord` values to `JsValue`
 ///
 pub(crate) fn to_record(cols: &Vec<Value>, primary_key_index: usize) -> JsValue {
-    
     let obj = Object::new();
     for (idx, col) in cols.iter().enumerate() {
         let value = match col.datatype() {
@@ -127,11 +131,15 @@ pub(crate) fn to_record(cols: &Vec<Value>, primary_key_index: usize) -> JsValue 
             },
             DataType::Float32 => match idx == primary_key_index {
                 true => f32::from(cast_arc_value!(col.value, F32)).into(),
-                false => cast_arc_value!(col.value, Option<F32>).map(|v| f32::from(v)).into()
+                false => cast_arc_value!(col.value, Option<F32>)
+                    .map(|v| f32::from(v))
+                    .into(),
             },
             DataType::Float64 => match idx == primary_key_index {
-                true =>f64::from(cast_arc_value!(col.value, F64)).into(),
-                false => cast_arc_value!(col.value, Option<F64>).map(|v| f64::from(v)).into()
+                true => f64::from(cast_arc_value!(col.value, F64)).into(),
+                false => cast_arc_value!(col.value, Option<F64>)
+                    .map(|v| f64::from(v))
+                    .into(),
             },
             DataType::String => match idx == primary_key_index {
                 true => (col.value.as_ref().downcast_ref::<String>().unwrap()).into(),
@@ -166,6 +174,7 @@ pub(crate) fn to_record(cols: &Vec<Value>, primary_key_index: usize) -> JsValue 
                     .map(|v| Uint8Array::from(v.as_slice()).into())
                     .unwrap_or(JsValue::NULL),
             },
+            DataType::Timestamp => unimplemented!(),
         };
 
         Reflect::set(&obj, &col.desc.name.as_str().into(), &value).unwrap();
@@ -176,7 +185,10 @@ pub(crate) fn to_record(cols: &Vec<Value>, primary_key_index: usize) -> JsValue 
 #[cfg(test)]
 mod tests {
 
-    use tonbo::{cast_arc_value, record::{DataType, ValueDesc, F64}};
+    use tonbo::{
+        cast_arc_value,
+        record::{DataType, ValueDesc, F64},
+    };
     use wasm_bindgen::JsValue;
     use wasm_bindgen_test::wasm_bindgen_test;
 

--- a/bindings/python/src/utils.rs
+++ b/bindings/python/src/utils.rs
@@ -130,6 +130,9 @@ pub(crate) fn to_dict(py: Python, primary_key_index: usize, record: Vec<Value>) 
                         .unwrap();
                 }
             }
+            TonboDataType::Timestamp => {
+                unimplemented!()
+            }
             TonboDataType::Float32 => {
                 unreachable!()
             }

--- a/src/record/key/mod.rs
+++ b/src/record/key/mod.rs
@@ -1,11 +1,13 @@
 mod num;
 mod str;
+mod timestamp;
 
 use std::{hash::Hash, sync::Arc};
 
 use arrow::array::Datum;
 use fusio_log::{Decode, Encode};
 pub use num::*;
+pub use timestamp::*;
 
 pub trait Key:
     'static + Encode + Decode + Ord + Clone + Send + Sync + Hash + std::fmt::Debug

--- a/src/record/key/timestamp.rs
+++ b/src/record/key/timestamp.rs
@@ -1,0 +1,84 @@
+use std::sync::Arc;
+
+use arrow::array::TimestampMillisecondArray;
+use fusio_log::{Decode, Encode};
+
+use super::{Key, KeyRef};
+
+/// Timestamp without timezone
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Timestamp(pub(crate) i64);
+
+impl Key for Timestamp {
+    type Ref<'r> = Timestamp;
+    fn as_key_ref(&self) -> Self::Ref<'_> {
+        *self
+    }
+
+    fn to_arrow_datum(&self) -> std::sync::Arc<dyn arrow::array::Datum> {
+        Arc::new(TimestampMillisecondArray::new_scalar(self.0))
+    }
+}
+
+impl<'r> KeyRef<'r> for Timestamp {
+    type Key = Timestamp;
+
+    fn to_key(self) -> Self::Key {
+        self
+    }
+}
+
+impl Decode for Timestamp {
+    type Error = fusio::Error;
+
+    async fn decode<R>(reader: &mut R) -> Result<Self, Self::Error>
+    where
+        R: fusio::SeqRead,
+    {
+        Ok(Timestamp(i64::decode(reader).await?))
+    }
+}
+
+impl Encode for Timestamp {
+    type Error = fusio::Error;
+
+    async fn encode<W>(&self, writer: &mut W) -> Result<(), Self::Error>
+    where
+        W: fusio::Write,
+    {
+        self.0.encode(writer).await
+    }
+
+    fn size(&self) -> usize {
+        self.0.size()
+    }
+}
+
+impl From<i64> for Timestamp {
+    fn from(value: i64) -> Self {
+        Self(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Cursor, SeekFrom};
+
+    use fusio_log::{Decode, Encode};
+    use tokio::io::AsyncSeekExt;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_timestamp_encode_decode() {
+        let ts = Timestamp(1717507203412);
+        let mut bytes = Vec::new();
+        let mut buf = Cursor::new(&mut bytes);
+        ts.encode(&mut buf).await.unwrap();
+
+        buf.seek(SeekFrom::Start(0)).await.unwrap();
+        let ts2 = Timestamp::decode(&mut buf).await.unwrap();
+
+        assert_eq!(ts, ts2);
+    }
+}

--- a/src/record/runtime/mod.rs
+++ b/src/record/runtime/mod.rs
@@ -26,6 +26,7 @@ pub enum DataType {
     Bytes,
     Float32,
     Float64,
+    Timestamp,
 }
 
 impl From<&ArrowDataType> for DataType {
@@ -44,6 +45,15 @@ impl From<&ArrowDataType> for DataType {
             ArrowDataType::Utf8 => DataType::String,
             ArrowDataType::Boolean => DataType::Boolean,
             ArrowDataType::Binary => DataType::Bytes,
+            ArrowDataType::Timestamp(unit, tz) => {
+                debug_assert!(
+                    unit == &arrow::datatypes::TimeUnit::Millisecond,
+                    "expected TimeUnit::Millisecond, get {:?}",
+                    unit
+                );
+                debug_assert!(tz.is_none(), "expected timezone is none, get {:?}", tz);
+                DataType::Timestamp
+            }
             _ => todo!(),
         }
     }


### PR DESCRIPTION
Add timestamp without timezone type. This type use i64 to represent the timestamp and store it as `Timestamp(TimeUnit::Millisecond, None)` in the parquet