### PR TITLE
refactor: Use `SsTableID` for identification

### DIFF
--- a/src/compaction/leveled.rs
+++ b/src/compaction/leveled.rs
@@ -10,7 +10,7 @@ use crate::{
     context::Context,
     fs::{generate_file_id, manager::StoreManager, FileId, FileType},
     inmem::{immutable::Immutable, mutable::MutableMemTable},
-    ondisk::sstable::SsTable,
+    ondisk::sstable::{SsTable, SsTableID},
     record::{Record, Schema as RecordSchema},
     scope::Scope,
     stream::{level::LevelStream, ScanStream},
@@ -201,7 +201,7 @@ where
         mut min: &<R::Schema as RecordSchema>::Key,
         mut max: &<R::Schema as RecordSchema>::Key,
         version_edits: &mut Vec<VersionEdit<<R::Schema as RecordSchema>::Key>>,
-        delete_gens: &mut Vec<(FileId, usize)>,
+        delete_gens: &mut Vec<SsTableID>,
         instance: &R::Schema,
         ctx: &Context<R>,
     ) -> Result<(), CompactionError<R>> {
@@ -300,14 +300,14 @@ where
                     level: level as u8,
                     gen: scope.gen,
                 });
-                delete_gens.push((scope.gen, level));
+                delete_gens.push(SsTableID::new(scope.gen, level));
             }
             for scope in meet_scopes_ll {
                 version_edits.push(VersionEdit::Remove {
                     level: (level + 1) as u8,
                     gen: scope.gen,
                 });
-                delete_gens.push((scope.gen, level + 1));
+                delete_gens.push(SsTableID::new(scope.gen, level + 1));
             }
             level += 1;
         }

--- a/src/ondisk/sstable.rs
+++ b/src/ondisk/sstable.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 
 #[derive(Clone)]
-pub struct SsTableID {
+pub(crate) struct SsTableID {
     // File id for the SStable
     file_id: FileId,
     // The level where the SSTable is located

--- a/src/ondisk/sstable.rs
+++ b/src/ondisk/sstable.rs
@@ -24,7 +24,9 @@ use crate::{
 
 #[derive(Clone)]
 pub struct SsTableID {
+    // File id for the SStable
     file_id: FileId,
+    // The level where the SSTable is located
     level: usize,
 }
 

--- a/src/ondisk/sstable.rs
+++ b/src/ondisk/sstable.rs
@@ -16,10 +16,31 @@ use ulid::Ulid;
 
 use super::{arrows::get_range_filter, scan::SsTableScan};
 use crate::{
+    fs::FileId,
     record::{Record, Schema},
     stream::record_batch::RecordBatchEntry,
     timestamp::{Timestamp, TsRef},
 };
+
+#[derive(Clone)]
+pub struct SsTableID {
+    file_id: FileId,
+    level: usize,
+}
+
+impl SsTableID {
+    pub fn new(file_id: FileId, level: usize) -> Self {
+        Self { file_id, level }
+    }
+
+    pub fn file_id(&self) -> FileId {
+        self.file_id
+    }
+
+    pub fn level(&self) -> usize {
+        self.level
+    }
+}
 
 pub(crate) struct SsTable<R>
 where

--- a/src/version/set.rs
+++ b/src/version/set.rs
@@ -16,6 +16,7 @@ use futures_util::StreamExt;
 use super::{TransactionTs, MAX_LEVEL};
 use crate::{
     fs::{generate_file_id, manager::StoreManager, parse_file_id, FileId, FileType},
+    ondisk::sstable::SsTableID,
     record::{Record, Schema},
     timestamp::Timestamp,
     version::{cleaner::CleanTag, edit::VersionEdit, Version, VersionError, VersionRef},
@@ -51,7 +52,7 @@ where
     current: VersionRef<R>,
     log_id: FileId,
     deleted_wal: Vec<FileId>,
-    deleted_sst: Vec<(FileId, usize)>,
+    deleted_sst: Vec<SsTableID>,
 }
 
 pub(crate) struct VersionSet<R>
@@ -190,7 +191,7 @@ where
     pub(crate) async fn apply_edits(
         &self,
         mut version_edits: Vec<VersionEdit<<R::Schema as Schema>::Key>>,
-        delete_gens: Option<Vec<(FileId, usize)>>,
+        delete_gens: Option<Vec<SsTableID>>,
         is_recover: bool,
     ) -> Result<(), VersionError<R>> {
         let timestamp = &self.timestamp;
@@ -237,7 +238,7 @@ where
                     }
                     if is_recover {
                         // issue: https://github.com/tonbo-io/tonbo/issues/123
-                        guard.deleted_sst.push((gen, level as usize));
+                        guard.deleted_sst.push(SsTableID::new(gen, level as usize));
                     }
                 }
                 VersionEdit::LatestTimeStamp { ts } => {


### PR DESCRIPTION
While reading throught the codebase I noticed that deleted SSTable identification was a little unclear (mostly that the usize was for the level). I added a new struct to replace this. 

```rust 
pub struct SsTableID {
    // File id for the SStable
    file_id: FileId,
    // The level for which the SSTable is located
    level: usize,
}
```