### PR TITLE
refactor: Move `CompactionError` into error file

### DIFF
--- a/src/compaction/error.rs
+++ b/src/compaction/error.rs
@@ -1,0 +1,26 @@
+use thiserror::Error;
+
+use crate::{record::Record, version::VersionError, CommitError};
+
+#[derive(Debug, Error)]
+pub enum CompactionError<R>
+where
+    R: Record,
+{
+    #[error("compaction io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("compaction parquet error: {0}")]
+    Parquet(#[from] parquet::errors::ParquetError),
+    #[error("compaction fusio error: {0}")]
+    Fusio(#[from] fusio::Error),
+    #[error("compaction version error: {0}")]
+    Version(#[from] VersionError<R>),
+    #[error("compaction logger error: {0}")]
+    Logger(#[from] fusio_log::error::LogError),
+    #[error("compaction channel is closed")]
+    ChannelClose,
+    #[error("database error: {0}")]
+    Commit(#[from] CommitError<R>),
+    #[error("the level being compacted does not have a table")]
+    EmptyLevel,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,7 +159,7 @@ use wal::log::Log;
 
 pub use crate::option::*;
 use crate::{
-    compaction::{CompactTask, CompactionError, Compactor},
+    compaction::{error::CompactionError, CompactTask, Compactor},
     executor::Executor,
     fs::{manager::StoreManager, parse_file_id, FileType},
     record::Schema,
@@ -1007,7 +1007,7 @@ pub(crate) mod tests {
 
     use crate::{
         cast_arc_value,
-        compaction::{leveled::LeveledCompactor, CompactTask, CompactionError, Compactor},
+        compaction::{error::CompactionError, leveled::LeveledCompactor, CompactTask, Compactor},
         context::Context,
         executor::{tokio::TokioExecutor, Executor},
         fs::{generate_file_id, manager::StoreManager},


### PR DESCRIPTION
`CompactionError` can be missed in the midst of all the files. We can move this into its own file in the compaction folder