### PR TITLE
fix(sstable): retain wal ids with sstable descriptor

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -286,11 +286,7 @@ impl<M: Mode, E: Executor + Timer> DB<M, E> {
             .filter_map(|ids| ids.as_ref())
             .flat_map(|ids| ids.clone())
             .collect();
-        let wal_ids = if wal_ids_flat.is_empty() {
-            None
-        } else {
-            Some(wal_ids_flat)
-        };
+        let wal_ids = (!wal_ids_flat.is_empty()).then_some(wal_ids_flat);
         builder.set_wal_ids(wal_ids);
 
         match builder.finish().await {


### PR DESCRIPTION
## Which issue does this PR close?

It address this issue: https://github.com/tonbo-io/tonbo/pull/506#discussion_r2466450182

## What changes are included in this PR?

* Retain wal_ids of `ParquetTableWriter` to `SstableDescriptor` 
* Add a test to make sure descriptor can see wal ids. 

## Are these changes tested?

`cargo +nightly fmt` `cargo test`