### PR TITLE
refactor: migrate ArrowArrays to record/ and remove useless errors

### DIFF
--- a/src/compaction/mod.rs
+++ b/src/compaction/mod.rs
@@ -12,8 +12,7 @@ use tokio::sync::oneshot;
 use crate::{
     compaction::error::CompactionError,
     fs::{generate_file_id, FileType},
-    inmem::immutable::{ArrowArrays, Builder},
-    record::{KeyRef, Record, Schema as RecordSchema},
+    record::{ArrowArrays, ArrowArraysBuilder, KeyRef, Record, Schema as RecordSchema},
     scope::Scope,
     stream::{merge::MergeStream, ScanStream},
     version::edit::VersionEdit,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,11 +156,11 @@ use trigger::FreezeTrigger;
 use version::timestamp::{Timestamp, TsRef};
 use wal::log::Log;
 
-// Re-export items needed by macros and tests
-#[doc(hidden)]
-pub use crate::inmem::immutable::{ArrowArrays, Builder};
 #[doc(hidden)]
 pub use crate::magic::TS;
+// Re-export items needed by macros and tests
+#[doc(hidden)]
+pub use crate::record::{ArrowArrays, ArrowArraysBuilder};
 #[doc(hidden)]
 pub use crate::version::timestamp::Ts;
 use crate::{

--- a/src/record/dynamic/array.rs
+++ b/src/record/dynamic/array.rs
@@ -18,9 +18,11 @@ use arrow::{
 
 use super::{record::DynRecord, record_ref::DynRecordRef, AsValue, DataType};
 use crate::{
-    inmem::immutable::{ArrowArrays, Builder},
     magic::USER_COLUMN_OFFSET,
-    record::{Key, LargeBinary, LargeString, Record, Schema, TimeUnit, ValueRef},
+    record::{
+        ArrowArrays, ArrowArraysBuilder, Key, LargeBinary, LargeString, Record, Schema, TimeUnit,
+        ValueRef,
+    },
     version::timestamp::Ts,
 };
 
@@ -143,7 +145,7 @@ macro_rules! implement_builder_array {
         { $( { $alt_ty:ty, $alt_variant:pat, $builder_ty:ty, $as_alt_value:ident } ),* $(,)? },
         { $( { $alt_ty2:ty, $alt_variant2:pat,$builder_ty2:ty, $array_ty3:ty, $as_alt_value2:ident } ),* }
     ) => {
-        impl Builder<DynRecordImmutableArrays> for DynRecordBuilder {
+        impl ArrowArraysBuilder<DynRecordImmutableArrays> for DynRecordBuilder {
             fn push(
                 &mut self,
                 key: Ts<<<<DynRecord as Record>::Schema as Schema>::Key as Key>::Ref<'_>>,
@@ -421,9 +423,9 @@ mod tests {
 
     use crate::{
         dyn_schema,
-        inmem::immutable::{ArrowArrays, Builder},
         record::{
-            DynRecord, DynRecordImmutableArrays, DynRecordRef, Record, RecordRef, Schema, Value,
+            ArrowArrays, ArrowArraysBuilder, DynRecord, DynRecordImmutableArrays, DynRecordRef,
+            Record, RecordRef, Schema, Value,
         },
     };
 

--- a/src/record/test.rs
+++ b/src/record/test.rs
@@ -10,12 +10,10 @@ use arrow::{
 use once_cell::sync::Lazy;
 use parquet::{arrow::ProjectionMask, format::SortingColumn, schema::types::ColumnPath};
 
-use super::{option::OptionRecordRef, Key, Record, RecordRef, Schema};
-use crate::{
-    inmem::immutable::{ArrowArrays, Builder},
-    magic,
-    version::timestamp::Ts,
+use super::{
+    option::OptionRecordRef, ArrowArrays, ArrowArraysBuilder, Key, Record, RecordRef, Schema,
 };
+use crate::{magic, version::timestamp::Ts};
 
 const PRIMARY_FIELD_NAME: &str = "vstring";
 
@@ -154,7 +152,7 @@ pub struct StringColumnsBuilder {
     string: StringBuilder,
 }
 
-impl Builder<StringColumns> for StringColumnsBuilder {
+impl ArrowArraysBuilder<StringColumns> for StringColumnsBuilder {
     fn push(&mut self, key: Ts<&str>, row: Option<&str>) {
         self._null.append(row.is_none());
         self._ts.append_value(key.ts.into());

--- a/src/stream/package.rs
+++ b/src/stream/package.rs
@@ -9,8 +9,7 @@ use futures_core::Stream;
 use pin_project_lite::pin_project;
 
 use crate::{
-    inmem::immutable::{ArrowArrays, Builder},
-    record::{Record, Schema},
+    record::{ArrowArrays, ArrowArraysBuilder, Record, Schema},
     stream::merge::MergeStream,
 };
 
@@ -90,13 +89,10 @@ mod tests {
 
     use crate::{
         inmem::{
-            immutable::{
-                tests::{TestImmutableArrays, TestSchema},
-                ArrowArrays,
-            },
+            immutable::tests::{TestImmutableArrays, TestSchema},
             mutable::MutableMemTable,
         },
-        record::Schema,
+        record::{ArrowArrays, Schema},
         stream::{merge::MergeStream, package::PackageStream},
         tests::Test,
         trigger::TriggerFactory,

--- a/tests/macros_correctness.rs
+++ b/tests/macros_correctness.rs
@@ -34,7 +34,7 @@ mod tests {
     use tokio::io::AsyncSeekExt;
     use tonbo::{
         record::{Record, RecordRef, Schema},
-        ArrowArrays, Builder, Ts, TS,
+        ArrowArrays, ArrowArraysBuilder, Ts, TS,
     };
 
     use crate::{Point, User, UserImmutableArrays, UserRef, UserSchema};

--- a/tonbo_macros/src/record.rs
+++ b/tonbo_macros/src/record.rs
@@ -818,7 +818,7 @@ fn struct_builder_codegen(
             _ts: ::tonbo::arrow::array::UInt32Builder,
         }
 
-        impl ::tonbo::Builder<#struct_arrays_name> for #struct_builder_name {
+        impl ::tonbo::ArrowArraysBuilder<#struct_arrays_name> for #struct_builder_name {
             fn push(&mut self, key: ::tonbo::Ts<<<<#struct_name as ::tonbo::record::Record>::Schema as ::tonbo::record::Schema>::Key as ::tonbo::record::Key>::Ref<'_>>, row: Option<#struct_ref_name>) {
                 #builder_append_primary_key
                 match row {


### PR DESCRIPTION
## What changes are included in this PR?
move the ArrowArrays and Builder traits from src/inmem/immutable.rs to src/record/mod.rs. This change improves code organization by colocating these traits with other record-related functionality.

remove useless RecordEncodeError and RecordDecodeError