### PR TITLE
refactor: rely on auto Send/Sync for DbInner

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -462,26 +462,6 @@ where
     minor_compaction: Option<MinorCompactionState>,
 }
 
-// SAFETY: DbInner shares internal state behind explicit synchronization.
-unsafe impl<FS, E> Send for DbInner<FS, E>
-where
-    FS: ManifestFs<E>,
-    E: Executor + Timer + Clone + Send + Sync,
-    DynMem: Send + Sync,
-    <FS as fusio::fs::Fs>::File: fusio::durability::FileCommit,
-{
-}
-
-// SAFETY: See rationale above for `Send`; read access is synchronized via external locks.
-unsafe impl<FS, E> Sync for DbInner<FS, E>
-where
-    FS: ManifestFs<E>,
-    E: Executor + Timer + Clone + Send + Sync,
-    DynMem: Send + Sync,
-    <FS as fusio::fs::Fs>::File: fusio::durability::FileCommit,
-{
-}
-
 impl<FS, E> DbInner<FS, E>
 where
     FS: ManifestFs<E>,


### PR DESCRIPTION
## Summary
- Remove manual `unsafe impl Send/Sync` for `DbInner` so auto-trait checks enforce thread-safety based on fields.
- Let the compiler catch non-`Send`/`Sync` additions instead of masking them.

## Testing
- `cargo +nightly fmt --all -- --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo build --verbose`
- `cargo test --verbose`
- `cargo llvm-cov --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 80`
- `cargo test public_api_e2e:: -- --nocapture`
