### PR TITLE
chore: restore gitignore patterns and tidy wal rfc formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,16 @@
 /target
 Cargo.lock
 .serena
+/.idea
+db_path
+guide/book
+
+# python
+__pycache__
+*.so
+
+# node
+node_modules
+dist
+
+.DS_Store

--- a/docs/rfcs/0002-wal.md
+++ b/docs/rfcs/0002-wal.md
@@ -27,7 +27,7 @@ Path: `/Users/gwo/Idea/seren`
 
 High-level model:
 
-- Sequential log with framed records supporting fragmentation: `Full/First/Middle/Last` frames per logical record (refer to [the type design of RocksDB](https://github.com/facebook/rocksdb/wiki/Write-Ahead-Log-File-Format#record-format)).
+- Sequential log with framed records supporting fragmentation: `Full/First/Middle/Last` frames per logical record (refer to [the type design of RocksDB](https://github.com/facebook/rocksdb/wiki/Write-Ahead-Log-File-Format)).
 - Records capture ingests and transactional groupings; recovery scans until the first invalid frame and replays valid records.
 - Commit timestamps are logical and reassigned on recovery while preserving ingest order.
 
@@ -103,7 +103,8 @@ Autocommit fast path:
 
 ## Recovery Algorithm
 
-1. Discover WAL files by name; sort by `start_seq`. Validate headers. 2. Sequentially scan frames:
+1. Discover WAL files by name; sort by `start_seq`. Validate headers.
+2. Sequentially scan frames:
    - Verify `len` and `crc32c`; stop at the first invalid/incomplete frame.
    - Maintain an in-memory map `provisional_id -> buffered appends`.
    - `TxnBegin`: create an empty buffer for `provisional_id`.
@@ -111,7 +112,9 @@ Autocommit fast path:
    - `TxnCommit`: apply buffered appends to the mutable store using the provided `commit_ts`; clear the buffer.
    - `TxnAbort`: drop any buffered appends.
    - `SealMarker`: optional bookkeeping; can be ignored initially.
-3. If recovery ends with open provisional txns (no commit), discard them. 4. Track last applied sequence and compute `last_commit_ts = max(commit_ts)` across commits; initialize the in-memory commit counter to `last_commit_ts + 1`. 5. On schema mismatch (dynamic), abort with a clear error.
+3. If recovery ends with open provisional txns (no commit), discard them.
+4. Track last applied sequence and compute `last_commit_ts = max(commit_ts)` across commits; initialize the in-memory commit counter to `last_commit_ts + 1`.
+5. On schema mismatch (dynamic), abort with a clear error.
 
 ## Integration Points
 


### PR DESCRIPTION
## Which issue does this PR close?
None

## What changes are included in this PR?
- reintroduce the IDE, Python, Node, and macOS ignore rules while keeping the new .serena entry
- fix formatting in the WAL RFC by cleaning up the RocksDB link and expanding the recovery algorithm list


## Are these changes tested?
No need, no code has been changed
