### PR TITLE
feat(core)!: composite PK plumbing, Key API change, and Arrow filters

### DIFF
--- a/guide/src/contribution/composite_primary_keys.md
+++ b/guide/src/contribution/composite_primary_keys.md
@@ -2,6 +2,15 @@
 
 This document outlines a practical, incremental plan to add composite (multi-column) primary key support to Tonbo while maintaining backward compatibility. It explains design goals, changes required across the codebase, and a step-by-step implementation and validation plan.
 
+## Current Status (2025-08-11)
+
+- Phase 1: Completed. Plural `Schema` APIs, fixed projections, and Parquet writer configuration are implemented for single-PK schemas.
+  - `Schema` now exposes `primary_key_indices()` and `primary_key_paths_and_sorting()` (src/record/mod.rs). Macro-generated single-PK schemas return one-element slices.
+  - Read paths build fixed projections as `[0, 1] ∪ PKs` using `primary_key_indices()` (src/lib.rs, src/transaction.rs).
+  - `DbOption::new` configures sorting columns (`_ts` then PKs) and enables stats + bloom filters for each PK column path (src/option.rs).
+- Phase 2: Not implemented. Composite key types under `src/record/key/composite/` are placeholders; derive macro still accepts only a single `#[record(primary_key)]` and generates a single-field key. No multi-PK trybuild/integration tests.
+- Phase 3: Not implemented. `DynSchema` remains single-PK (stores one `primary_index_arrow`, one `pk_path`, and sorting with a single PK column).
+
 ## Goals
 
 - Support multi-column primary keys with lexicographic ordering of PK components.

--- a/src/compaction/leveled.rs
+++ b/src/compaction/leveled.rs
@@ -289,6 +289,7 @@ where
                                 None,
                                 ProjectionMask::all(),
                                 None, // Default order for compaction
+                                instance.primary_key_indices(),
                             )
                             .await?,
                     });
@@ -307,6 +308,7 @@ where
                     level_fs.clone(),
                     ctx.parquet_lru.clone(),
                     None, // Default order for compaction
+                    instance.primary_key_indices(),
                 )
                 .ok_or(CompactionError::EmptyLevel)?;
 
@@ -333,6 +335,7 @@ where
                     level_l_fs.clone(),
                     ctx.parquet_lru.clone(),
                     None, // Default order for compaction
+                    instance.primary_key_indices(),
                 )
                 .ok_or(CompactionError::EmptyLevel)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -749,6 +749,7 @@ where
                 TsRef::new(key, ts),
                 projection,
                 ctx.cache().clone(),
+                self.record_schema.primary_key_indices(),
             )
             .await?
             .map(|entry| Entry::RecordBatch(entry)))
@@ -1009,6 +1010,7 @@ where
                 self.limit,
                 self.projection,
                 self.order,
+                self.mem_storage.record_schema.primary_key_indices(),
             )
             .await?;
 
@@ -1070,6 +1072,7 @@ where
                 self.limit,
                 self.projection,
                 self.order,
+                self.mem_storage.record_schema.primary_key_indices(),
             )
             .await?;
         let merge_stream = MergeStream::from_vec(streams, self.ts, self.order).await?;

--- a/src/ondisk/sstable.rs
+++ b/src/ondisk/sstable.rs
@@ -131,9 +131,8 @@ where
         let schema_descriptor = builder.metadata().file_metadata().schema_descr();
         let full_schema = builder.schema().clone();
 
-        // Safety: filter's lifetime relies on range's lifetime, sstable must not live longer than
-        // it
-        let filter = unsafe { get_range_filter::<R>(schema_descriptor, range, ts, pk_indices) };
+        // Build a row filter for ts and primary key range
+        let filter = get_range_filter::<R>(schema_descriptor, range, ts, pk_indices);
 
         Ok(SsTableScan::new(
             builder.with_row_filter(filter).build()?,

--- a/src/record/dynamic/value/mod.rs
+++ b/src/record/dynamic/value/mod.rs
@@ -127,8 +127,8 @@ impl Key for Value {
         ValueRef::from(self)
     }
 
-    fn to_arrow_datum(&self) -> Arc<dyn arrow::array::Datum> {
-        match self {
+    fn to_arrow_datums(&self) -> Vec<Arc<dyn arrow::array::Datum>> {
+        let datum: Arc<dyn arrow::array::Datum> = match self {
             Value::Null => panic!("Null value cannot be converted to arrow datum"),
             Value::Boolean(v) => Arc::new(arrow::array::BooleanArray::new_scalar(*v)),
             Value::Int8(v) => Arc::new(arrow::array::Int8Array::new_scalar(*v)),
@@ -179,7 +179,8 @@ impl Key for Value {
             Value::List(_, _) => {
                 unreachable!("List value cannot be used as primary key.")
             }
-        }
+        };
+        vec![datum]
     }
 }
 

--- a/src/record/key/composite/mod.rs
+++ b/src/record/key/composite/mod.rs
@@ -1,1 +1,118 @@
+#[cfg(test)]
+mod tests {
+    use std::hash::Hash;
 
+    use arrow::array::Datum;
+    use fusio::{SeqRead, Write};
+    use fusio_log::{Decode, Encode};
+
+    use crate::record::{Key, KeyRef};
+
+    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    pub struct Key2<K1: Key, K2: Key>(pub K1, pub K2);
+
+    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    pub struct Key2Ref<'r, R1: KeyRef<'r>, R2: KeyRef<'r>>(
+        pub R1,
+        pub R2,
+        std::marker::PhantomData<&'r ()>,
+    );
+
+    impl<K1: Key, K2: Key> Key for Key2<K1, K2> {
+        type Ref<'r> = Key2Ref<'r, <K1 as Key>::Ref<'r>, <K2 as Key>::Ref<'r>>;
+
+        fn as_key_ref(&self) -> Self::Ref<'_> {
+            Key2Ref(
+                self.0.as_key_ref(),
+                self.1.as_key_ref(),
+                std::marker::PhantomData,
+            )
+        }
+
+        fn to_arrow_datums(&self) -> Vec<std::sync::Arc<dyn Datum>> {
+            let mut out = Vec::new();
+            out.extend(self.0.to_arrow_datums());
+            out.extend(self.1.to_arrow_datums());
+            out
+        }
+    }
+
+    impl<'r, R1, R2> KeyRef<'r> for Key2Ref<'r, R1, R2>
+    where
+        R1: KeyRef<'r>,
+        R2: KeyRef<'r>,
+    {
+        type Key = Key2<R1::Key, R2::Key>;
+
+        fn to_key(self) -> Self::Key {
+            Key2(self.0.to_key(), self.1.to_key())
+        }
+    }
+
+    impl<K1: Key, K2: Key> Encode for Key2<K1, K2> {
+        async fn encode<W>(&self, writer: &mut W) -> Result<(), fusio::Error>
+        where
+            W: Write,
+        {
+            self.0.encode(writer).await?;
+            self.1.encode(writer).await
+        }
+
+        fn size(&self) -> usize {
+            self.0.size() + self.1.size()
+        }
+    }
+
+    impl<'r, R1, R2> Encode for Key2Ref<'r, R1, R2>
+    where
+        R1: KeyRef<'r>,
+        R2: KeyRef<'r>,
+    {
+        async fn encode<W>(&self, writer: &mut W) -> Result<(), fusio::Error>
+        where
+            W: Write,
+        {
+            self.0.encode(writer).await?;
+            self.1.encode(writer).await
+        }
+
+        fn size(&self) -> usize {
+            self.0.size() + self.1.size()
+        }
+    }
+
+    impl<K1: Key, K2: Key> Decode for Key2<K1, K2> {
+        async fn decode<R>(reader: &mut R) -> Result<Self, fusio::Error>
+        where
+            R: SeqRead,
+        {
+            let k1 = K1::decode(reader).await?;
+            let k2 = K2::decode(reader).await?;
+            Ok(Key2(k1, k2))
+        }
+    }
+
+    #[tokio::test]
+    async fn key2_roundtrip_and_order() {
+        let k = Key2("x".to_string(), 10u32);
+        let mut bytes = Vec::new();
+        let mut cursor = std::io::Cursor::new(&mut bytes);
+        k.encode(&mut cursor).await.unwrap();
+        cursor.set_position(0);
+        let k2 = <Key2<String, u32> as Decode>::decode(&mut cursor)
+            .await
+            .unwrap();
+
+        assert_eq!(k, k2);
+        assert!(Key2("a".to_string(), 1u32) < Key2("a".to_string(), 2u32));
+        assert!(Key2("a".to_string(), 1u32) < Key2("b".to_string(), 0u32));
+
+        // Check borrowed ref form encodes properly and converts back to owned
+        let r = Key2Ref::<_, _>("zz", 5u32, std::marker::PhantomData);
+        let mut bytes2 = Vec::new();
+        let mut w = std::io::Cursor::new(&mut bytes2);
+        r.encode(&mut w).await.unwrap();
+        let owned: Key2<String, u32> = r.to_key();
+        assert_eq!(owned, Key2("zz".to_string(), 5));
+    }
+}

--- a/src/record/key/datetime.rs
+++ b/src/record/key/datetime.rs
@@ -141,8 +141,9 @@ macro_rules! make_date_type {
                 *self
             }
 
-            fn to_arrow_datum(&self) -> std::sync::Arc<dyn arrow::array::Datum> {
-                Arc::new(<$array_ty>::new_scalar(self.0))
+            fn to_arrow_datums(&self) -> Vec<std::sync::Arc<dyn arrow::array::Datum>> {
+                vec![Arc::new(<$array_ty>::new_scalar(self.0))
+                    as std::sync::Arc<dyn arrow::array::Datum>]
             }
         }
         impl<'r> KeyRef<'r> for $struct_name {
@@ -207,10 +208,12 @@ impl Key for Time32 {
         *self
     }
 
-    fn to_arrow_datum(&self) -> std::sync::Arc<dyn arrow::array::Datum> {
+    fn to_arrow_datums(&self) -> Vec<std::sync::Arc<dyn arrow::array::Datum>> {
         match self.unit {
-            TimeUnit::Second => Arc::new(Time32SecondArray::new_scalar(self.time)),
-            TimeUnit::Millisecond => Arc::new(Time32MillisecondArray::new_scalar(self.time)),
+            TimeUnit::Second => vec![Arc::new(Time32SecondArray::new_scalar(self.time))
+                as std::sync::Arc<dyn arrow::array::Datum>],
+            TimeUnit::Millisecond => vec![Arc::new(Time32MillisecondArray::new_scalar(self.time))
+                as std::sync::Arc<dyn arrow::array::Datum>],
             TimeUnit::Microsecond | TimeUnit::Nanosecond => {
                 unreachable!("microsecond and nanosecond is not supported")
             }
@@ -225,10 +228,12 @@ impl Key for Time64 {
         *self
     }
 
-    fn to_arrow_datum(&self) -> std::sync::Arc<dyn arrow::array::Datum> {
+    fn to_arrow_datums(&self) -> Vec<std::sync::Arc<dyn arrow::array::Datum>> {
         match self.unit {
-            TimeUnit::Microsecond => Arc::new(Time64MicrosecondArray::new_scalar(self.time)),
-            TimeUnit::Nanosecond => Arc::new(Time64NanosecondArray::new_scalar(self.time)),
+            TimeUnit::Microsecond => vec![Arc::new(Time64MicrosecondArray::new_scalar(self.time))
+                as std::sync::Arc<dyn arrow::array::Datum>],
+            TimeUnit::Nanosecond => vec![Arc::new(Time64NanosecondArray::new_scalar(self.time))
+                as std::sync::Arc<dyn arrow::array::Datum>],
             TimeUnit::Second | TimeUnit::Millisecond => {
                 unreachable!("second and millisecond is not supported")
             }

--- a/src/record/key/mod.rs
+++ b/src/record/key/mod.rs
@@ -22,7 +22,11 @@ pub trait Key:
 
     fn as_key_ref(&self) -> Self::Ref<'_>;
 
-    fn to_arrow_datum(&self) -> Arc<dyn Datum>;
+    /// Returns Arrow scalar Datums corresponding to the primary key columns.
+    ///
+    /// For single-column primary keys, this will return a single-element vector. For composite
+    /// keys, it returns a vector with one Datum per component in lexicographic order.
+    fn to_arrow_datums(&self) -> Vec<Arc<dyn Datum>>;
 }
 
 pub trait KeyRef<'r>: Clone + Encode + Send + Sync + Ord + std::fmt::Debug {

--- a/src/record/key/num.rs
+++ b/src/record/key/num.rs
@@ -18,8 +18,8 @@ macro_rules! implement_key {
                 *self
             }
 
-            fn to_arrow_datum(&self) -> Arc<dyn Datum> {
-                Arc::new($array_name::new_scalar(*self))
+            fn to_arrow_datums(&self) -> Vec<Arc<dyn Datum>> {
+                vec![Arc::new($array_name::new_scalar(*self)) as Arc<dyn Datum>]
             }
         }
 
@@ -135,8 +135,8 @@ macro_rules! implement_float_key {
                 *self
             }
 
-            fn to_arrow_datum(&self) -> Arc<dyn Datum> {
-                Arc::new($array_name::new_scalar(self.0))
+            fn to_arrow_datums(&self) -> Vec<Arc<dyn Datum>> {
+                vec![Arc::new($array_name::new_scalar(self.0)) as Arc<dyn Datum>]
             }
         }
 

--- a/src/record/key/str.rs
+++ b/src/record/key/str.rs
@@ -13,8 +13,8 @@ impl Key for String {
         self
     }
 
-    fn to_arrow_datum(&self) -> Arc<dyn Datum> {
-        Arc::new(StringArray::new_scalar(self))
+    fn to_arrow_datums(&self) -> Vec<Arc<dyn Datum>> {
+        vec![Arc::new(StringArray::new_scalar(self)) as Arc<dyn Datum>]
     }
 }
 

--- a/src/record/key/timestamp.rs
+++ b/src/record/key/timestamp.rs
@@ -90,12 +90,16 @@ impl Key for Timestamp {
         *self
     }
 
-    fn to_arrow_datum(&self) -> std::sync::Arc<dyn arrow::array::Datum> {
+    fn to_arrow_datums(&self) -> Vec<std::sync::Arc<dyn arrow::array::Datum>> {
         match self.unit {
-            TimeUnit::Second => Arc::new(TimestampSecondArray::new_scalar(self.ts)),
-            TimeUnit::Millisecond => Arc::new(TimestampMillisecondArray::new_scalar(self.ts)),
-            TimeUnit::Microsecond => Arc::new(TimestampMicrosecondArray::new_scalar(self.ts)),
-            TimeUnit::Nanosecond => Arc::new(TimestampNanosecondArray::new_scalar(self.ts)),
+            TimeUnit::Second => vec![Arc::new(TimestampSecondArray::new_scalar(self.ts))
+                as std::sync::Arc<dyn arrow::array::Datum>],
+            TimeUnit::Millisecond => vec![Arc::new(TimestampMillisecondArray::new_scalar(self.ts))
+                as std::sync::Arc<dyn arrow::array::Datum>],
+            TimeUnit::Microsecond => vec![Arc::new(TimestampMicrosecondArray::new_scalar(self.ts))
+                as std::sync::Arc<dyn arrow::array::Datum>],
+            TimeUnit::Nanosecond => vec![Arc::new(TimestampNanosecondArray::new_scalar(self.ts))
+                as std::sync::Arc<dyn arrow::array::Datum>],
         }
     }
 }

--- a/src/stream/level.rs
+++ b/src/stream/level.rs
@@ -60,6 +60,7 @@ where
     path: Option<Path>,
     parquet_lru: Arc<dyn DynLruCache<Ulid> + Send + Sync>,
     order: Option<Order>,
+    pk_indices: &'level [usize],
 }
 
 impl<'level, R> LevelStream<'level, R>
@@ -83,6 +84,7 @@ where
         fs: Arc<dyn DynFs>,
         parquet_lru: Arc<dyn DynLruCache<Ulid> + Send + Sync>,
         order: Option<Order>,
+        pk_indices: &'level [usize],
     ) -> Option<Self> {
         let (lower, upper) = range;
         let mut gens: VecDeque<FileId> = version.level_slice[level][start..end + 1]
@@ -112,6 +114,7 @@ where
             path: None,
             parquet_lru,
             order,
+            pk_indices,
         })
     }
 }
@@ -206,6 +209,7 @@ where
                             self.limit,
                             self.projection_mask.clone(),
                             self.order,
+                            self.pk_indices,
                         )));
                         continue;
                     }
@@ -284,6 +288,7 @@ mod tests {
                 manager.base_fs().clone(),
                 Arc::new(NoCache::default()),
                 None, // Default order for test
+                TestSchema {}.primary_key_indices(),
             )
             .unwrap();
 
@@ -324,6 +329,7 @@ mod tests {
                 manager.base_fs().clone(),
                 Arc::new(NoCache::default()),
                 None, // Default order for test
+                TestSchema {}.primary_key_indices(),
             )
             .unwrap();
 
@@ -364,6 +370,7 @@ mod tests {
                 manager.base_fs().clone(),
                 Arc::new(NoCache::default()),
                 None, // Default order for test
+                TestSchema {}.primary_key_indices(),
             )
             .unwrap();
 
@@ -428,6 +435,7 @@ mod tests {
                 manager.base_fs().clone(),
                 Arc::new(NoCache::default()),
                 Some(Order::Desc),
+                TestSchema {}.primary_key_indices(),
             )
             .unwrap();
             let expected = ["6", "5", "4", "3", "2", "1"];


### PR DESCRIPTION
- Key API: replace `Key::to_arrow_datum` with `Key::to_arrow_datums` to supportmulti-component keys; update all builtin `Key` impls (ints/floats/string/date/time/timestamp/dynamic `Value`) to return a single-element Vec for single-PK types.
- Composite key showcase: add `Key2`/`Key2Ref` under `#[cfg(test)]` with `Encode`/`Decode`, `Ord`, `Hash`, `Key`/`KeyRef`; round-trip and ordering tests included.
- Parquet scan filtering: implement lexicographic composite range predicates in`get_range_filter` using `eq/gt/gt_eq/lt/lt_eq` with `and_kleene`/`or_kleene`; retain `_ts` upper-bound predicate.
- Scan plumbing: thread `pk_indices` through `SsTable::{get,scan}`, `Version::{query,streams,table_query}`, and `LevelStream`; update test callers. Build fixed projections as `[0, 1] ∪ pk_indices` in read paths.
- Docs: update composite PK RFC with “Current Status (2025-08-11)”; add draft RFC “Replace Schema Trait with Arrow Schema”.
- Clippy hygiene: remove needless range loops and redundant `.into_iter()`; add a focused `#[allow(clippy::too_many_arguments)]` on `Version::table_query`.

BREAKING CHANGE:
- `Key::to_arrow_datum` was replaced by `Key::to_arrow_datums(Vec<Arc<dyn Datum>>)`; external `Key` implementors must migrate to the new method (return one datum per PK component).