### PR TITLE
fix: return cloned new record in __call__

### DIFF
--- a/bindings/python/tests/test_db.py
+++ b/bindings/python/tests/test_db.py
@@ -21,6 +21,15 @@ async def test_db_write():
     for i in range(0, 100):
         await db.insert(User(age=i, height=i * 10, weight=i * 20))
 
+@pytest.mark.asyncio
+async def test_db_write_none_value():
+    db = build_db()
+    await db.insert(User(age=1, height=100, weight=20))
+    await db.insert(User(age=2, weight=30))
+    user1 = await db.get(1)
+    user2 = await db.get(2)
+    assert user1 == {"age": 1, "height": 100, "weight": 20}
+    assert user2 == {"age": 2, "height": None, "weight": 30}
 
 @pytest.mark.asyncio
 async def test_db_read():


### PR DESCRIPTION
In python binding, value in old record still exists even though creating new record, for example:

```python
user1 = User(id=1, name='tonbo') # {id: 1, name: 'tonbo'}
user2 = User(id=2) 
# expected user2: { id=1, name=None }
# actual   user2: {id: 2, name: 'tonbo'}
```
This PR solves this issue by creating a new instanc( use `call` method, the `self()` in python) and then set data to the new instance