### PR TITLE
feat: add `FixedSizeBianry` type for Value

### DIFF
--- a/bindings/js/src/utils.rs
+++ b/bindings/js/src/utils.rs
@@ -71,6 +71,7 @@ pub(crate) fn to_record(schema: &[DynamicField], cols: &[Value]) -> JsValue {
             Value::Float64(v) => (*v).into(),
             Value::String(v) => v.to_owned().into(),
             Value::Binary(v) => v.to_vec().into(),
+            Value::FixedSizeBinary(v, w) => v.to_vec().into(),
             Value::Date32(_)
             | Value::Date64(_)
             | Value::Time32(_, _)
@@ -101,6 +102,7 @@ pub(crate) fn to_record_ref(schema: &[DynamicField], cols: &[ValueRef]) -> JsVal
             ValueRef::Float64(v) => (*v).into(),
             ValueRef::String(v) => v.to_owned().into(),
             ValueRef::Binary(v) => v.to_vec().into(),
+            ValueRef::FixedSizeBinary(v, _) => v.to_vec().into(),
             ValueRef::Date32(_)
             | ValueRef::Date64(_)
             | ValueRef::Time32(_, _)

--- a/bindings/python/src/utils.rs
+++ b/bindings/python/src/utils.rs
@@ -32,6 +32,7 @@ pub(crate) fn to_dict(
             Value::Float64(v) => dict.set_item(name, v)?,
             Value::String(v) => dict.set_item(name, v)?,
             Value::Binary(v) => dict.set_item(name, v)?,
+            Value::FixedSizeBinary(v, _) => dict.set_item(name, v)?,
             Value::Date32(_)
             | Value::Date64(_)
             | Value::Timestamp(_, _)
@@ -67,6 +68,7 @@ pub(crate) fn to_dict_ref<'py, 'r>(
             ValueRef::Float64(v) => dict.set_item(name, v)?,
             ValueRef::String(v) => dict.set_item(name, v)?,
             ValueRef::Binary(v) => dict.set_item(name, v)?,
+            ValueRef::FixedSizeBinary(v, _) => dict.set_item(name, v)?,
             ValueRef::Date32(_)
             | ValueRef::Date64(_)
             | ValueRef::Timestamp(_, _)

--- a/src/record/dynamic/array.rs
+++ b/src/record/dynamic/array.rs
@@ -3,12 +3,12 @@ use std::{mem, sync::Arc};
 use arrow::{
     array::{
         Array, ArrayBuilder, ArrayRef, BooleanArray, BooleanBufferBuilder, BooleanBuilder,
-        Date32Builder, Date64Builder, Float32Builder, Float64Builder, GenericBinaryBuilder,
-        Int16Builder, Int32Builder, Int64Builder, Int8Builder, LargeStringBuilder,
-        PrimitiveBuilder, StringBuilder, Time32MillisecondBuilder, Time32SecondBuilder,
-        Time64MicrosecondBuilder, Time64NanosecondBuilder, TimestampMicrosecondBuilder,
-        TimestampMillisecondBuilder, TimestampNanosecondBuilder, TimestampSecondBuilder,
-        UInt16Builder, UInt32Builder, UInt64Builder, UInt8Builder,
+        Date32Builder, Date64Builder, FixedSizeBinaryBuilder, Float32Builder, Float64Builder,
+        GenericBinaryBuilder, Int16Builder, Int32Builder, Int64Builder, Int8Builder,
+        LargeStringBuilder, PrimitiveBuilder, StringBuilder, Time32MillisecondBuilder,
+        Time32SecondBuilder, Time64MicrosecondBuilder, Time64NanosecondBuilder,
+        TimestampMicrosecondBuilder, TimestampMillisecondBuilder, TimestampNanosecondBuilder,
+        TimestampSecondBuilder, UInt16Builder, UInt32Builder, UInt64Builder, UInt8Builder,
     },
     datatypes::{
         Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type, Schema as ArrowSchema,
@@ -86,6 +86,7 @@ macro_rules! implement_arrow_array {
                                 builders.push(Box::new(<$builder_ty>::with_capacity(capacity, 0)));
                             }
                         )*
+                        DataType::FixedSizeBinary(w) => builders.push(Box::new(FixedSizeBinaryBuilder::with_capacity(capacity, *w))),
                         DataType::Time32(_) | DataType::Time64(_) => unreachable!(),
                     }
                     datatypes.push(datatype);
@@ -205,6 +206,14 @@ macro_rules! implement_builder_array {
                                         }
                                     }
                                 )*
+                                DataType::FixedSizeBinary(w) =>{
+                                    let bd = Self::as_builder_mut::<FixedSizeBinaryBuilder>(builder.as_mut());
+                                    match col.as_bytes_opt() {
+                                        Some(value) => bd.append_value(value).unwrap(),
+                                        None if is_nullable => bd.append_null(),
+                                        None => bd.append_value(vec![0; w as usize]).unwrap(),
+                                    }
+                                }
                                 DataType::Time32(_) | DataType::Time64(_) => unreachable!(),
                             }
                         }
@@ -238,6 +247,10 @@ macro_rules! implement_builder_array {
                                             .append_value(Default::default());
                                     }
                                 )*
+                                DataType::FixedSizeBinary(w) =>{
+                                    Self::as_builder_mut::<FixedSizeBinaryBuilder>(builder.as_mut())
+                                        .append_value(vec![0; *w as usize]).unwrap();
+                                }
                                 DataType::Time32(_) | DataType::Time64(_) => unreachable!(),
                             }
                         }
@@ -274,6 +287,9 @@ macro_rules! implement_builder_array {
                                         .values_slice()
                                 ),
                             )*
+                            DataType::FixedSizeBinary(_) => mem::size_of_val(
+                                Self::as_builder::<FixedSizeBinaryBuilder>(builder.as_ref()).values_slice()
+                            ),
                             DataType::Time32(_) | DataType::Time64(_) => unreachable!(),
                         }
                     })
@@ -321,6 +337,14 @@ macro_rules! implement_builder_array {
                                 array_refs.push(array.clone());
                             }
                         )*
+                        DataType::FixedSizeBinary(_) => {
+                            let array = Arc::new(
+                                Self::as_builder_mut::<FixedSizeBinaryBuilder>(builder.as_mut())
+                                    .finish(),
+                            );
+                            array_refs.push(array.clone());
+                        }
+
                         DataType::Time32(_) | DataType::Time64(_) => unreachable!(),
                     };
                 }
@@ -419,13 +443,14 @@ implement_builder_array!(
 #[cfg(test)]
 mod tests {
 
+    use arrow::datatypes::DataType;
     use parquet::arrow::ProjectionMask;
 
     use crate::{
         dyn_schema,
         record::{
             ArrowArrays, ArrowArraysBuilder, DynRecord, DynRecordImmutableArrays, DynRecordRef,
-            Record, RecordRef, Schema, Value,
+            DynSchema, DynamicField, Record, RecordRef, Schema, Value,
         },
     };
 
@@ -542,6 +567,66 @@ mod tests {
                 record_ref.get().unwrap().columns,
                 record.as_record_ref().columns
             );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_build_fixed_size_binary() {
+        let schema = DynSchema::new(
+            vec![
+                DynamicField::new("four".into(), DataType::FixedSizeBinary(4), false),
+                DynamicField::new("five".into(), DataType::FixedSizeBinary(5), true),
+                DynamicField::new("three".into(), DataType::FixedSizeBinary(3), false),
+            ],
+            0,
+        );
+
+        let record1 = DynRecord::new(
+            vec![
+                Value::FixedSizeBinary(vec![1, 2, 3, 4], 4),
+                Value::FixedSizeBinary(vec![1, 2, 3, 4, 5], 5),
+                Value::FixedSizeBinary(vec![1, 2, 3], 3),
+            ],
+            0,
+        );
+        let record2 = DynRecord::new(
+            vec![
+                Value::FixedSizeBinary(vec![2, 3, 4, 5], 4),
+                Value::Null,
+                Value::FixedSizeBinary(vec![2, 3, 7], 3),
+            ],
+            0,
+        );
+
+        let mut builder = DynRecordImmutableArrays::builder(schema.arrow_schema().clone(), 5);
+        let key = crate::version::timestamp::Ts {
+            ts: 0.into(),
+            value: record1.key(),
+        };
+        let key2 = crate::version::timestamp::Ts {
+            ts: 0.into(),
+            value: record2.key(),
+        };
+        builder.push(key, Some(record1.as_record_ref()));
+        builder.push(key, None);
+        builder.push(key2, Some(record2.as_record_ref()));
+        let arrays = builder.finish(None);
+
+        {
+            let res1 = arrays.get(0, &ProjectionMask::all());
+            let cols = res1.unwrap().unwrap().columns;
+            for (actual, expected) in cols.iter().zip(record1.as_record_ref().columns.iter()) {
+                assert_eq!(actual, expected);
+            }
+
+            let res2 = arrays.get(1, &ProjectionMask::all());
+            assert!(res2.unwrap().is_none());
+
+            let res3 = arrays.get(2, &ProjectionMask::all());
+            let cols = res3.unwrap().unwrap().columns;
+            for (actual, expected) in cols.iter().zip(record2.as_record_ref().columns.iter()) {
+                assert_eq!(actual, expected);
+            }
         }
     }
 }

--- a/src/record/dynamic/mod.rs
+++ b/src/record/dynamic/mod.rs
@@ -28,6 +28,7 @@ pub enum DataType {
     Boolean,
     Bytes,
     LargeBinary,
+    FixedSizeBinary(i32),
     Float32,
     Float64,
     Timestamp(TimeUnit),
@@ -75,6 +76,7 @@ impl From<&ArrowDataType> for DataType {
             ArrowDataType::Date64 => DataType::Date64,
             ArrowDataType::LargeBinary => DataType::LargeBinary,
             ArrowDataType::LargeUtf8 => DataType::LargeString,
+            ArrowDataType::FixedSizeBinary(w) => DataType::FixedSizeBinary(*w),
             _ => todo!(),
         }
     }

--- a/src/record/dynamic/value/cast.rs
+++ b/src/record/dynamic/value/cast.rs
@@ -170,6 +170,7 @@ impl AsValue for Value {
     fn as_bytes_opt(&self) -> Option<&[u8]> {
         match self {
             Value::Binary(v) => Some(v),
+            Value::FixedSizeBinary(v, _) => Some(v),
             _ => None,
         }
     }
@@ -263,6 +264,7 @@ impl AsValue for ValueRef<'_> {
     fn as_bytes_opt(&self) -> Option<&[u8]> {
         match self {
             ValueRef::Binary(v) => Some(v),
+            ValueRef::FixedSizeBinary(v, _) => Some(v),
             _ => None,
         }
     }

--- a/src/record/dynamic/value/value_ref.rs
+++ b/src/record/dynamic/value/value_ref.rs
@@ -30,6 +30,7 @@ pub enum ValueRef<'a> {
     Float64(f64),
     String(&'a str),
     Binary(&'a [u8]),
+    FixedSizeBinary(&'a [u8], u32),
     Date32(i32),
     Date64(i64),
     Timestamp(i64, TimeUnit),
@@ -131,6 +132,12 @@ impl<'a> ValueRef<'a> {
                     .ok_or_else(|| ValueError::InvalidConversion("Binary cast failed".into()))?;
                 Ok(ValueRef::Binary(arr.value(index)))
             }
+            DataType::FixedSizeBinary(w) => {
+                let arr = array.as_fixed_size_binary_opt().ok_or_else(|| {
+                    ValueError::InvalidConversion("FixedSizeBinary cast failed".into())
+                })?;
+                Ok(ValueRef::FixedSizeBinary(arr.value(index), *w as u32))
+            }
             DataType::Date32 => {
                 let arr = array
                     .as_any()
@@ -207,6 +214,7 @@ impl<'a> ValueRef<'a> {
             ValueRef::Float64(_) => DataType::Float64,
             ValueRef::String(_) => DataType::Utf8,
             ValueRef::Binary(_) => DataType::Binary,
+            ValueRef::FixedSizeBinary(_, w) => DataType::FixedSizeBinary(*w as i32),
             ValueRef::Date32(_) => DataType::Date32,
             ValueRef::Date64(_) => DataType::Date64,
             ValueRef::Timestamp(_, unit) => {
@@ -261,6 +269,7 @@ impl ValueRef<'_> {
             ValueRef::Float64(v) => Value::Float64(v),
             ValueRef::String(s) => Value::String(s.to_string()),
             ValueRef::Binary(b) => Value::Binary(b.to_vec()),
+            ValueRef::FixedSizeBinary(b, w) => Value::FixedSizeBinary(b.to_vec(), w),
             ValueRef::Date32(v) => Value::Date32(v),
             ValueRef::Date64(v) => Value::Date64(v),
             ValueRef::Timestamp(v, unit) => Value::Timestamp(v, unit),
@@ -287,6 +296,7 @@ impl<'a> From<&'a Value> for ValueRef<'a> {
             Value::Float64(v) => ValueRef::Float64(*v),
             Value::String(s) => ValueRef::String(s.as_str()),
             Value::Binary(b) => ValueRef::Binary(b.as_slice()),
+            Value::FixedSizeBinary(b, w) => ValueRef::FixedSizeBinary(b.as_slice(), *w),
             Value::Date32(v) => ValueRef::Date32(*v),
             Value::Date64(v) => ValueRef::Date64(*v),
             Value::Timestamp(v, unit) => ValueRef::Timestamp(*v, *unit),
@@ -317,6 +327,7 @@ impl PartialEq for ValueRef<'_> {
             (ValueRef::Float64(a), ValueRef::Float64(b)) => a.to_bits() == b.to_bits(),
             (ValueRef::String(a), ValueRef::String(b)) => a.eq(b),
             (ValueRef::Binary(a), ValueRef::Binary(b)) => a.eq(b),
+            (ValueRef::FixedSizeBinary(a, _), ValueRef::FixedSizeBinary(b, _)) => a.eq(b),
             (ValueRef::Date32(a), ValueRef::Date32(b)) => a.eq(b),
             (ValueRef::Date64(a), ValueRef::Date64(b)) => a.eq(b),
             (ValueRef::Timestamp(a, unit1), ValueRef::Timestamp(b, unit2)) => {
@@ -375,6 +386,7 @@ impl Ord for ValueRef<'_> {
             (ValueRef::Float64(a), ValueRef::Float64(b)) => a.total_cmp(b),
             (ValueRef::String(a), ValueRef::String(b)) => a.cmp(b),
             (ValueRef::Binary(a), ValueRef::Binary(b)) => a.cmp(b),
+            (ValueRef::FixedSizeBinary(a, _), ValueRef::FixedSizeBinary(b, _)) => a.cmp(b),
             (ValueRef::Date32(a), ValueRef::Date32(b)) => a.cmp(b),
             (ValueRef::Date64(a), ValueRef::Date64(b)) => a.cmp(b),
             (ValueRef::Timestamp(a, unit1), ValueRef::Timestamp(b, unit2)) => {
@@ -414,6 +426,7 @@ impl<'a> KeyRef<'a> for ValueRef<'a> {
             ValueRef::Float64(v) => Value::Float64(v),
             ValueRef::String(v) => Value::String(v.to_string()),
             ValueRef::Binary(v) => Value::Binary(v.to_vec()),
+            ValueRef::FixedSizeBinary(v, w) => Value::FixedSizeBinary(v.to_vec(), w),
             ValueRef::Date32(v) => Value::Date32(v),
             ValueRef::Date64(v) => Value::Date64(v),
             ValueRef::Timestamp(v, time_unit) => Value::Timestamp(v, time_unit),
@@ -428,7 +441,10 @@ mod tests {
     use std::sync::Arc;
 
     use arrow::{
-        array::{ArrayRef, Int32Array, StringArray, TimestampMillisecondArray},
+        array::{
+            ArrayRef, BinaryArray, FixedSizeBinaryArray, Int32Array, StringArray,
+            TimestampMillisecondArray,
+        },
         datatypes::DataType,
     };
 
@@ -561,6 +577,36 @@ mod tests {
                 ValueRef::from_array_ref(&array, 1).unwrap(),
                 ValueRef::Timestamp(2, TimeUnit::Millisecond)
             );
+        }
+    }
+
+    #[test]
+    fn test_binary_value_ref_from_array_ref() {
+        {
+            let values: Vec<Option<&[u8]>> = vec![Some(b"one"), Some(b"three"), None];
+            let array = Arc::new(BinaryArray::from(values)) as ArrayRef;
+            assert_eq!(
+                ValueRef::from_array_ref(&array, 0).unwrap(),
+                ValueRef::Binary(b"one")
+            );
+            assert_eq!(
+                ValueRef::from_array_ref(&array, 1).unwrap(),
+                ValueRef::Binary(b"three")
+            );
+            assert_eq!(ValueRef::from_array_ref(&array, 2).unwrap(), ValueRef::Null);
+        }
+        {
+            let values: Vec<Option<&[u8]>> = vec![Some(b"one"), Some(b"two"), None];
+            let array = Arc::new(FixedSizeBinaryArray::from(values)) as ArrayRef;
+            assert_eq!(
+                ValueRef::from_array_ref(&array, 0).unwrap(),
+                ValueRef::FixedSizeBinary(b"one", 3)
+            );
+            assert_eq!(
+                ValueRef::from_array_ref(&array, 1).unwrap(),
+                ValueRef::FixedSizeBinary(b"two", 3)
+            );
+            assert_eq!(ValueRef::from_array_ref(&array, 2).unwrap(), ValueRef::Null);
         }
     }
 }

--- a/src/record/error.rs
+++ b/src/record/error.rs
@@ -1,0 +1,13 @@
+use thiserror::Error;
+
+use crate::record::ValueError;
+
+#[derive(Debug, Error)]
+pub enum RecordError {
+    #[error("value error: {0}")]
+    ValueError(#[source] ValueError),
+    #[error("Null value not allowed: {0}")]
+    NullNotAllowed(String),
+    #[error("Invalid argument : {0}")]
+    InvalidArgumentError(String),
+}

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -1,4 +1,5 @@
 pub mod dynamic;
+pub mod error;
 pub mod key;
 pub mod option;
 #[cfg(test)]


### PR DESCRIPTION


## What changes are included in this PR?

<!--
Summarize the pull request to help reviewers have an easier time to understand what they're reviewing.
-->

- add `Value::FixedSizeBianry(Vec<u8>, u32)` to represent a `FixedSizeBianry` value in arrow
- provide a `DynRecord::try_new()` method to validate when create `DynRecord`

**Note**: I don't verify data in the comparison, which means `FixedSizeBianry(v, 3)` can be compared with `FixedSizeBianry(v, 5)`

## Are these changes tested?

<!--
Specify what test covers (unit test, integration test, etc.).

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

add encode/decode, binary conversions test