### PR TITLE
doc:updated dependency requirement

### DIFF
--- a/guide/src/start.md
+++ b/guide/src/start.md
@@ -15,6 +15,7 @@ For native platforms, [Tokio](https://github.com/tokio-rs/tokio) is the most pop
 ```toml
 tokio = { version = "1", features = ["full"] }
 tonbo = { git = "https://github.com/tonbo-io/tonbo" }
+fusio = { version = "*", features = ["tokio"] }
 ```
 
 For browser targets using OPFS as the storage backend, disable the `tokio` feature and enable the `wasm` feature because Tokio is incompatible with OPFS. Since `tokio` is enabled by default, you must disable default features. If you plan to use S3 as the backend, also enable the `wasm-http` feature:


### PR DESCRIPTION
While I was going through the documentation guide to test out Tonbo in a standalone environment, I noticed the [dependency] portion of cargo.toml did not include fusio which is being used in the later part of the examples, this is a very minor tweak to the documentation involved.