### PR TITLE
fix: lock storage in share mode in `flush_wal`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -483,7 +483,7 @@ where
     /// necessary to call this method before exiting if data loss is not acceptable. See also
     /// [`DbOption::disable_wal`] and [`DbOption::wal_buffer_size`].
     pub async fn flush_wal(&self) -> Result<(), DbError<R>> {
-        self.schema.write().await.flush_wal().await?;
+        self.schema.read().await.flush_wal().await?;
         Ok(())
     }
 


### PR DESCRIPTION
#361 

It's enough to lock storage in share mode when calling `flush_wal` since wal file will be locked while writing/flushing.