### PR TITLE
refactor: move `is_threshold_exceeded_major` to `LevelCompactor`

### DIFF
--- a/src/compaction/leveled.rs
+++ b/src/compaction/leveled.rs
@@ -100,7 +100,7 @@ where
                 let mut version_edits = vec![];
                 let mut delete_gens = vec![];
 
-                if self.option.is_threshold_exceeded_major(&version_ref, 0) {
+                if Self::is_threshold_exceeded_major(&self.option, &version_ref, 0) {
                     Self::major_compaction(
                         &version_ref,
                         &self.option,
@@ -208,7 +208,7 @@ where
         let mut level = 0;
 
         while level < MAX_LEVEL - 2 {
-            if !option.is_threshold_exceeded_major(version, level) {
+            if !Self::is_threshold_exceeded_major(option, version, level) {
                 break;
             }
             let (meet_scopes_l, start_l, end_l) = Self::this_level_scopes(version, min, max, level);
@@ -402,6 +402,22 @@ where
             }
         }
         (meet_scopes_l, start_l, end_l - 1)
+    }
+
+    /// Checks if the number of SST files in a level exceeds the major compaction threshold
+    ///
+    /// The threshold is calculated by multiplying the base threshold with a magnification factor
+    /// that increases exponentially with the level number.
+    ///
+    /// Returns true if the number of tables in the level exceeds the threshold.
+    pub(crate) fn is_threshold_exceeded_major(
+        option: &DbOption,
+        version: &Version<R>,
+        level: usize,
+    ) -> bool {
+        Version::<R>::tables_len(version, level)
+            >= (option.major_threshold_with_sst_size
+                * option.level_sst_magnification.pow(level as u32))
     }
 }
 

--- a/src/option.rs
+++ b/src/option.rs
@@ -12,9 +12,9 @@ use thiserror::Error;
 
 use crate::{
     fs::{FileId, FileType},
-    record::{Record, Schema},
+    record::Schema,
     trigger::TriggerType,
-    version::{Version, MAX_LEVEL},
+    version::MAX_LEVEL,
 };
 
 const DEFAULT_WAL_BUFFER_SIZE: usize = 4 * 1024;
@@ -238,15 +238,6 @@ impl DbOption {
 
     pub(crate) fn level_fs_path(&self, level: usize) -> Option<&Path> {
         self.level_paths[level].as_ref().map(|(path, _)| path)
-    }
-
-    pub(crate) fn is_threshold_exceeded_major<R: Record>(
-        &self,
-        version: &Version<R>,
-        level: usize,
-    ) -> bool {
-        Version::<R>::tables_len(version, level)
-            >= (self.major_threshold_with_sst_size * self.level_sst_magnification.pow(level as u32))
     }
 }
 


### PR DESCRIPTION
I think `is_threshold_exceeded_major` make sense for only level compaction. So it's better to move it to `LevelCompactor`