### PR TITLE
fix: Remove required input for issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -4,26 +4,26 @@ labels: enhancement
 body:
   - type: textarea
     attributes:
-      label: What is the current?
+      label: What is the current issue?
     validations:
       required: true
   - type: textarea
     attributes:
-      label: What will it become?
+      label: What is your solution?
     validations:
       required: true
   - type: textarea
     attributes:
-      label: What are the benefits?
+      label: What does this improve?
     validations:
       required: true
   - type: textarea
     attributes:
       label: Are there any alternatives?
     validations:
-      required: true
+      required: false
   - type: textarea
     attributes:
       label: Does it have a reference?
     validations:
-      required: true
+      required: false


### PR DESCRIPTION
# Rationale
I do not feel that an alternative or reference should be required. 

# Changes
 - Made it so alternative or reference is not longer required.
 - Reworded some of the points