### PR TITLE
feat: Fast path for `apply_edits`

### DIFF
--- a/src/version/set.rs
+++ b/src/version/set.rs
@@ -179,6 +179,7 @@ where
             manager,
         };
 
+        // Only generate a new manifest if there is no rewrites
         if edits.is_empty() {
             set.rewrite().await?;
         } else {

--- a/src/version/set.rs
+++ b/src/version/set.rs
@@ -178,7 +178,13 @@ where
             option,
             manager,
         };
-        set.apply_edits(edits, None, true).await?;
+
+        if edits.is_empty() {
+            set.rewrite().await?;
+            set.clean().await?;
+        } else {
+            set.apply_edits(edits, None, true).await?;
+        }
 
         Ok(set)
     }

--- a/src/version/set.rs
+++ b/src/version/set.rs
@@ -181,7 +181,6 @@ where
 
         if edits.is_empty() {
             set.rewrite().await?;
-            set.clean().await?;
         } else {
             set.apply_edits(edits, None, true).await?;
         }


### PR DESCRIPTION
When calling `VersionSet::new()` we do not need to call `apply_edits()` if `edits.is_empty()`. 