### PR TITLE
feat: Optimize binary search for `VersionEdit::Add`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ fusio-log = { git = "https://github.com/tonbo-io/fusio", rev = "278eb79091b24df2
 fusio-parquet = { git = "https://github.com/tonbo-io/fusio", rev = "278eb79091b24df29eb9f3ac78ae6c3305ea3ee6", version = "0.3.8", package = "fusio-parquet" }
 futures-core = "0.3"
 futures-util = "0.3"
+itertools = "0.14.0"
 lockable = "0.1.1"
 once_cell = "1"
 parquet = { version = "55", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ fusio-log = { git = "https://github.com/tonbo-io/fusio", rev = "278eb79091b24df2
 fusio-parquet = { git = "https://github.com/tonbo-io/fusio", rev = "278eb79091b24df29eb9f3ac78ae6c3305ea3ee6", version = "0.3.8", package = "fusio-parquet" }
 futures-core = "0.3"
 futures-util = "0.3"
+itertools = { version = "0.14.0" }
 lockable = "0.1.1"
 once_cell = "1"
 parquet = { version = "55", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,6 @@ fusio-log = { git = "https://github.com/tonbo-io/fusio", rev = "278eb79091b24df2
 fusio-parquet = { git = "https://github.com/tonbo-io/fusio", rev = "278eb79091b24df29eb9f3ac78ae6c3305ea3ee6", version = "0.3.8", package = "fusio-parquet" }
 futures-core = "0.3"
 futures-util = "0.3"
-itertools = "0.14.0"
 lockable = "0.1.1"
 once_cell = "1"
 parquet = { version = "55", default-features = false, features = [

--- a/src/version/set.rs
+++ b/src/version/set.rs
@@ -661,7 +661,7 @@ pub(crate) mod tests {
         drop(version_set);
     }
 
-   #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_apply_edits_batch_add_out_of_index() {
         let temp_dir = TempDir::new().unwrap();
         let path = Path::from_filesystem_path(temp_dir.path()).unwrap();

--- a/src/version/set.rs
+++ b/src/version/set.rs
@@ -251,13 +251,13 @@ where
             }
         }
 
-        // Due to many compaction add operations being consecutive, this checks if the 
+        // Due to many compaction add operations being consecutive, this checks if the
         // SSTs can be splice inserted instead of inserting eac one individually
         if !batch_add.is_empty() {
             for (level, mut scopes) in batch_add.into_iter() {
                 scopes.sort_unstable_by_key(|scope| scope.min.clone());
                 let sort_runs = &mut new_version.level_slice[level as usize];
-                
+
                 let mut ptr = 0;
                 while ptr < scopes.len() {
                     let pos = sort_runs

--- a/src/version/set.rs
+++ b/src/version/set.rs
@@ -12,6 +12,7 @@ use flume::Sender;
 use fusio::{fs::FileMeta, DynFs};
 use fusio_log::{Logger, Options};
 use futures_util::StreamExt;
+use itertools::Itertools;
 
 use super::{TransactionTs, MAX_LEVEL};
 use crate::{
@@ -258,27 +259,12 @@ where
                 scopes.sort_unstable_by_key(|scope| scope.min.clone());
                 let sort_runs = &mut new_version.level_slice[level as usize];
 
-                let mut ptr = 0;
-                while ptr < scopes.len() {
-                    let pos = sort_runs
-                        .binary_search_by(|s| s.min.cmp(&scopes[ptr].min))
-                        .unwrap_or_else(|index| index);
-
-                    // Check if the next value in scopes is also less than the next SST
-                    let mut end = ptr + 1;
-                    while end < scopes.len() {
-                        if pos + (end - ptr) < sort_runs.len()
-                            && scopes[end].min < sort_runs[pos + (end - ptr)].min
-                        {
-                            end += 1;
-                        } else {
-                            break;
-                        }
-                    }
-
-                    sort_runs.splice(pos..pos, scopes[ptr..end].iter().cloned());
-                    ptr = end;
-                }
+                let merged: Vec<_> = scopes
+                    .iter()
+                    .cloned()
+                    .merge_by(sort_runs.iter().cloned(), |a, b| a.min <= b.min)
+                    .collect();
+                *sort_runs = merged;
             }
         }
 
@@ -675,8 +661,8 @@ pub(crate) mod tests {
         drop(version_set);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_apply_edits_batch_add() {
+   #[tokio::test(flavor = "multi_thread")]
+    async fn test_apply_edits_batch_add_out_of_index() {
         let temp_dir = TempDir::new().unwrap();
         let path = Path::from_filesystem_path(temp_dir.path()).unwrap();
         let manager = Arc::new(StoreManager::new(FsOptions::Local, vec![]).unwrap());
@@ -741,8 +727,8 @@ pub(crate) mod tests {
                     VersionEdit::Add {
                         level: 1,
                         scope: Scope {
-                            min: "2".to_string(),
-                            max: "2".to_string(),
+                            min: "5".to_string(),
+                            max: "5".to_string(),
                             gen: gen_c,
                             wal_ids: None,
                         },
@@ -760,7 +746,102 @@ pub(crate) mod tests {
                 .iter()
                 .map(|scope| scope.min.clone())
                 .collect();
-            assert_eq!(keys, vec!["1", "2", "2", "4"]);
+            assert_eq!(keys, vec!["1", "2", "4", "5"]);
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_apply_edits_batch_add() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = Path::from_filesystem_path(temp_dir.path()).unwrap();
+        let manager = Arc::new(StoreManager::new(FsOptions::Local, vec![]).unwrap());
+        let (sender, _) = bounded(1);
+        let mut option = DbOption::new(path, &StringSchema);
+        option.version_log_snapshot_threshold = u32::MAX;
+        let option = Arc::new(option);
+
+        manager
+            .local_fs()
+            .create_dir_all(&option.version_log_dir_path())
+            .await
+            .unwrap();
+        manager
+            .base_fs()
+            .create_dir_all(&option.version_log_dir_path())
+            .await
+            .unwrap();
+
+        let version_set: VersionSet<String> =
+            VersionSet::new(sender.clone(), option.clone(), manager.clone())
+                .await
+                .unwrap();
+
+        let gen_d = generate_file_id();
+        {
+            let mut guard = version_set.inner.write().await;
+            let mut v = Version::clone(&guard.current);
+            v.level_slice[1].push(Scope {
+                min: "4".to_string(),
+                max: "4".to_string(),
+                gen: gen_d,
+                wal_ids: None,
+            });
+            v.level_slice[1].push(Scope {
+                min: "8".to_string(),
+                max: "8".to_string(),
+                gen: gen_d,
+                wal_ids: None,
+            });
+            guard.current = Arc::new(v);
+        }
+
+        let gen_a = generate_file_id();
+        let gen_b = generate_file_id();
+        let gen_c = generate_file_id();
+        version_set
+            .apply_edits(
+                vec![
+                    VersionEdit::Add {
+                        level: 1,
+                        scope: Scope {
+                            min: "2".to_string(),
+                            max: "2".to_string(),
+                            gen: gen_b,
+                            wal_ids: None,
+                        },
+                    },
+                    VersionEdit::Add {
+                        level: 1,
+                        scope: Scope {
+                            min: "5".to_string(),
+                            max: "5".to_string(),
+                            gen: gen_a,
+                            wal_ids: None,
+                        },
+                    },
+                    VersionEdit::Add {
+                        level: 1,
+                        scope: Scope {
+                            min: "7".to_string(),
+                            max: "7".to_string(),
+                            gen: gen_c,
+                            wal_ids: None,
+                        },
+                    },
+                ],
+                None,
+                true,
+            )
+            .await
+            .unwrap();
+
+        {
+            let guard = version_set.inner.read().await;
+            let keys: Vec<_> = guard.current.level_slice[1]
+                .iter()
+                .map(|scope| scope.min.clone())
+                .collect();
+            assert_eq!(keys, vec!["2", "4", "5", "7", "8"]);
         }
     }
 

--- a/src/version/set.rs
+++ b/src/version/set.rs
@@ -252,7 +252,7 @@ where
         }
 
         // Due to many compaction add operations being consecutive, this checks if the
-        // SSTs can be splice inserted instead of inserting eac one individually
+        // SSTs can be splice inserted instead of inserting each one individually
         if !batch_add.is_empty() {
             for (level, mut scopes) in batch_add.into_iter() {
                 scopes.sort_unstable_by_key(|scope| scope.min.clone());

--- a/src/version/set.rs
+++ b/src/version/set.rs
@@ -675,6 +675,95 @@ pub(crate) mod tests {
         drop(version_set);
     }
 
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_apply_edits_batch_add() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = Path::from_filesystem_path(temp_dir.path()).unwrap();
+        let manager = Arc::new(StoreManager::new(FsOptions::Local, vec![]).unwrap());
+        let (sender, _) = bounded(1);
+        let mut option = DbOption::new(path, &StringSchema);
+        option.version_log_snapshot_threshold = u32::MAX;
+        let option = Arc::new(option);
+
+        manager
+            .local_fs()
+            .create_dir_all(&option.version_log_dir_path())
+            .await
+            .unwrap();
+        manager
+            .base_fs()
+            .create_dir_all(&option.version_log_dir_path())
+            .await
+            .unwrap();
+
+        let version_set: VersionSet<String> =
+            VersionSet::new(sender.clone(), option.clone(), manager.clone())
+                .await
+                .unwrap();
+
+        let gen_d = generate_file_id();
+        {
+            let mut guard = version_set.inner.write().await;
+            let mut v = Version::clone(&guard.current);
+            v.level_slice[1].push(Scope {
+                min: "4".to_string(),
+                max: "4".to_string(),
+                gen: gen_d,
+                wal_ids: None,
+            });
+            guard.current = Arc::new(v);
+        }
+
+        let gen_a = generate_file_id();
+        let gen_b = generate_file_id();
+        let gen_c = generate_file_id();
+        version_set
+            .apply_edits(
+                vec![
+                    VersionEdit::Add {
+                        level: 1,
+                        scope: Scope {
+                            min: "2".to_string(),
+                            max: "2".to_string(),
+                            gen: gen_b,
+                            wal_ids: None,
+                        },
+                    },
+                    VersionEdit::Add {
+                        level: 1,
+                        scope: Scope {
+                            min: "1".to_string(),
+                            max: "1".to_string(),
+                            gen: gen_a,
+                            wal_ids: None,
+                        },
+                    },
+                    VersionEdit::Add {
+                        level: 1,
+                        scope: Scope {
+                            min: "2".to_string(),
+                            max: "2".to_string(),
+                            gen: gen_c,
+                            wal_ids: None,
+                        },
+                    },
+                ],
+                None,
+                true,
+            )
+            .await
+            .unwrap();
+
+        {
+            let guard = version_set.inner.read().await;
+            let keys: Vec<_> = guard.current.level_slice[1]
+                .iter()
+                .map(|scope| scope.min.clone())
+                .collect();
+            assert_eq!(keys, vec!["1", "2", "2", "4"]);
+        }
+    }
+
     async fn version_log_snap_shot(base_option: FsOptions, path: Path) {
         let manager = Arc::new(StoreManager::new(base_option, vec![]).unwrap());
         let (sender, _) = bounded(1);


### PR DESCRIPTION
When compaction generates `VersionSet::Add` SST operations, many of these operations will be consecutive. To avoid doing a binary search for every element + insert (shifts all elements) we can instead batch all 'add' operations and check if consecutive ssts can be inserted together. 