### PR TITLE
feat: optimize Parquet pruning with bloom filters, caching, and page indexes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ arrow-buffer = "57.1.0"
 arrow-ipc = "57.1.0"
 arrow-schema = { version = "57.1.0", features = ["serde"] }
 arrow-select = "57.1.0"
+bytes = "1"
 crc32c = "0.6"
 crossbeam-skiplist = "0.1"
 datafusion-common = "51.0.0"

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -4,8 +4,12 @@
 //! the earlier `Mode` trait indirection has been removed to simplify the core
 //! engine while we focus on a single runtime representation.
 
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex, MutexGuard},
+};
 
+use aisle::Pruner;
 use arrow_array::RecordBatch;
 use arrow_schema::{ArrowError, SchemaRef};
 use fusio::{
@@ -44,7 +48,11 @@ use crate::{
         WalSegmentRef,
     },
     mvcc::{CommitClock, ReadView, Timestamp},
-    ondisk::sstable::{SsTable, SsTableBuilder, SsTableConfig, SsTableDescriptor, SsTableError},
+    ondisk::{
+        bloom::{BloomFilterCache, default_bloom_cache},
+        metadata::{ParquetMetadataCache, default_parquet_metadata_cache},
+        sstable::{SsTable, SsTableBuilder, SsTableConfig, SsTableDescriptor, SsTableError},
+    },
     transaction::{Snapshot as TxSnapshot, SnapshotError, TransactionDurability, TransactionError},
     wal::{
         WalConfig as RuntimeWalConfig, WalHandle, frame::INITIAL_FRAME_SEQ, manifest_ext,
@@ -62,6 +70,7 @@ pub use crate::{
 
 /// Internal shared handle for the database backed by an `Arc`.
 pub(crate) type DynDbHandle<FS, E> = Arc<DbInner<FS, E>>;
+type PrunerCache = HashMap<String, Arc<Pruner>>;
 
 /// Metadata about a committed database version.
 ///
@@ -382,6 +391,12 @@ where
     /// Manifest handle with concrete filesystem type for static dispatch.
     manifest: TonboManifest<FS, E>,
     manifest_table: TableId,
+    /// Cached bloom filters for remote SST pruning.
+    bloom_cache: Arc<E::Mutex<BloomFilterCache>>,
+    /// Cached Aisle pruners keyed by schema fingerprint.
+    pruner_cache: Arc<E::Mutex<PrunerCache>>,
+    /// Cached Parquet metadata for SST pruning.
+    metadata_cache: Arc<E::Mutex<ParquetMetadataCache>>,
     /// WAL frame bounds covering the current mutable memtable, if any.
     mutable_wal_range: Arc<Mutex<Option<WalFrameRange>>>,
     /// Per-key transactional locks (wired once transactional writes arrive).
@@ -429,6 +444,12 @@ where
     /// Manifest handle with concrete filesystem type for static dispatch.
     manifest: TonboManifest<FS, E>,
     manifest_table: TableId,
+    /// Cached bloom filters for remote SST pruning.
+    bloom_cache: Arc<E::Mutex<BloomFilterCache>>,
+    /// Cached Aisle pruners keyed by schema fingerprint.
+    pruner_cache: Arc<E::Mutex<PrunerCache>>,
+    /// Cached Parquet metadata for SST pruning.
+    metadata_cache: Arc<E::Mutex<ParquetMetadataCache>>,
     /// WAL frame bounds covering the current mutable memtable, if any.
     mutable_wal_range: Arc<Mutex<Option<WalFrameRange>>>,
     /// Per-key transactional locks (wired once transactional writes arrive).
@@ -485,6 +506,21 @@ where
         self.mem.delete_projection()
     }
 
+    /// Access the shared bloom filter cache for pruning.
+    pub(crate) fn bloom_cache(&self) -> Arc<E::Mutex<BloomFilterCache>> {
+        Arc::clone(&self.bloom_cache)
+    }
+
+    /// Access the shared pruner cache for pruning.
+    pub(crate) fn pruner_cache(&self) -> Arc<E::Mutex<PrunerCache>> {
+        Arc::clone(&self.pruner_cache)
+    }
+
+    /// Access the shared Parquet metadata cache for pruning.
+    pub(crate) fn metadata_cache(&self) -> Arc<E::Mutex<ParquetMetadataCache>> {
+        Arc::clone(&self.metadata_cache)
+    }
+
     /// Acquire a read guard to the mutable memtable (for testing/inspection).
     #[cfg(all(test, feature = "tokio"))]
     pub(crate) fn mem_read(&self) -> crate::inmem::mutable::memtable::TestMemRef<'_> {
@@ -538,6 +574,9 @@ where
             commit_clock: CommitClock::default(),
             manifest,
             manifest_table,
+            bloom_cache: default_bloom_cache::<E>(),
+            pruner_cache: Arc::new(E::mutex(HashMap::new())),
+            metadata_cache: default_parquet_metadata_cache::<E>(),
             mutable_wal_range: Arc::new(Mutex::new(None)),
             _key_locks: Arc::new(LockableHashMap::new()),
             compaction_worker: None,

--- a/src/mode/mod.rs
+++ b/src/mode/mod.rs
@@ -108,7 +108,7 @@ pub(crate) fn table_definition(config: &DynModeConfig, table_name: &str) -> Tabl
     }
 }
 
-fn fingerprint_schema(schema: &SchemaRef) -> String {
+pub(crate) fn fingerprint_schema(schema: &SchemaRef) -> String {
     let mut hasher = Sha256::new();
     let value =
         serde_json::to_value(schema.as_ref()).expect("arrow schema serialization should not fail");

--- a/src/ondisk/bloom.rs
+++ b/src/ondisk/bloom.rs
@@ -1,0 +1,294 @@
+//! Bloom filter loading utilities for Parquet-backed SSTs.
+
+use std::{
+    collections::{HashMap, VecDeque},
+    ops::Range,
+    sync::Arc,
+};
+
+use bytes::Bytes;
+use fusio::{
+    dynamic::DynFile,
+    executor::{Executor, Mutex},
+};
+use fusio_parquet::reader::AsyncReader;
+use futures::FutureExt;
+use parquet::{
+    arrow::{arrow_reader::ArrowReaderOptions, async_reader::AsyncFileReader},
+    bloom_filter::Sbbf,
+    errors::ParquetError,
+    file::metadata::ParquetMetaData,
+};
+
+use crate::ondisk::scan::UnpinExec;
+
+const DEFAULT_BLOOM_CACHE_ENTRIES: usize = 256;
+const DEFAULT_RANGE_COALESCE_GAP_BYTES: u64 = 64 * 1024;
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+struct BloomCacheKey {
+    path: fusio::path::Path,
+    row_group: usize,
+    column: usize,
+}
+
+#[derive(Debug)]
+pub(crate) struct BloomFilterCache {
+    max_entries: usize,
+    order: VecDeque<BloomCacheKey>,
+    entries: HashMap<BloomCacheKey, Sbbf>,
+}
+
+impl BloomFilterCache {
+    pub(crate) fn new(max_entries: usize) -> Self {
+        Self {
+            max_entries: max_entries.max(1),
+            order: VecDeque::new(),
+            entries: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn default() -> Self {
+        Self::new(DEFAULT_BLOOM_CACHE_ENTRIES)
+    }
+
+    fn get(&self, key: &BloomCacheKey) -> Option<Sbbf> {
+        self.entries.get(key).cloned()
+    }
+
+    fn insert(&mut self, key: BloomCacheKey, value: Sbbf) {
+        if let std::collections::hash_map::Entry::Occupied(mut entry) =
+            self.entries.entry(key.clone())
+        {
+            entry.insert(value);
+            return;
+        }
+        self.order.push_back(key.clone());
+        self.entries.insert(key, value);
+        while self.entries.len() > self.max_entries {
+            if let Some(evicted) = self.order.pop_front() {
+                self.entries.remove(&evicted);
+            }
+        }
+    }
+}
+
+pub(crate) struct BatchedAsyncReader<E>
+where
+    E: Executor + Clone + 'static,
+{
+    inner: AsyncReader<UnpinExec<E>>,
+    coalesce_gap_bytes: u64,
+}
+
+impl<E> BatchedAsyncReader<E>
+where
+    E: Executor + Clone + 'static,
+{
+    pub(crate) async fn new(
+        file: Box<dyn DynFile>,
+        content_length: u64,
+        executor: E,
+    ) -> Result<Self, fusio::error::Error> {
+        Ok(Self {
+            inner: AsyncReader::new(file, content_length, UnpinExec(executor)).await?,
+            coalesce_gap_bytes: DEFAULT_RANGE_COALESCE_GAP_BYTES,
+        })
+    }
+}
+
+impl<E> AsyncFileReader for BatchedAsyncReader<E>
+where
+    E: Executor + Clone + 'static,
+{
+    fn get_bytes(
+        &mut self,
+        range: Range<u64>,
+    ) -> futures::future::BoxFuture<'_, Result<Bytes, ParquetError>> {
+        self.inner.get_bytes(range)
+    }
+
+    fn get_byte_ranges(
+        &mut self,
+        ranges: Vec<Range<u64>>,
+    ) -> futures::future::BoxFuture<'_, Result<Vec<Bytes>, ParquetError>> {
+        async move {
+            if ranges.is_empty() {
+                return Ok(Vec::new());
+            }
+            let mut indexed: Vec<(usize, Range<u64>)> = ranges.into_iter().enumerate().collect();
+            indexed.sort_by_key(|(_, range)| range.start);
+            let total_ranges = indexed.len();
+
+            struct Batch {
+                start: u64,
+                end: u64,
+                items: Vec<(usize, Range<u64>)>,
+            }
+
+            let mut batches: Vec<Batch> = Vec::new();
+            for (idx, range) in indexed {
+                if let Some(last) = batches.last_mut()
+                    && range.start <= last.end.saturating_add(self.coalesce_gap_bytes)
+                {
+                    last.end = last.end.max(range.end);
+                    last.items.push((idx, range));
+                    continue;
+                }
+                batches.push(Batch {
+                    start: range.start,
+                    end: range.end,
+                    items: vec![(idx, range)],
+                });
+            }
+
+            let mut results: Vec<Option<Bytes>> = vec![None; total_ranges];
+            for batch in batches {
+                let buffer = self.inner.get_bytes(batch.start..batch.end).await?;
+                for (idx, range) in batch.items {
+                    let offset = (range.start - batch.start) as usize;
+                    let len = (range.end - range.start) as usize;
+                    results[idx] = Some(buffer.slice(offset..offset + len));
+                }
+            }
+
+            let mut output = Vec::with_capacity(results.len());
+            for item in results {
+                let Some(bytes) = item else {
+                    return Err(ParquetError::General(
+                        "missing range result for bloom filter batch".to_string(),
+                    ));
+                };
+                output.push(bytes);
+            }
+            Ok(output)
+        }
+        .boxed()
+    }
+
+    fn get_metadata<'a>(
+        &'a mut self,
+        options: Option<&'a ArrowReaderOptions>,
+    ) -> futures::future::BoxFuture<'a, Result<Arc<ParquetMetaData>, ParquetError>> {
+        self.inner.get_metadata(options)
+    }
+}
+
+pub(crate) struct SstBloomFilterProvider<E>
+where
+    E: Executor + Clone + 'static,
+{
+    path: fusio::path::Path,
+    metadata: Arc<ParquetMetaData>,
+    reader: BatchedAsyncReader<E>,
+    cache: Arc<E::Mutex<BloomFilterCache>>,
+}
+
+impl<E> SstBloomFilterProvider<E>
+where
+    E: Executor + Clone + 'static,
+{
+    pub(crate) fn new(
+        path: fusio::path::Path,
+        metadata: Arc<ParquetMetaData>,
+        reader: BatchedAsyncReader<E>,
+        cache: Arc<E::Mutex<BloomFilterCache>>,
+    ) -> Self {
+        Self {
+            path,
+            metadata,
+            reader,
+            cache,
+        }
+    }
+
+    fn cache_key(&self, row_group_idx: usize, column_idx: usize) -> BloomCacheKey {
+        BloomCacheKey {
+            path: self.path.clone(),
+            row_group: row_group_idx,
+            column: column_idx,
+        }
+    }
+
+    async fn lookup_cached(&self, key: &BloomCacheKey) -> Option<Sbbf> {
+        let guard = self.cache.lock().await;
+        guard.get(key)
+    }
+
+    async fn insert_cache(&self, key: BloomCacheKey, filter: Sbbf) {
+        let mut guard = self.cache.lock().await;
+        guard.insert(key, filter);
+    }
+
+    fn bloom_range(&self, row_group_idx: usize, column_idx: usize) -> Option<Range<u64>> {
+        let row_group = self.metadata.row_group(row_group_idx);
+        let column = row_group.column(column_idx);
+        let offset: u64 = column.bloom_filter_offset()?.try_into().ok()?;
+        let length: u64 = column.bloom_filter_length()?.try_into().ok()?;
+        Some(offset..offset + length)
+    }
+}
+
+impl<E> aisle::AsyncBloomFilterProvider for SstBloomFilterProvider<E>
+where
+    E: Executor + Clone + 'static,
+{
+    async fn bloom_filter(&mut self, row_group_idx: usize, column_idx: usize) -> Option<Sbbf> {
+        let key = self.cache_key(row_group_idx, column_idx);
+        if let Some(filter) = self.lookup_cached(&key).await {
+            return Some(filter);
+        }
+
+        let range = self.bloom_range(row_group_idx, column_idx)?;
+        let bytes = self.reader.get_bytes(range).await.ok()?;
+        let filter = Sbbf::from_bytes(bytes.as_ref()).ok()?;
+        self.insert_cache(key, filter.clone()).await;
+        Some(filter)
+    }
+
+    async fn bloom_filters_batch<'a>(
+        &'a mut self,
+        requests: &'a [(usize, usize)],
+    ) -> HashMap<(usize, usize), Sbbf> {
+        let mut result = HashMap::new();
+        let mut misses: Vec<(usize, usize, Range<u64>)> = Vec::new();
+
+        for &(row_group_idx, column_idx) in requests {
+            let key = self.cache_key(row_group_idx, column_idx);
+            if let Some(filter) = self.lookup_cached(&key).await {
+                result.insert((row_group_idx, column_idx), filter);
+                continue;
+            }
+            if let Some(range) = self.bloom_range(row_group_idx, column_idx) {
+                misses.push((row_group_idx, column_idx, range));
+            }
+        }
+
+        if misses.is_empty() {
+            return result;
+        }
+
+        let ranges: Vec<Range<u64>> = misses.iter().map(|(_, _, range)| range.clone()).collect();
+        let bytes = match self.reader.get_byte_ranges(ranges).await {
+            Ok(bytes) => bytes,
+            Err(_) => return result,
+        };
+
+        for ((row_group_idx, column_idx, _range), blob) in misses.into_iter().zip(bytes) {
+            if let Ok(filter) = Sbbf::from_bytes(blob.as_ref()) {
+                let key = self.cache_key(row_group_idx, column_idx);
+                self.insert_cache(key, filter.clone()).await;
+                result.insert((row_group_idx, column_idx), filter);
+            }
+        }
+
+        result
+    }
+}
+
+pub(crate) fn default_bloom_cache<E>() -> Arc<E::Mutex<BloomFilterCache>>
+where
+    E: Executor + Clone + 'static,
+{
+    Arc::new(E::mutex(BloomFilterCache::default()))
+}

--- a/src/ondisk/metadata.rs
+++ b/src/ondisk/metadata.rs
@@ -1,0 +1,63 @@
+//! Parquet metadata caching utilities for SST planning.
+
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::Arc,
+};
+
+use parquet::file::metadata::ParquetMetaData;
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+struct CacheKey {
+    path: fusio::path::Path,
+}
+
+#[derive(Debug)]
+pub(crate) struct ParquetMetadataCache {
+    max_entries: usize,
+    order: VecDeque<CacheKey>,
+    entries: HashMap<CacheKey, Arc<ParquetMetaData>>,
+}
+
+impl ParquetMetadataCache {
+    pub(crate) fn new(max_entries: usize) -> Self {
+        Self {
+            max_entries: max_entries.max(1),
+            order: VecDeque::new(),
+            entries: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn default() -> Self {
+        Self::new(256)
+    }
+
+    pub(crate) fn get(&self, path: &fusio::path::Path) -> Option<Arc<ParquetMetaData>> {
+        let key = CacheKey { path: path.clone() };
+        self.entries.get(&key).cloned()
+    }
+
+    pub(crate) fn insert(&mut self, path: &fusio::path::Path, metadata: Arc<ParquetMetaData>) {
+        let key = CacheKey { path: path.clone() };
+        if let std::collections::hash_map::Entry::Occupied(mut entry) =
+            self.entries.entry(key.clone())
+        {
+            entry.insert(metadata);
+            return;
+        }
+        self.order.push_back(key.clone());
+        self.entries.insert(key, metadata);
+        while self.entries.len() > self.max_entries {
+            if let Some(evicted) = self.order.pop_front() {
+                self.entries.remove(&evicted);
+            }
+        }
+    }
+}
+
+pub(crate) fn default_parquet_metadata_cache<E>() -> Arc<E::Mutex<ParquetMetadataCache>>
+where
+    E: fusio::executor::Executor + Clone + 'static,
+{
+    Arc::new(E::mutex(ParquetMetadataCache::default()))
+}

--- a/src/ondisk/mod.rs
+++ b/src/ondisk/mod.rs
@@ -13,3 +13,9 @@ pub mod merge;
 
 /// Scan stream for a sstable
 pub mod scan;
+
+/// Bloom filter loading utilities for pruning.
+pub mod bloom;
+
+/// Parquet metadata caching utilities.
+pub mod metadata;

--- a/src/ondisk/sstable.rs
+++ b/src/ondisk/sstable.rs
@@ -41,6 +41,7 @@ use parquet::{
         metadata::{PageIndexPolicy, ParquetMetaData, ParquetMetaDataReader},
         properties::{EnabledStatistics, WriterProperties},
     },
+    schema::types::ColumnPath,
 };
 use serde::{Deserialize, Serialize};
 
@@ -63,6 +64,7 @@ use crate::{
 };
 
 const MVCC_SEQUENCE_COL: &str = "_sequence";
+const SST_DATA_PAGE_SIZE_LIMIT: usize = 8 * 1024 * 1024;
 
 /// Identifier for an SSTable stored on disk.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -83,6 +85,8 @@ impl SsTableId {
 /// Default iteration budget used by merge operations to guard against runaway loops.
 /// `usize::MAX` disables the guard; set explicitly via config when debugging.
 pub const DEFAULT_MERGE_ITERATION_BUDGET: usize = usize::MAX;
+/// Default maximum number of rows per Parquet row group (Parquet default is 1M rows).
+pub const DEFAULT_MAX_ROW_GROUP_ROWS: usize = 1024 * 1024;
 
 /// Configuration bundle shared by SSTable builders and readers.
 #[derive(Clone)]
@@ -94,6 +98,7 @@ pub struct SsTableConfig {
     root: Path,
     key_extractor: Option<Arc<dyn KeyProjection>>,
     merge_iteration_budget: usize,
+    max_row_group_rows: usize,
 }
 
 impl SsTableConfig {
@@ -107,6 +112,7 @@ impl SsTableConfig {
             root,
             key_extractor: None,
             merge_iteration_budget: DEFAULT_MERGE_ITERATION_BUDGET,
+            max_row_group_rows: DEFAULT_MAX_ROW_GROUP_ROWS,
         }
     }
 
@@ -176,6 +182,17 @@ impl SsTableConfig {
     pub fn merge_iteration_budget(&self) -> usize {
         self.merge_iteration_budget
     }
+
+    /// Configure the maximum number of rows per Parquet row group.
+    pub fn with_max_row_group_rows(mut self, rows: usize) -> Self {
+        self.max_row_group_rows = rows.max(1);
+        self
+    }
+
+    /// Access the configured maximum row group row count.
+    pub fn max_row_group_rows(&self) -> usize {
+        self.max_row_group_rows
+    }
 }
 
 impl fmt::Debug for SsTableConfig {
@@ -187,6 +204,7 @@ impl fmt::Debug for SsTableConfig {
             .field("root", &self.root)
             .field("has_key_extractor", &self.key_extractor.is_some())
             .field("merge_iteration_budget", &self.merge_iteration_budget)
+            .field("max_row_group_rows", &self.max_row_group_rows)
             .finish()
     }
 }
@@ -655,8 +673,30 @@ impl ParquetTableWriter {
     }
 }
 
-fn writer_properties(compression: SsTableCompression) -> WriterProperties {
-    let builder = match compression {
+fn bloom_filter_columns(config: &SsTableConfig, schema: &SchemaRef) -> Vec<ColumnPath> {
+    // Bloom filters add write CPU and file size; restrict to key columns to target
+    // high-cardinality point lookups without bloating all columns.
+    let Some(extractor) = config.key_extractor() else {
+        return Vec::new();
+    };
+    let base_schema = config.schema();
+    extractor
+        .key_indices()
+        .iter()
+        .filter_map(|index| {
+            base_schema.fields().get(*index).and_then(|field| {
+                if schema.field_with_name(field.name()).is_ok() {
+                    Some(ColumnPath::from(field.name().as_str()))
+                } else {
+                    None
+                }
+            })
+        })
+        .collect()
+}
+
+fn writer_properties(config: &SsTableConfig, schema: &SchemaRef) -> WriterProperties {
+    let mut builder = match config.compression() {
         SsTableCompression::None => {
             WriterProperties::builder().set_compression(Compression::UNCOMPRESSED)
         }
@@ -664,11 +704,16 @@ fn writer_properties(compression: SsTableCompression) -> WriterProperties {
             WriterProperties::builder().set_compression(Compression::ZSTD(ZstdLevel::default()))
         }
     };
-    builder
+    builder = builder
         // Always emit page indexes for SST reads.
         .set_statistics_enabled(EnabledStatistics::Page)
         .set_offset_index_disabled(false)
-        .build()
+        .set_data_page_size_limit(SST_DATA_PAGE_SIZE_LIMIT)
+        .set_max_row_group_size(config.max_row_group_rows());
+    for column in bloom_filter_columns(config, schema) {
+        builder = builder.set_column_bloom_filter_enabled(column, true);
+    }
+    builder.build()
 }
 
 /// Append the `_commit_ts` column to a record batch for persistence.
@@ -723,6 +768,7 @@ struct WriteContext<E>
 where
     E: Executor + Clone,
 {
+    config: Arc<SsTableConfig>,
     fs: Arc<dyn DynFs>,
     data_path: Path,
     delete_path: Path,
@@ -760,13 +806,15 @@ where
             config.schema().metadata().clone(),
         ));
 
+        let data_properties = writer_properties(config.as_ref(), &data_schema);
         let data_writer = AsyncArrowWriter::try_new(
             AsyncWriter::new(data_file, executor.clone()),
             data_schema,
-            Some(writer_properties(config.compression())),
+            Some(data_properties),
         )?;
 
         Ok(Self {
+            config: Arc::clone(&config),
             fs,
             data_path,
             data_writer: Some(data_writer),
@@ -804,7 +852,7 @@ where
             let writer = AsyncArrowWriter::try_new(
                 AsyncWriter::new(file, self.executor.clone()),
                 batch.schema(),
-                Some(writer_properties(self.compression)),
+                Some(writer_properties(self.config.as_ref(), &batch.schema())),
             )?;
             self.delete_writer = Some(writer);
         }


### PR DESCRIPTION
## Summary
- Enable Parquet page indexes and key-column bloom filters for SST writes to improve pruning effectiveness.
- Add batched async bloom filter loading with caching to reduce S3 request overhead.
- Cache Parquet metadata and Aisle pruners by schema to avoid repeat parsing/compilation.
- Add configurable max row-group rows in `SsTableConfig` (default 1M) to support future tuning.

## Testing
- `cargo +nightly fmt --all -- --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo build --verbose`
- `cargo test --verbose`
- `cargo llvm-cov --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 80`
- `cargo test public_api_e2e:: -- --nocapture`

## Notes
- Optional Step 3.6 work is partially complete: row-group sizing is implemented; column ordering and sort-by filtered columns are deferred (documented in `.personal/in_progress/TONBO_INTEGRATION_STEP3.md`).
