### PR TITLE
refactor: adjust dynamic schema api to support composite key

### DIFF
--- a/bindings/python/src/range.rs
+++ b/bindings/python/src/range.rs
@@ -14,6 +14,7 @@ pub enum Bound {
 
 impl Bound {
     pub(crate) fn to_bound(&self, py: Python, col: &Column) -> ops::Bound<Value> {
+        // TODO: handle multiple primary keys
         match self {
             Bound::Included { key } => ops::Bound::Included(to_col(py, col, key.clone_ref(py))),
             Bound::Excluded { key } => ops::Bound::Excluded(to_col(py, col, key.clone_ref(py))),

--- a/examples/dynamic.rs
+++ b/examples/dynamic.rs
@@ -12,7 +12,7 @@ use tonbo::{
 async fn main() {
     fs::create_dir_all("./db_path/users").unwrap();
 
-    let schema = dyn_schema!(("foo", Utf8, false), ("bar", Int32, true), 0);
+    let schema = dyn_schema!(("foo", Utf8, false), ("bar", Int32, true), [0]);
 
     let options = DbOption::new(
         Path::from_filesystem_path(fs::canonicalize(PathBuf::from("./db_path/users")).unwrap())
@@ -25,7 +25,10 @@ async fn main() {
 
     {
         let mut txn = db.transaction().await;
-        let record = DynRecord::new(vec![Value::String("hello".to_owned()), Value::Int32(1)], 0);
+        let record = DynRecord::new(
+            vec![Value::String("hello".to_owned()), Value::Int32(1)],
+            vec![0],
+        );
         txn.insert(record);
 
         txn.commit().await.unwrap();

--- a/src/compaction/leveled.rs
+++ b/src/compaction/leveled.rs
@@ -728,7 +728,7 @@ pub(crate) mod tests {
                 ArrayDataType::Int32,
                 false,
             )][..],
-            0,
+            &[0],
         );
         let option = DbOption::new(
             Path::from_filesystem_path(temp_dir.path()).unwrap(),
@@ -750,9 +750,9 @@ pub(crate) mod tests {
                 continue;
             }
             if i < 35 && (i % 2 == 0 || i % 5 == 0) {
-                batch1_data.push((LogType::Full, DynRecord::new(vec![col], 0), 0.into()));
+                batch1_data.push((LogType::Full, DynRecord::new(vec![col], vec![0]), 0.into()));
             } else if i >= 7 {
-                batch2_data.push((LogType::Full, DynRecord::new(vec![col], 0), 0.into()));
+                batch2_data.push((LogType::Full, DynRecord::new(vec![col], vec![0]), 0.into()));
             }
         }
 
@@ -771,7 +771,7 @@ pub(crate) mod tests {
         let scope = LeveledCompactor::<DynRecord>::minor_compaction(
             &option,
             None,
-            &vec![
+            &[
                 (Some(generate_file_id()), batch_1),
                 (Some(generate_file_id()), batch_2),
             ],

--- a/src/inmem/mutable.rs
+++ b/src/inmem/mutable.rs
@@ -460,7 +460,7 @@ mod tests {
                 DynamicField::new("age".to_string(), ArrayDataType::Int8, false),
                 DynamicField::new("height".to_string(), ArrayDataType::Int16, true),
             ][..],
-            0,
+            &[0],
         );
         let option = DbOption::new(
             Path::from_filesystem_path(temp_dir.path()).unwrap(),
@@ -480,7 +480,7 @@ mod tests {
         mutable
             .insert(
                 LogType::Full,
-                DynRecord::new(vec![Value::Int8(1_i8), Value::Int16(1236_i16)], 0),
+                DynRecord::new(vec![Value::Int8(1_i8), Value::Int16(1236_i16)], vec![0]),
                 0_u32.into(),
             )
             .await

--- a/src/magic.rs
+++ b/src/magic.rs
@@ -1,2 +1,3 @@
 pub const TS: &str = "_ts";
 pub(crate) const USER_COLUMN_OFFSET: usize = 2;
+pub(crate) const PK_USER_INDICES: &str = "tonbo.primary_key_user_indices";

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1001,7 +1001,7 @@ mod tests {
                 Value::Int16(180_i16),
                 Value::Int32(56_i32),
             ],
-            0,
+            vec![0],
         ))
         .await
         .unwrap();
@@ -1033,7 +1033,7 @@ mod tests {
                 .await
                 .unwrap();
             while let Some(entry) = scan.next().await.transpose().unwrap() {
-                assert_eq!(entry.value().unwrap().primary_index, 0);
+                assert_eq!(entry.value().unwrap().primary_indices.as_slice(), &[0]);
                 assert_eq!(entry.value().unwrap().columns.len(), 3);
                 let columns = entry.value().unwrap().columns;
                 dbg!(columns.clone());

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -25,7 +25,7 @@ mod tests {
             DynamicField::new("email".to_string(), DataType::Utf8, true),
             DynamicField::new("bytes".to_string(), DataType::Binary, true),
         ];
-        DynSchema::new(&descs, 0)
+        DynSchema::new(&descs, &[0])
     }
 
     fn test_dyn_items() -> Vec<DynRecord> {
@@ -39,7 +39,7 @@ mod tests {
                 Value::Binary((i as i32).to_le_bytes().to_vec()),
             ];
 
-            items.push(DynRecord::new(columns, 0));
+            items.push(DynRecord::new(columns, vec![0]));
         }
         items
     }


### PR DESCRIPTION
## What changes are included in this PR?

adjust dynamic schema api to support composite key in the future.



**BREAKING CHANGE**:
- `DynRecord::new(Vec<Value>, usize)` --> `DynRecord::new(Vec<Value>, Vec<usize>)`
- `DynSchema::new(Vec<DynamicField>, usize)` --> `DynRecord::new(Vec<DynamicField>, Vec<usize>)`
- `dyn_schema!(fields, ..., 0)` --> `dyn_schema!(fields, ..., [0])`
- `make_dyn_schema(fields ..., 0)` --> `make_dyn_schema(fields ..., [0])`