### PR TITLE
fix: make tracing std explicit for tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ js-sys = "0.3"
 clap = { version = "4.5.4", features = ["derive"] }
 futures = "0.3"
 tempfile = "3"
+tracing = { version = "0.1", default-features = false, features = ["attributes", "std"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 typed-arrow = { version = "0.6.0", default-features = false, features = ["arrow-57", "ext-hooks", "views"] }
 


### PR DESCRIPTION
Summary:
- Make `tracing/std` explicit for tests so `tracing::subscriber::with_default` is guaranteed.
- Avoid relying on transitive feature unification from dev dependencies.

Tests:
- `cargo +nightly fmt --all -- --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo build --verbose`
- `cargo test --verbose`
- `cargo llvm-cov --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 80`
- LocalStack bootstrap + `cargo test public_api_e2e:: -- --nocapture`
