### PR TITLE
feat: ship single-process root-set SST GC with snapshot pinning

### DIFF
--- a/benches/compaction/README.md
+++ b/benches/compaction/README.md
@@ -7,6 +7,9 @@ This benchmark suite lives in `benches/compaction_local.rs` and now supports:
 - Tail latency reporting (p50/p95/p99 in addition to mean).
 - A directional report block for `read_baseline` vs `read_compaction_quiesced`.
 
+For the SST-GC pre-enablement baseline workflow, use
+`benches/compaction/sst_gc_baseline.md`.
+
 ## Program Context
 
 This suite is one current engine-layer benchmark inside Tonbo's broader
@@ -224,6 +227,36 @@ Semantics:
 - Logical should be used as the primary compaction-effectiveness metric because it tracks manifest-visible live state.
 - Physical remains useful for debugging storage amplification and cleanup lag.
 
+For schema `11+` artifacts, setup payloads may also include `setup.gc_observation` for
+GC-enabled scenarios. This captures:
+
+- `volume_before_gc` and `volume_after_gc`
+- `physical_stale_estimate_before_explicit_sweep` and `physical_stale_estimate_after_explicit_sweep`
+- `persisted_plan_before_explicit_sweep` and `persisted_plan_after_explicit_sweep`
+- `reclaimed_sst_objects` and `reclaimed_sst_bytes`
+- `explicit_sweep_result.deleted_objects`
+- `explicit_sweep_result.deleted_bytes`
+- `explicit_sweep_result.delete_failures`
+- `explicit_sweep_result.duration_ms`
+- cumulative counters before/after the explicit sweep, including:
+  `sweep_runs`, `deleted_objects`, `deleted_bytes`, `delete_failures`,
+  `sweep_duration_ms_total`, `gc_plan_write_runs`, `gc_plan_overwrite_non_empty`,
+  `gc_plan_take_runs`, `gc_plan_taken_sst_candidates`,
+  `gc_plan_authorized_sst_candidates`, `gc_plan_blocked_sst_candidates`,
+  `gc_plan_requeued_sst_candidates`
+
+Interpretation:
+
+- `physical_stale_estimate_*` is a physical-vs-logical SST storage delta estimate. It is not the persisted GC plan.
+- `persisted_plan_*` is the manifest GC plan at the explicit sweep observation point, including the currently authorized subset.
+- `explicit_sweep_result.*` is what that explicit benchmark sweep invocation actually deleted.
+- A non-zero `physical_stale_estimate_before_explicit_sweep` with `persisted_plan_before_explicit_sweep = null` means stale-looking SST objects still exist physically, but no persisted plan remained staged for the explicit sweep to consume.
+
+Use these fields to compare a GC-on scenario against its GC-off companion:
+
+- `read_compaction_quiesced` vs `read_compaction_quiesced_after_gc`
+- `write_heavy_no_sst_sweep` vs `write_heavy_with_sst_sweep`
+
 Planned artifact growth for the broader benchmark program:
 
 - topology fields such as runner region, bucket region, path placement, and
@@ -263,3 +296,5 @@ After `read_baseline` and `read_compaction_quiesced` complete, the harness print
   - `benches/compaction/results/compaction_directional_matrix_2026-02-27.md`
 - Directional + latency phase split validation (new probe wiring + dominance view):
   - `benches/compaction/results/compaction_directional_phase_split_2026-03-01.md`
+- SST GC timing rerun with snapshot-pin semantics:
+  - `benches/compaction/results/sst_gc_rerun_2026-03-19.md`

--- a/benches/compaction/common.rs
+++ b/benches/compaction/common.rs
@@ -31,12 +31,13 @@ use serde::Serialize;
 use thiserror::Error;
 use tokio::{runtime::Runtime, time::sleep};
 use tonbo::db::{
-    AwsCreds, CompactionOptions, CompactionStrategy, DB, DBError, DbBuildError, DbBuilder,
-    LeveledPlannerConfig, ObjectSpec, S3Spec, ScanSetupProfile, WalSyncPolicy,
+    AwsCreds, CompactionMetrics, CompactionMetricsSnapshot, CompactionOptions, CompactionStrategy,
+    DB, DBError, DbBuildError, DbBuilder, LeveledPlannerConfig, ObjectSpec, S3Spec,
+    ScanSetupProfile, SstSweepSummary, WalSyncPolicy,
 };
 
 pub(crate) const BENCH_ID: &str = "compaction_local";
-pub(crate) const BENCH_SCHEMA_VERSION: u32 = 8;
+pub(crate) const BENCH_SCHEMA_VERSION: u32 = 13;
 
 const DEFAULT_INGEST_BATCHES: usize = 640;
 const DEFAULT_DATASET_SCALE: usize = 1;
@@ -90,6 +91,17 @@ pub(crate) struct IoProbe {
 struct IoProbeState {
     read_ops: AtomicU64,
     write_ops: AtomicU64,
+    list_ops: AtomicU64,
+    remove_ops: AtomicU64,
+    copy_ops: AtomicU64,
+    link_ops: AtomicU64,
+    cas_load_ops: AtomicU64,
+    cas_put_ops: AtomicU64,
+    head_ops: AtomicU64,
+    sst_request_ops: AtomicU64,
+    wal_request_ops: AtomicU64,
+    manifest_request_ops: AtomicU64,
+    other_request_ops: AtomicU64,
     bytes_read: AtomicU64,
     bytes_written: AtomicU64,
     sst_paths: Mutex<HashSet<String>>,
@@ -99,6 +111,17 @@ struct IoProbeState {
 pub(crate) struct IoCountersArtifact {
     read_ops: u64,
     write_ops: u64,
+    list_ops: u64,
+    remove_ops: u64,
+    copy_ops: u64,
+    link_ops: u64,
+    cas_load_ops: u64,
+    cas_put_ops: u64,
+    head_ops: u64,
+    sst_request_ops: u64,
+    wal_request_ops: u64,
+    manifest_request_ops: u64,
+    other_request_ops: u64,
     bytes_read: u64,
     bytes_written: u64,
     ssts_touched: usize,
@@ -108,9 +131,13 @@ pub(crate) struct IoCountersArtifact {
 pub(crate) struct StorageVolumeArtifact {
     object_count: u64,
     total_bytes: u64,
+    sst_object_count: u64,
     sst_bytes: u64,
+    wal_object_count: u64,
     wal_bytes: u64,
+    manifest_object_count: u64,
     manifest_bytes: u64,
+    other_object_count: u64,
     other_bytes: u64,
 }
 
@@ -121,6 +148,100 @@ pub(crate) struct LogicalVolumeArtifact {
     wal_bytes: Option<u64>,
     manifest_bytes: Option<u64>,
     total_bytes: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct PhysicalStaleEstimateArtifact {
+    candidate_sst_objects: u64,
+    candidate_sst_bytes: u64,
+    live_sst_objects: u64,
+    live_sst_bytes: u64,
+    physical_sst_objects: u64,
+    physical_sst_bytes: u64,
+    stale_sst_byte_amplification_pct: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct GcSweepArtifact {
+    deleted_objects: u64,
+    deleted_bytes: u64,
+    delete_failures: u64,
+    duration_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct GcCountersArtifact {
+    sweep_runs: u64,
+    deleted_objects: u64,
+    deleted_bytes: u64,
+    delete_failures: u64,
+    sweep_duration_ms_total: u64,
+    gc_plan_write_runs: u64,
+    gc_plan_overwrite_non_empty: u64,
+    gc_plan_previous_sst_candidates: u64,
+    gc_plan_written_sst_candidates: u64,
+    gc_plan_take_runs: u64,
+    gc_plan_taken_sst_candidates: u64,
+    gc_plan_authorized_sst_candidates: u64,
+    gc_plan_blocked_sst_candidates: u64,
+    gc_plan_requeued_sst_candidates: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct GcObservationArtifact {
+    volume_before_gc: StorageVolumeArtifact,
+    volume_after_gc: StorageVolumeArtifact,
+    physical_stale_estimate_before_explicit_sweep: PhysicalStaleEstimateArtifact,
+    physical_stale_estimate_after_explicit_sweep: PhysicalStaleEstimateArtifact,
+    reclaimed_sst_objects: u64,
+    reclaimed_sst_bytes: u64,
+    persisted_plan_before_explicit_sweep: Option<GcPlanInspectionArtifact>,
+    explicit_sweep_result: GcSweepArtifact,
+    cumulative_before_explicit_sweep: GcCountersArtifact,
+    cumulative_after_explicit_sweep: GcCountersArtifact,
+    persisted_plan_after_explicit_sweep: Option<GcPlanInspectionArtifact>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct GcDerivedArtifact {
+    sst_sweep_runs: u64,
+    sst_sweep_duration_ms_total: u64,
+    sst_deleted_objects_total: u64,
+    sst_deleted_bytes_total: u64,
+    sst_sweep_runs_before_explicit_sweep: u64,
+    sst_sweep_duration_ms_before_explicit_sweep: u64,
+    sst_deleted_objects_before_explicit_sweep: u64,
+    sst_deleted_bytes_before_explicit_sweep: u64,
+    explicit_sweep_runs: u64,
+    explicit_sweep_duration_ms: u64,
+    explicit_sweep_deleted_objects: u64,
+    explicit_sweep_deleted_bytes: u64,
+    sst_deleted_bytes_per_ms: Option<f64>,
+    sst_deleted_objects_per_ms: Option<f64>,
+    gc_time_share_pct_of_setup: Option<f64>,
+    gc_time_share_pct_of_total_elapsed: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct GcPlanCandidateArtifact {
+    sst_id: u64,
+    level: u32,
+    data_path: String,
+    delete_path: Option<String>,
+    authorized: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct GcPlanInspectionArtifact {
+    staged_sst_candidates: u64,
+    authorized_sst_candidates: u64,
+    blocked_sst_candidates: u64,
+    obsolete_wal_segments: u64,
+    protected_versions: u64,
+    active_snapshot_versions: u64,
+    protected_sst_objects: u64,
+    blocker: String,
+    candidates: Vec<GcPlanCandidateArtifact>,
 }
 
 impl LogicalVolumeArtifact {
@@ -145,6 +266,229 @@ impl LogicalVolumeArtifact {
     }
 }
 
+impl PhysicalStaleEstimateArtifact {
+    pub(crate) fn from_volume(
+        physical: &StorageVolumeArtifact,
+        logical: &LogicalVolumeArtifact,
+    ) -> Self {
+        let live_sst_objects = u64::try_from(logical.sst_count).unwrap_or(u64::MAX);
+        let candidate_sst_objects = physical.sst_object_count.saturating_sub(live_sst_objects);
+        let candidate_sst_bytes = physical.sst_bytes.saturating_sub(logical.sst_bytes);
+        let stale_sst_byte_amplification_pct = if logical.sst_bytes == 0 {
+            0.0
+        } else {
+            (candidate_sst_bytes as f64 / logical.sst_bytes as f64) * 100.0
+        };
+
+        Self {
+            candidate_sst_objects,
+            candidate_sst_bytes,
+            live_sst_objects,
+            live_sst_bytes: logical.sst_bytes,
+            physical_sst_objects: physical.sst_object_count,
+            physical_sst_bytes: physical.sst_bytes,
+            stale_sst_byte_amplification_pct,
+        }
+    }
+}
+
+impl GcSweepArtifact {
+    fn from_summary(summary: SstSweepSummary) -> Self {
+        Self {
+            deleted_objects: summary.deleted_objects,
+            deleted_bytes: summary.deleted_bytes,
+            delete_failures: summary.delete_failures,
+            duration_ms: summary.duration_ms,
+        }
+    }
+}
+
+impl GcCountersArtifact {
+    fn from_snapshot(snapshot: CompactionMetricsSnapshot) -> Self {
+        Self {
+            sweep_runs: snapshot.sst_sweep_runs,
+            deleted_objects: snapshot.sst_deleted_objects,
+            deleted_bytes: snapshot.sst_deleted_bytes,
+            delete_failures: snapshot.sst_delete_failures,
+            sweep_duration_ms_total: snapshot.sst_sweep_duration_ms_total,
+            gc_plan_write_runs: snapshot.gc_plan_write_runs,
+            gc_plan_overwrite_non_empty: snapshot.gc_plan_overwrite_non_empty,
+            gc_plan_previous_sst_candidates: snapshot.gc_plan_previous_sst_candidates,
+            gc_plan_written_sst_candidates: snapshot.gc_plan_written_sst_candidates,
+            gc_plan_take_runs: snapshot.gc_plan_take_runs,
+            gc_plan_taken_sst_candidates: snapshot.gc_plan_taken_sst_candidates,
+            gc_plan_authorized_sst_candidates: snapshot.gc_plan_authorized_sst_candidates,
+            gc_plan_blocked_sst_candidates: snapshot.gc_plan_blocked_sst_candidates,
+            gc_plan_requeued_sst_candidates: snapshot.gc_plan_requeued_sst_candidates,
+        }
+    }
+}
+
+impl GcObservationArtifact {
+    #[allow(clippy::too_many_arguments)]
+    fn from_parts(
+        volume_before_gc: StorageVolumeArtifact,
+        volume_after_gc: StorageVolumeArtifact,
+        physical_stale_estimate_before_explicit_sweep: PhysicalStaleEstimateArtifact,
+        physical_stale_estimate_after_explicit_sweep: PhysicalStaleEstimateArtifact,
+        persisted_plan_before_explicit_sweep: Option<GcPlanInspectionArtifact>,
+        explicit_sweep: SstSweepSummary,
+        cumulative_before_explicit_sweep: CompactionMetricsSnapshot,
+        cumulative_after_explicit_sweep: CompactionMetricsSnapshot,
+        persisted_plan_after_explicit_sweep: Option<GcPlanInspectionArtifact>,
+    ) -> Self {
+        Self {
+            reclaimed_sst_objects: volume_before_gc
+                .sst_object_count
+                .saturating_sub(volume_after_gc.sst_object_count),
+            reclaimed_sst_bytes: volume_before_gc
+                .sst_bytes
+                .saturating_sub(volume_after_gc.sst_bytes),
+            volume_before_gc,
+            volume_after_gc,
+            physical_stale_estimate_before_explicit_sweep,
+            physical_stale_estimate_after_explicit_sweep,
+            persisted_plan_before_explicit_sweep,
+            explicit_sweep_result: GcSweepArtifact::from_summary(explicit_sweep),
+            cumulative_before_explicit_sweep: GcCountersArtifact::from_snapshot(
+                cumulative_before_explicit_sweep,
+            ),
+            cumulative_after_explicit_sweep: GcCountersArtifact::from_snapshot(
+                cumulative_after_explicit_sweep,
+            ),
+            persisted_plan_after_explicit_sweep,
+        }
+    }
+}
+
+impl GcDerivedArtifact {
+    fn from_gc_observation(
+        gc: &GcObservationArtifact,
+        setup_elapsed_ns: u64,
+        total_elapsed_ns: u64,
+    ) -> Self {
+        let total_duration_ms = gc.cumulative_after_explicit_sweep.sweep_duration_ms_total;
+        let total_runs = gc.cumulative_after_explicit_sweep.sweep_runs;
+        let total_deleted_objects = gc.cumulative_after_explicit_sweep.deleted_objects;
+        let total_deleted_bytes = gc.cumulative_after_explicit_sweep.deleted_bytes;
+        let before_duration_ms = gc.cumulative_before_explicit_sweep.sweep_duration_ms_total;
+        let before_runs = gc.cumulative_before_explicit_sweep.sweep_runs;
+        let before_deleted_objects = gc.cumulative_before_explicit_sweep.deleted_objects;
+        let before_deleted_bytes = gc.cumulative_before_explicit_sweep.deleted_bytes;
+        let explicit_sweep_runs = total_runs.saturating_sub(before_runs);
+        let explicit_sweep_duration_ms = total_duration_ms.saturating_sub(before_duration_ms);
+        let explicit_sweep_deleted_objects =
+            total_deleted_objects.saturating_sub(before_deleted_objects);
+        let explicit_sweep_deleted_bytes = total_deleted_bytes.saturating_sub(before_deleted_bytes);
+
+        Self {
+            sst_sweep_runs: total_runs,
+            sst_sweep_duration_ms_total: total_duration_ms,
+            sst_deleted_objects_total: total_deleted_objects,
+            sst_deleted_bytes_total: total_deleted_bytes,
+            sst_sweep_runs_before_explicit_sweep: before_runs,
+            sst_sweep_duration_ms_before_explicit_sweep: before_duration_ms,
+            sst_deleted_objects_before_explicit_sweep: before_deleted_objects,
+            sst_deleted_bytes_before_explicit_sweep: before_deleted_bytes,
+            explicit_sweep_runs,
+            explicit_sweep_duration_ms,
+            explicit_sweep_deleted_objects,
+            explicit_sweep_deleted_bytes,
+            sst_deleted_bytes_per_ms: ratio_per_ms(total_deleted_bytes, total_duration_ms),
+            sst_deleted_objects_per_ms: ratio_per_ms(total_deleted_objects, total_duration_ms),
+            gc_time_share_pct_of_setup: pct_of_elapsed_ms(total_duration_ms, setup_elapsed_ns),
+            gc_time_share_pct_of_total_elapsed: pct_of_elapsed_ms(
+                total_duration_ms,
+                total_elapsed_ns,
+            ),
+        }
+    }
+}
+
+impl GcPlanInspectionArtifact {
+    fn from_inspection(inspection: tonbo::db::SstGcInspection) -> Self {
+        let blocker = if inspection.staged_sst_candidates == 0 {
+            "no staged SST GC candidates remain in the manifest plan".to_string()
+        } else if inspection.authorized_sst_candidates > 0 {
+            "some staged SST candidates are authorized for deletion".to_string()
+        } else if inspection.active_snapshot_versions > 0 {
+            format!(
+                "all staged SST candidates are still protected by {} live in-process snapshot \
+                 pin(s); they will only become reclaimable after those snapshots drop",
+                inspection.active_snapshot_versions
+            )
+        } else {
+            "all staged SST candidates are still protected by the current manifest root set"
+                .to_string()
+        };
+        Self {
+            staged_sst_candidates: inspection.staged_sst_candidates,
+            authorized_sst_candidates: inspection.authorized_sst_candidates,
+            blocked_sst_candidates: inspection.blocked_sst_candidates,
+            obsolete_wal_segments: inspection.obsolete_wal_segments,
+            protected_versions: inspection.protected_versions,
+            active_snapshot_versions: inspection.active_snapshot_versions,
+            protected_sst_objects: inspection.protected_sst_objects,
+            blocker,
+            candidates: inspection
+                .candidates
+                .into_iter()
+                .map(|candidate| GcPlanCandidateArtifact {
+                    sst_id: candidate.sst_id,
+                    level: candidate.level,
+                    data_path: candidate.data_path,
+                    delete_path: candidate.delete_path,
+                    authorized: candidate.authorized,
+                })
+                .collect(),
+        }
+    }
+}
+
+fn empty_compaction_metrics_snapshot() -> CompactionMetricsSnapshot {
+    CompactionMetricsSnapshot {
+        job_count: 0,
+        job_failures: 0,
+        cas_retries: 0,
+        cas_aborts: 0,
+        queue_drops_planner_full: 0,
+        queue_drops_planner_closed: 0,
+        queue_drops_cascade_full: 0,
+        queue_drops_cascade_closed: 0,
+        cascades_scheduled: 0,
+        cascades_blocked_cooldown: 0,
+        cascades_blocked_budget: 0,
+        backpressure_slowdown: 0,
+        backpressure_stall: 0,
+        trigger_kick: 0,
+        trigger_periodic: 0,
+        bytes_in: 0,
+        bytes_out: 0,
+        rows_in: 0,
+        rows_out: 0,
+        tombstones_in: 0,
+        tombstones_out: 0,
+        duration_ms_total: 0,
+        sst_sweep_runs: 0,
+        sst_deleted_objects: 0,
+        sst_deleted_bytes: 0,
+        sst_sweep_duration_ms_total: 0,
+        sst_delete_failures: 0,
+        gc_plan_write_runs: 0,
+        gc_plan_overwrite_non_empty: 0,
+        gc_plan_previous_sst_candidates: 0,
+        gc_plan_previous_wal_candidates: 0,
+        gc_plan_written_sst_candidates: 0,
+        gc_plan_written_wal_candidates: 0,
+        gc_plan_take_runs: 0,
+        gc_plan_taken_sst_candidates: 0,
+        gc_plan_authorized_sst_candidates: 0,
+        gc_plan_blocked_sst_candidates: 0,
+        gc_plan_requeued_sst_candidates: 0,
+        last_job: None,
+    }
+}
+
 impl IoProbe {
     pub(crate) fn snapshot(&self) -> IoCountersArtifact {
         let ssts_touched = match self.inner.sst_paths.lock() {
@@ -154,6 +498,17 @@ impl IoProbe {
         IoCountersArtifact {
             read_ops: self.inner.read_ops.load(Ordering::Relaxed),
             write_ops: self.inner.write_ops.load(Ordering::Relaxed),
+            list_ops: self.inner.list_ops.load(Ordering::Relaxed),
+            remove_ops: self.inner.remove_ops.load(Ordering::Relaxed),
+            copy_ops: self.inner.copy_ops.load(Ordering::Relaxed),
+            link_ops: self.inner.link_ops.load(Ordering::Relaxed),
+            cas_load_ops: self.inner.cas_load_ops.load(Ordering::Relaxed),
+            cas_put_ops: self.inner.cas_put_ops.load(Ordering::Relaxed),
+            head_ops: self.inner.head_ops.load(Ordering::Relaxed),
+            sst_request_ops: self.inner.sst_request_ops.load(Ordering::Relaxed),
+            wal_request_ops: self.inner.wal_request_ops.load(Ordering::Relaxed),
+            manifest_request_ops: self.inner.manifest_request_ops.load(Ordering::Relaxed),
+            other_request_ops: self.inner.other_request_ops.load(Ordering::Relaxed),
             bytes_read: self.inner.bytes_read.load(Ordering::Relaxed),
             bytes_written: self.inner.bytes_written.load(Ordering::Relaxed),
             ssts_touched,
@@ -163,6 +518,17 @@ impl IoProbe {
     pub(crate) fn reset(&self) {
         self.inner.read_ops.store(0, Ordering::Relaxed);
         self.inner.write_ops.store(0, Ordering::Relaxed);
+        self.inner.list_ops.store(0, Ordering::Relaxed);
+        self.inner.remove_ops.store(0, Ordering::Relaxed);
+        self.inner.copy_ops.store(0, Ordering::Relaxed);
+        self.inner.link_ops.store(0, Ordering::Relaxed);
+        self.inner.cas_load_ops.store(0, Ordering::Relaxed);
+        self.inner.cas_put_ops.store(0, Ordering::Relaxed);
+        self.inner.head_ops.store(0, Ordering::Relaxed);
+        self.inner.sst_request_ops.store(0, Ordering::Relaxed);
+        self.inner.wal_request_ops.store(0, Ordering::Relaxed);
+        self.inner.manifest_request_ops.store(0, Ordering::Relaxed);
+        self.inner.other_request_ops.store(0, Ordering::Relaxed);
         self.inner.bytes_read.store(0, Ordering::Relaxed);
         self.inner.bytes_written.store(0, Ordering::Relaxed);
         match self.inner.sst_paths.lock() {
@@ -174,13 +540,61 @@ impl IoProbe {
     fn record_read(&self, path: &FusioPath, bytes: u64) {
         saturating_add(&self.inner.read_ops, 1);
         saturating_add(&self.inner.bytes_read, bytes);
-        self.record_sst(path);
+        self.record_request_path(path);
     }
 
     fn record_write(&self, path: &FusioPath, bytes: u64) {
         saturating_add(&self.inner.write_ops, 1);
         saturating_add(&self.inner.bytes_written, bytes);
-        self.record_sst(path);
+        self.record_request_path(path);
+    }
+
+    fn record_list(&self, path: &FusioPath) {
+        saturating_add(&self.inner.list_ops, 1);
+        self.record_request_path(path);
+    }
+
+    fn record_remove(&self, path: &FusioPath) {
+        saturating_add(&self.inner.remove_ops, 1);
+        self.record_request_path(path);
+    }
+
+    fn record_copy(&self, path: &FusioPath) {
+        saturating_add(&self.inner.copy_ops, 1);
+        self.record_request_path(path);
+    }
+
+    fn record_link(&self, path: &FusioPath) {
+        saturating_add(&self.inner.link_ops, 1);
+        self.record_request_path(path);
+    }
+
+    fn record_cas_load(&self, path: &FusioPath) {
+        saturating_add(&self.inner.cas_load_ops, 1);
+        self.record_request_path(path);
+    }
+
+    fn record_cas_put(&self, path: &FusioPath) {
+        saturating_add(&self.inner.cas_put_ops, 1);
+        self.record_request_path(path);
+    }
+
+    fn record_head(&self, path: &FusioPath) {
+        saturating_add(&self.inner.head_ops, 1);
+        self.record_request_path(path);
+    }
+
+    fn record_request_path(&self, path: &FusioPath) {
+        if is_sst_path(path) {
+            saturating_add(&self.inner.sst_request_ops, 1);
+            self.record_sst(path);
+        } else if is_wal_path(path.as_ref()) {
+            saturating_add(&self.inner.wal_request_ops, 1);
+        } else if is_manifest_path(path.as_ref()) {
+            saturating_add(&self.inner.manifest_request_ops, 1);
+        } else {
+            saturating_add(&self.inner.other_request_ops, 1);
+        }
     }
 
     fn record_sst(&self, path: &FusioPath) {
@@ -330,18 +744,24 @@ where
         impl futures::Stream<Item = Result<FileMeta, FusioError>> + fusio::dynamic::MaybeSend,
         FusioError,
     > {
+        self.probe.record_list(path);
         self.inner.list(path).await
     }
 
     async fn remove(&self, path: &FusioPath) -> Result<(), FusioError> {
+        self.probe.record_remove(path);
         self.inner.remove(path).await
     }
 
     async fn copy(&self, from: &FusioPath, to: &FusioPath) -> Result<(), FusioError> {
+        let _ = from;
+        self.probe.record_copy(to);
         self.inner.copy(from, to).await
     }
 
     async fn link(&self, from: &FusioPath, to: &FusioPath) -> Result<(), FusioError> {
+        let _ = from;
+        self.probe.record_link(to);
         self.inner.link(from, to).await
     }
 }
@@ -355,6 +775,7 @@ where
         path: &FusioPath,
     ) -> Pin<Box<dyn MaybeSendFuture<Output = Result<Option<(Vec<u8>, String)>, FusioError>> + '_>>
     {
+        self.probe.record_cas_load(path);
         self.inner.load_with_tag(path)
     }
 
@@ -366,6 +787,7 @@ where
         metadata: Option<Vec<(String, String)>>,
         condition: CasCondition,
     ) -> Pin<Box<dyn MaybeSendFuture<Output = Result<String, FusioError>> + '_>> {
+        self.probe.record_cas_put(path);
         self.inner
             .put_conditional(path, payload, content_type, metadata, condition)
     }
@@ -381,6 +803,7 @@ where
     ) -> Pin<
         Box<dyn MaybeSendFuture<Output = Result<Option<HashMap<String, String>>, FusioError>> + 'a>,
     > {
+        self.probe.record_head(path);
         self.inner.head_metadata(path)
     }
 }
@@ -732,6 +1155,13 @@ pub(crate) enum ScenarioWorkload {
     ReadOnly,
     ReadWhileCompaction,
     WriteThroughput,
+    SweepEstimate,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum ScenarioStorageTarget {
+    Local { root: PathBuf },
+    ObjectStore { spec: ObjectSpec },
 }
 
 #[derive(Clone)]
@@ -768,15 +1198,18 @@ pub(crate) struct ScenarioState {
     pub(crate) scenario_variant_id: String,
     pub(crate) benchmark_id: String,
     pub(crate) workload: ScenarioWorkload,
+    pub(crate) storage_target: ScenarioStorageTarget,
     pub(crate) dimensions: ScenarioDimensionsArtifact,
     pub(crate) db: BenchmarkDb,
     pub(crate) io_probe: IoProbe,
+    pub(crate) setup_elapsed_ns: u64,
     pub(crate) setup_io: IoCountersArtifact,
     pub(crate) rows_per_op_hint: usize,
     pub(crate) version_before_compaction: VersionSummary,
     pub(crate) version_ready: VersionSummary,
     pub(crate) volume_before_compaction: StorageVolumeArtifact,
     pub(crate) volume_ready: StorageVolumeArtifact,
+    pub(crate) gc_observation: Option<GcObservationArtifact>,
     pub(crate) write_state: Option<WriteWorkloadState>,
 }
 
@@ -840,6 +1273,8 @@ pub(crate) struct CompactionSweepArtifact {
 
 #[derive(Debug, Serialize)]
 struct ScenarioSetupArtifact {
+    total_elapsed_ns: u64,
+    total_elapsed_ms: f64,
     rows_per_scan: usize,
     sst_count_before_compaction: usize,
     level_count_before_compaction: usize,
@@ -849,6 +1284,9 @@ struct ScenarioSetupArtifact {
     logical_ready: LogicalVolumeArtifact,
     volume_before_compaction: StorageVolumeArtifact,
     volume_ready: StorageVolumeArtifact,
+    physical_stale_estimate_before_compaction: PhysicalStaleEstimateArtifact,
+    physical_stale_estimate_ready: PhysicalStaleEstimateArtifact,
+    gc_observation: Option<GcObservationArtifact>,
     io: IoCountersArtifact,
 }
 
@@ -856,11 +1294,14 @@ struct ScenarioSetupArtifact {
 struct ScenarioSummaryArtifact {
     iterations: usize,
     total_elapsed_ns: u64,
+    total_elapsed_ms: f64,
     rows_processed: u64,
     throughput: ThroughputSummary,
     latency_ns: LatencySummary,
     read_path_latency_ns: Option<ReadPathLatencySummary>,
     read_path_internal_ns: Option<ReadPathInternalSummary>,
+    physical_stale_estimate: Option<PhysicalStaleEstimateArtifact>,
+    gc: Option<GcDerivedArtifact>,
     io: IoCountersArtifact,
 }
 
@@ -886,6 +1327,7 @@ struct ScenarioMeasurement {
     latencies_ns: Vec<u64>,
     rows_processed: u64,
     read_path: Option<ReadPathAggregate>,
+    physical_stale_estimate: Option<PhysicalStaleEstimateArtifact>,
     io: IoCountersArtifact,
 }
 
@@ -1011,6 +1453,7 @@ impl ReadPathAggregate {
 struct OperationResult {
     rows: usize,
     read_path: Option<ReadPathBreakdown>,
+    physical_stale_estimate: Option<PhysicalStaleEstimateArtifact>,
 }
 
 impl ScenarioDimensionsArtifact {
@@ -1052,6 +1495,7 @@ async fn run_scenario_operation(scenario: &ScenarioState) -> Result<OperationRes
             Ok(OperationResult {
                 rows,
                 read_path: Some(read_path),
+                physical_stale_estimate: None,
             })
         }
         ScenarioWorkload::ReadWhileCompaction => {
@@ -1069,6 +1513,7 @@ async fn run_scenario_operation(scenario: &ScenarioState) -> Result<OperationRes
             Ok(OperationResult {
                 rows,
                 read_path: Some(read_path),
+                physical_stale_estimate: None,
             })
         }
         ScenarioWorkload::WriteThroughput => {
@@ -1082,6 +1527,18 @@ async fn run_scenario_operation(scenario: &ScenarioState) -> Result<OperationRes
             Ok(OperationResult {
                 rows,
                 read_path: None,
+                physical_stale_estimate: None,
+            })
+        }
+        ScenarioWorkload::SweepEstimate => {
+            let version = latest_version_summary(&scenario.db).await?;
+            let physical = snapshot_storage_target_volume(&scenario.storage_target).await?;
+            let logical = LogicalVolumeArtifact::from_version(version);
+            let estimate = PhysicalStaleEstimateArtifact::from_volume(&physical, &logical);
+            Ok(OperationResult {
+                rows: 1,
+                read_path: None,
+                physical_stale_estimate: Some(estimate),
             })
         }
     }
@@ -1236,13 +1693,24 @@ pub(crate) fn print_directional_report(artifact: &BenchmarkArtifact, config: &Re
         baseline.summary.latency_ns.p99,
         quiesced.summary.latency_ns.p99,
     );
+    let physical_stale_sst_bytes = quiesced
+        .setup
+        .physical_stale_estimate_ready
+        .candidate_sst_bytes;
+    let physical_stale_sst_objects = quiesced
+        .setup
+        .physical_stale_estimate_ready
+        .candidate_sst_objects;
 
     let observed = format!(
-        "read_ops_delta={}, bytes_delta={}, mean_delta={}, p99_delta={}",
+        "read_ops_delta={}, bytes_delta={}, mean_delta={}, p99_delta={}, \
+         physical_stale_estimate_sst_objects={}, physical_stale_estimate_sst_bytes={}",
         fmt_pct_opt(read_ops_drop),
         fmt_pct_opt(bytes_drop),
         fmt_pct_opt(mean_improve),
-        fmt_pct_opt(p99_improve)
+        fmt_pct_opt(p99_improve),
+        physical_stale_sst_objects,
+        physical_stale_sst_bytes
     );
     let baseline_latency = &baseline.summary.latency_ns;
     let quiesced_latency = &quiesced.summary.latency_ns;
@@ -1277,6 +1745,229 @@ pub(crate) fn print_directional_report(artifact: &BenchmarkArtifact, config: &Re
         "  Implication: rerun with larger TONBO_BENCH_DATASET_SCALE, compare local vs \
          object_store, and track p99 alongside mean."
     );
+
+    if let (Some(gc_off), Some(gc_on)) = (
+        artifact
+            .scenarios
+            .iter()
+            .find(|scenario| scenario.scenario_id == "read_compaction_quiesced"),
+        artifact
+            .scenarios
+            .iter()
+            .find(|scenario| scenario.scenario_id == "read_compaction_quiesced_after_gc"),
+    ) {
+        print_gc_latency_report("read", gc_off, gc_on);
+    }
+    if let (Some(gc_off), Some(gc_on)) = (
+        artifact
+            .scenarios
+            .iter()
+            .find(|scenario| scenario.scenario_id == "write_heavy_no_sst_sweep"),
+        artifact
+            .scenarios
+            .iter()
+            .find(|scenario| scenario.scenario_id == "write_heavy_with_sst_sweep"),
+    ) {
+        print_gc_latency_report("write", gc_off, gc_on);
+    }
+}
+
+fn print_gc_latency_report(label: &str, gc_off: &ScenarioArtifact, gc_on: &ScenarioArtifact) {
+    let mean_delta = pct_drop_float(
+        gc_off.summary.latency_ns.mean,
+        gc_on.summary.latency_ns.mean,
+    );
+    let p99_delta = pct_drop(gc_off.summary.latency_ns.p99, gc_on.summary.latency_ns.p99);
+    let throughput_delta = pct_drop_float(
+        gc_off.summary.throughput.ops_per_sec,
+        gc_on.summary.throughput.ops_per_sec,
+    )
+    .map(|pct| -pct);
+
+    eprintln!("tonbo benchmark gc comparison");
+    eprintln!(
+        "  Workload: {label} ({}) vs {}",
+        gc_off.scenario_id, gc_on.scenario_id
+    );
+    eprintln!(
+        "  Latency delta: mean={}, p99={}, throughput_delta={}",
+        fmt_pct_opt(mean_delta),
+        fmt_pct_opt(p99_delta),
+        fmt_pct_opt(throughput_delta),
+    );
+    if let Some(gc) = gc_on.setup.gc_observation.as_ref() {
+        if let Some(derived) = gc_on.summary.gc.as_ref() {
+            eprintln!(
+                "  GC timing: setup_elapsed_ms={:.3}, steady_state_elapsed_ms={:.3}, \
+                 total_sweep_runs={}, total_sweep_duration_ms={}, total_deleted_objects={}, \
+                 total_deleted_bytes={}, total_deleted_bytes_per_ms={}, \
+                 total_deleted_objects_per_ms={}, before_explicit_sweep_runs={}, \
+                 before_explicit_sweep_duration_ms={}, before_explicit_sweep_deleted_objects={}, \
+                 before_explicit_sweep_deleted_bytes={}, explicit_sweep_runs={}, \
+                 explicit_sweep_duration_ms={}, explicit_sweep_deleted_objects={}, \
+                 explicit_sweep_deleted_bytes={}, gc_time_share_pct_of_setup={}, \
+                 gc_time_share_pct_of_total_elapsed={}",
+                gc_on.setup.total_elapsed_ms,
+                gc_on.summary.total_elapsed_ms,
+                derived.sst_sweep_runs,
+                derived.sst_sweep_duration_ms_total,
+                derived.sst_deleted_objects_total,
+                derived.sst_deleted_bytes_total,
+                fmt_ratio_opt(derived.sst_deleted_bytes_per_ms),
+                fmt_ratio_opt(derived.sst_deleted_objects_per_ms),
+                derived.sst_sweep_runs_before_explicit_sweep,
+                derived.sst_sweep_duration_ms_before_explicit_sweep,
+                derived.sst_deleted_objects_before_explicit_sweep,
+                derived.sst_deleted_bytes_before_explicit_sweep,
+                derived.explicit_sweep_runs,
+                derived.explicit_sweep_duration_ms,
+                derived.explicit_sweep_deleted_objects,
+                derived.explicit_sweep_deleted_bytes,
+                fmt_pct_opt(derived.gc_time_share_pct_of_setup),
+                fmt_pct_opt(derived.gc_time_share_pct_of_total_elapsed),
+            );
+        }
+        eprintln!(
+            "  Physical SST: before(objects={}, bytes={}) after(objects={}, bytes={}) \
+             reclaimed(objects={}, bytes={})",
+            gc.volume_before_gc.sst_object_count,
+            gc.volume_before_gc.sst_bytes,
+            gc.volume_after_gc.sst_object_count,
+            gc.volume_after_gc.sst_bytes,
+            gc.reclaimed_sst_objects,
+            gc.reclaimed_sst_bytes,
+        );
+        eprintln!(
+            "  Physical estimate before explicit sweep: stale_sst_objects={}, stale_sst_bytes={}, \
+             live_sst_objects={}, live_sst_bytes={}, physical_sst_objects={}, \
+             physical_sst_bytes={}",
+            gc.physical_stale_estimate_before_explicit_sweep
+                .candidate_sst_objects,
+            gc.physical_stale_estimate_before_explicit_sweep
+                .candidate_sst_bytes,
+            gc.physical_stale_estimate_before_explicit_sweep
+                .live_sst_objects,
+            gc.physical_stale_estimate_before_explicit_sweep
+                .live_sst_bytes,
+            gc.physical_stale_estimate_before_explicit_sweep
+                .physical_sst_objects,
+            gc.physical_stale_estimate_before_explicit_sweep
+                .physical_sst_bytes,
+        );
+        eprintln!(
+            "  Cumulative sweep counters: before(runs={}, plan_writes={}, \
+             plan_overwrite_non_empty={}, plan_takes={}) after(runs={}, plan_writes={}, \
+             plan_overwrite_non_empty={}, plan_takes={})",
+            gc.cumulative_before_explicit_sweep.sweep_runs,
+            gc.cumulative_before_explicit_sweep.gc_plan_write_runs,
+            gc.cumulative_before_explicit_sweep
+                .gc_plan_overwrite_non_empty,
+            gc.cumulative_before_explicit_sweep.gc_plan_take_runs,
+            gc.cumulative_after_explicit_sweep.sweep_runs,
+            gc.cumulative_after_explicit_sweep.gc_plan_write_runs,
+            gc.cumulative_after_explicit_sweep
+                .gc_plan_overwrite_non_empty,
+            gc.cumulative_after_explicit_sweep.gc_plan_take_runs,
+        );
+        if let Some(plan) = gc.persisted_plan_before_explicit_sweep.as_ref() {
+            eprintln!(
+                "  Persisted plan before explicit sweep: staged_ssts={}, authorized_ssts={}, \
+                 blocked_ssts={}, protected_versions={}, active_snapshot_versions={}, \
+                 protected_sst_objects={}, obsolete_wal_segments={}",
+                plan.staged_sst_candidates,
+                plan.authorized_sst_candidates,
+                plan.blocked_sst_candidates,
+                plan.protected_versions,
+                plan.active_snapshot_versions,
+                plan.protected_sst_objects,
+                plan.obsolete_wal_segments,
+            );
+            eprintln!(
+                "  Persisted plan blocker before explicit sweep: {}",
+                plan.blocker
+            );
+        } else {
+            eprintln!("  Persisted plan before explicit sweep: none");
+        }
+        eprintln!(
+            "  Explicit sweep result: deleted_objects={}, deleted_bytes={}, delete_failures={}, \
+             duration_ms={}",
+            gc.explicit_sweep_result.deleted_objects,
+            gc.explicit_sweep_result.deleted_bytes,
+            gc.explicit_sweep_result.delete_failures,
+            gc.explicit_sweep_result.duration_ms,
+        );
+        eprintln!(
+            "  Physical estimate after explicit sweep: stale_sst_objects={}, stale_sst_bytes={}, \
+             live_sst_objects={}, live_sst_bytes={}, physical_sst_objects={}, \
+             physical_sst_bytes={}",
+            gc.physical_stale_estimate_after_explicit_sweep
+                .candidate_sst_objects,
+            gc.physical_stale_estimate_after_explicit_sweep
+                .candidate_sst_bytes,
+            gc.physical_stale_estimate_after_explicit_sweep
+                .live_sst_objects,
+            gc.physical_stale_estimate_after_explicit_sweep
+                .live_sst_bytes,
+            gc.physical_stale_estimate_after_explicit_sweep
+                .physical_sst_objects,
+            gc.physical_stale_estimate_after_explicit_sweep
+                .physical_sst_bytes,
+        );
+        if let Some(plan) = gc.persisted_plan_after_explicit_sweep.as_ref() {
+            eprintln!(
+                "  Persisted plan after explicit sweep: staged_ssts={}, authorized_ssts={}, \
+                 blocked_ssts={}, protected_versions={}, active_snapshot_versions={}, \
+                 protected_sst_objects={}, obsolete_wal_segments={}",
+                plan.staged_sst_candidates,
+                plan.authorized_sst_candidates,
+                plan.blocked_sst_candidates,
+                plan.protected_versions,
+                plan.active_snapshot_versions,
+                plan.protected_sst_objects,
+                plan.obsolete_wal_segments,
+            );
+            eprintln!(
+                "  Persisted plan blocker after explicit sweep: {}",
+                plan.blocker
+            );
+        } else {
+            eprintln!("  Persisted plan after explicit sweep: none");
+        }
+        if let Some(interpretation) = explain_gc_observation(gc) {
+            eprintln!("  Interpretation: {interpretation}");
+        }
+    }
+}
+
+fn explain_gc_observation(gc: &GcObservationArtifact) -> Option<String> {
+    let physical = &gc.physical_stale_estimate_before_explicit_sweep;
+    let has_physical_stale_estimate =
+        physical.candidate_sst_objects > 0 || physical.candidate_sst_bytes > 0;
+    let persisted_plan_empty = gc.persisted_plan_before_explicit_sweep.is_none();
+    let prior_staged_or_authorized_candidates = gc
+        .cumulative_before_explicit_sweep
+        .gc_plan_written_sst_candidates
+        > 0
+        || gc
+            .cumulative_before_explicit_sweep
+            .gc_plan_authorized_sst_candidates
+            > 0;
+
+    if has_physical_stale_estimate && persisted_plan_empty {
+        let message = if prior_staged_or_authorized_candidates {
+            "physical estimate is non-zero while the persisted plan is empty: the storage delta is \
+             broader than the current staged plan, and earlier compaction-triggered sweeps already \
+             wrote/took authorized candidates before this explicit sweep point"
+        } else {
+            "physical estimate is non-zero while the persisted plan is empty: this means \
+             stale-looking SST objects still exist physically, but no persisted GC plan remained \
+             staged for the explicit sweep to consume"
+        };
+        return Some(message.to_string());
+    }
+
+    None
 }
 
 pub(crate) fn benchmark_schema() -> SchemaRef {
@@ -1303,6 +1994,7 @@ pub(crate) async fn open_benchmark_db(
 ) -> Result<BenchmarkDb, BenchError> {
     let root_string = absolutize(root)?.to_string_lossy().into_owned();
     let fs = Arc::new(ProbedFs::new(LocalFs {}, io_probe.clone()));
+    let compaction_metrics = Arc::new(CompactionMetrics::new());
     let mut builder = DbBuilder::from_schema_key_name(Arc::clone(schema), "id")?
         .on_durable_fs(fs, root_string)?
         .wal_sync_policy(config.wal_sync_policy.clone())
@@ -1311,12 +2003,14 @@ pub(crate) async fn open_benchmark_db(
     match compaction_profile {
         CompactionProfile::Disabled => {}
         CompactionProfile::Default { periodic_tick_ms } => {
-            let options =
-                CompactionOptions::new().periodic_tick(Duration::from_millis(*periodic_tick_ms));
+            let options = CompactionOptions::new()
+                .periodic_tick(Duration::from_millis(*periodic_tick_ms))
+                .compaction_metrics(Arc::clone(&compaction_metrics));
             builder = builder.with_compaction_options(options);
         }
         CompactionProfile::Swept(tuning) => {
-            let options = build_swept_compaction_options(tuning);
+            let options =
+                build_swept_compaction_options(tuning).compaction_metrics(compaction_metrics);
             builder = builder.with_compaction_options(options);
         }
     }
@@ -1333,6 +2027,7 @@ pub(crate) async fn open_object_store_benchmark_db(
     io_probe: &IoProbe,
 ) -> Result<BenchmarkDb, BenchError> {
     let (fs, root) = build_probed_object_store_fs(object_spec, io_probe)?;
+    let compaction_metrics = Arc::new(CompactionMetrics::new());
     let mut builder = DbBuilder::from_schema_key_name(Arc::clone(schema), "id")?
         .object_store_with_fs(fs, root)?
         .wal_sync_policy(config.wal_sync_policy.clone())
@@ -1341,12 +2036,14 @@ pub(crate) async fn open_object_store_benchmark_db(
     match compaction_profile {
         CompactionProfile::Disabled => {}
         CompactionProfile::Default { periodic_tick_ms } => {
-            let options =
-                CompactionOptions::new().periodic_tick(Duration::from_millis(*periodic_tick_ms));
+            let options = CompactionOptions::new()
+                .periodic_tick(Duration::from_millis(*periodic_tick_ms))
+                .compaction_metrics(Arc::clone(&compaction_metrics));
             builder = builder.with_compaction_options(options);
         }
         CompactionProfile::Swept(tuning) => {
-            let options = build_swept_compaction_options(tuning);
+            let options =
+                build_swept_compaction_options(tuning).compaction_metrics(compaction_metrics);
             builder = builder.with_compaction_options(options);
         }
     }
@@ -1375,6 +2072,72 @@ pub(crate) async fn snapshot_object_store_storage_volume(
     let probe = IoProbe::default();
     let (fs, root) = build_probed_object_store_fs(object_spec, &probe)?;
     snapshot_storage_volume_with_fs(fs.as_ref(), &root).await
+}
+
+pub(crate) async fn snapshot_storage_target_volume(
+    target: &ScenarioStorageTarget,
+) -> Result<StorageVolumeArtifact, BenchError> {
+    match target {
+        ScenarioStorageTarget::Local { root } => snapshot_local_storage_volume(root).await,
+        ScenarioStorageTarget::ObjectStore { spec } => {
+            snapshot_object_store_storage_volume(spec).await
+        }
+    }
+}
+
+pub(crate) async fn run_gc_observation(
+    db: &BenchmarkDb,
+    target: &ScenarioStorageTarget,
+) -> Result<GcObservationArtifact, BenchError> {
+    let volume_before_gc = snapshot_storage_target_volume(target).await?;
+    let logical_before_sweep =
+        LogicalVolumeArtifact::from_version(latest_version_summary(db).await?);
+    let physical_stale_estimate_before_explicit_sweep =
+        PhysicalStaleEstimateArtifact::from_volume(&volume_before_gc, &logical_before_sweep);
+    let cumulative_before_explicit_sweep = match db {
+        BenchmarkDb::Local(inner) => inner.compaction_metrics_snapshot(),
+        BenchmarkDb::ObjectStore(inner) => inner.compaction_metrics_snapshot(),
+    }
+    .unwrap_or_else(empty_compaction_metrics_snapshot);
+    let persisted_plan_before_explicit_sweep = match db {
+        BenchmarkDb::Local(inner) => inner.inspect_sst_gc_plan().await,
+        BenchmarkDb::ObjectStore(inner) => inner.inspect_sst_gc_plan().await,
+    }
+    .map_err(BenchError::from)?
+    .map(GcPlanInspectionArtifact::from_inspection);
+    let explicit_sweep_result = match db {
+        BenchmarkDb::Local(inner) => inner.sweep_sst_objects().await,
+        BenchmarkDb::ObjectStore(inner) => inner.sweep_sst_objects().await,
+    }
+    .map_err(BenchError::from)?;
+    let volume_after_gc = snapshot_storage_target_volume(target).await?;
+    let logical_after_sweep =
+        LogicalVolumeArtifact::from_version(latest_version_summary(db).await?);
+    let physical_stale_estimate_after_explicit_sweep =
+        PhysicalStaleEstimateArtifact::from_volume(&volume_after_gc, &logical_after_sweep);
+    let cumulative_after_explicit_sweep = match db {
+        BenchmarkDb::Local(inner) => inner.compaction_metrics_snapshot(),
+        BenchmarkDb::ObjectStore(inner) => inner.compaction_metrics_snapshot(),
+    }
+    .unwrap_or_else(empty_compaction_metrics_snapshot);
+    let persisted_plan_after_explicit_sweep = match db {
+        BenchmarkDb::Local(inner) => inner.inspect_sst_gc_plan().await,
+        BenchmarkDb::ObjectStore(inner) => inner.inspect_sst_gc_plan().await,
+    }
+    .map_err(BenchError::from)?
+    .map(GcPlanInspectionArtifact::from_inspection);
+
+    Ok(GcObservationArtifact::from_parts(
+        volume_before_gc,
+        volume_after_gc,
+        physical_stale_estimate_before_explicit_sweep,
+        physical_stale_estimate_after_explicit_sweep,
+        persisted_plan_before_explicit_sweep,
+        explicit_sweep_result,
+        cumulative_before_explicit_sweep,
+        cumulative_after_explicit_sweep,
+        persisted_plan_after_explicit_sweep,
+    ))
 }
 
 fn build_probed_object_store_fs(
@@ -1466,12 +2229,16 @@ async fn snapshot_storage_volume_with_fs<FS: Fs>(
             volume.object_count = volume.object_count.saturating_add(1);
             volume.total_bytes = volume.total_bytes.saturating_add(size);
             if is_sst_path(&meta.path) {
+                volume.sst_object_count = volume.sst_object_count.saturating_add(1);
                 volume.sst_bytes = volume.sst_bytes.saturating_add(size);
             } else if is_wal_path(path) {
+                volume.wal_object_count = volume.wal_object_count.saturating_add(1);
                 volume.wal_bytes = volume.wal_bytes.saturating_add(size);
             } else if is_manifest_path(path) {
+                volume.manifest_object_count = volume.manifest_object_count.saturating_add(1);
                 volume.manifest_bytes = volume.manifest_bytes.saturating_add(size);
             } else {
+                volume.other_object_count = volume.other_object_count.saturating_add(1);
                 volume.other_bytes = volume.other_bytes.saturating_add(size);
             }
         }
@@ -1772,6 +2539,7 @@ fn measure_scenario(
         let mut latencies_ns = Vec::with_capacity(iterations);
         let mut rows_processed = 0u64;
         let mut read_path = ReadPathAggregate::default();
+        let mut physical_stale_estimate = None;
         let started = Instant::now();
         for _ in 0..iterations {
             let op_started = Instant::now();
@@ -1779,6 +2547,9 @@ fn measure_scenario(
             rows_processed = rows_processed.saturating_add(usize_to_u64(result.rows));
             if let Some(breakdown) = result.read_path {
                 read_path.record(breakdown);
+            }
+            if let Some(estimate) = result.physical_stale_estimate {
+                physical_stale_estimate = Some(estimate);
             }
             black_box(result.rows);
             latencies_ns.push(duration_ns_u64(op_started.elapsed()));
@@ -1793,6 +2564,7 @@ fn measure_scenario(
             } else {
                 None
             },
+            physical_stale_estimate,
             io: scenario.io_probe.snapshot(),
         })
     })
@@ -1828,6 +2600,18 @@ fn to_scenario_artifact(
             rows_per_sec: 0.0,
         }
     };
+    let total_elapsed_ms = measurement.total_elapsed_ns as f64 / 1_000_000.0;
+    let gc = scenario.gc_observation.as_ref().map(|gc| {
+        GcDerivedArtifact::from_gc_observation(
+            gc,
+            scenario.setup_elapsed_ns,
+            measurement.total_elapsed_ns,
+        )
+    });
+
+    let logical_before_compaction =
+        LogicalVolumeArtifact::from_version(scenario.version_before_compaction);
+    let logical_ready = LogicalVolumeArtifact::from_version(scenario.version_ready);
 
     ScenarioArtifact {
         scenario_id: scenario.scenario_id.to_string(),
@@ -1835,27 +2619,39 @@ fn to_scenario_artifact(
         scenario_variant_id: scenario.scenario_variant_id.clone(),
         dimensions: scenario.dimensions.clone(),
         setup: ScenarioSetupArtifact {
+            total_elapsed_ns: scenario.setup_elapsed_ns,
+            total_elapsed_ms: scenario.setup_elapsed_ns as f64 / 1_000_000.0,
             rows_per_scan: scenario.rows_per_op_hint,
             sst_count_before_compaction: scenario.version_before_compaction.sst_count,
             level_count_before_compaction: scenario.version_before_compaction.level_count,
             sst_count_ready: scenario.version_ready.sst_count,
             level_count_ready: scenario.version_ready.level_count,
-            logical_before_compaction: LogicalVolumeArtifact::from_version(
-                scenario.version_before_compaction,
-            ),
-            logical_ready: LogicalVolumeArtifact::from_version(scenario.version_ready),
+            logical_before_compaction: logical_before_compaction.clone(),
+            logical_ready: logical_ready.clone(),
             volume_before_compaction: scenario.volume_before_compaction.clone(),
             volume_ready: scenario.volume_ready.clone(),
+            physical_stale_estimate_before_compaction: PhysicalStaleEstimateArtifact::from_volume(
+                &scenario.volume_before_compaction,
+                &logical_before_compaction,
+            ),
+            physical_stale_estimate_ready: PhysicalStaleEstimateArtifact::from_volume(
+                &scenario.volume_ready,
+                &logical_ready,
+            ),
+            gc_observation: scenario.gc_observation.clone(),
             io: scenario.setup_io.clone(),
         },
         summary: ScenarioSummaryArtifact {
             iterations: measurement.iterations,
             total_elapsed_ns: measurement.total_elapsed_ns,
+            total_elapsed_ms,
             rows_processed: measurement.rows_processed,
             throughput,
             latency_ns: latency,
             read_path_latency_ns: read_path_latency,
             read_path_internal_ns: read_path_internal,
+            physical_stale_estimate: measurement.physical_stale_estimate,
+            gc,
             io: measurement.io,
         },
     }
@@ -2192,6 +2988,13 @@ fn fmt_pct_opt(value: Option<f64>) -> String {
     }
 }
 
+fn fmt_ratio_opt(value: Option<f64>) -> String {
+    match value {
+        Some(value) => format!("{value:.2}"),
+        None => "n/a".to_string(),
+    }
+}
+
 fn build_interpretation(
     backend: BenchBackend,
     read_ops_drop: Option<f64>,
@@ -2237,6 +3040,20 @@ fn duration_ns_u64(duration: Duration) -> u64 {
     u64::try_from(nanos).unwrap_or(u64::MAX)
 }
 
+fn ratio_per_ms(value: u64, duration_ms: u64) -> Option<f64> {
+    if duration_ms == 0 {
+        return None;
+    }
+    Some(value as f64 / duration_ms as f64)
+}
+
+fn pct_of_elapsed_ms(duration_ms: u64, elapsed_ns: u64) -> Option<f64> {
+    if elapsed_ns == 0 {
+        return None;
+    }
+    Some((duration_ms as f64 / (elapsed_ns as f64 / 1_000_000.0)) * 100.0)
+}
+
 fn usize_to_u64(value: usize) -> u64 {
     u64::try_from(value).unwrap_or(u64::MAX)
 }
@@ -2247,4 +3064,212 @@ fn unix_epoch_ms() -> u64 {
         Err(_) => Duration::from_secs(0),
     };
     u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn physical_stale_estimate_is_physical_minus_logical_delta() {
+        let physical = super::StorageVolumeArtifact {
+            sst_object_count: 7,
+            sst_bytes: 700,
+            ..super::StorageVolumeArtifact::default()
+        };
+        let logical = super::LogicalVolumeArtifact {
+            sst_count: 3,
+            sst_bytes: 250,
+            wal_bytes: None,
+            manifest_bytes: None,
+            total_bytes: 250,
+        };
+
+        let estimate = super::PhysicalStaleEstimateArtifact::from_volume(&physical, &logical);
+
+        assert_eq!(
+            estimate,
+            super::PhysicalStaleEstimateArtifact {
+                candidate_sst_objects: 4,
+                candidate_sst_bytes: 450,
+                live_sst_objects: 3,
+                live_sst_bytes: 250,
+                physical_sst_objects: 7,
+                physical_sst_bytes: 700,
+                stale_sst_byte_amplification_pct: 180.0,
+            }
+        );
+    }
+
+    #[test]
+    fn interpretation_calls_out_empty_persisted_plan_vs_physical_estimate() {
+        let gc = super::GcObservationArtifact {
+            volume_before_gc: super::StorageVolumeArtifact::default(),
+            volume_after_gc: super::StorageVolumeArtifact::default(),
+            physical_stale_estimate_before_explicit_sweep: super::PhysicalStaleEstimateArtifact {
+                candidate_sst_objects: 6,
+                candidate_sst_bytes: 600,
+                live_sst_objects: 3,
+                live_sst_bytes: 300,
+                physical_sst_objects: 9,
+                physical_sst_bytes: 900,
+                stale_sst_byte_amplification_pct: 200.0,
+            },
+            physical_stale_estimate_after_explicit_sweep: super::PhysicalStaleEstimateArtifact {
+                candidate_sst_objects: 6,
+                candidate_sst_bytes: 600,
+                live_sst_objects: 3,
+                live_sst_bytes: 300,
+                physical_sst_objects: 9,
+                physical_sst_bytes: 900,
+                stale_sst_byte_amplification_pct: 200.0,
+            },
+            reclaimed_sst_objects: 0,
+            reclaimed_sst_bytes: 0,
+            persisted_plan_before_explicit_sweep: None,
+            explicit_sweep_result: super::GcSweepArtifact {
+                deleted_objects: 0,
+                deleted_bytes: 0,
+                delete_failures: 0,
+                duration_ms: 1,
+            },
+            cumulative_before_explicit_sweep: super::GcCountersArtifact {
+                sweep_runs: 1,
+                deleted_objects: 0,
+                deleted_bytes: 0,
+                delete_failures: 0,
+                sweep_duration_ms_total: 1,
+                gc_plan_write_runs: 1,
+                gc_plan_overwrite_non_empty: 0,
+                gc_plan_previous_sst_candidates: 0,
+                gc_plan_written_sst_candidates: 6,
+                gc_plan_take_runs: 1,
+                gc_plan_taken_sst_candidates: 6,
+                gc_plan_authorized_sst_candidates: 6,
+                gc_plan_blocked_sst_candidates: 0,
+                gc_plan_requeued_sst_candidates: 0,
+            },
+            cumulative_after_explicit_sweep: super::GcCountersArtifact {
+                sweep_runs: 2,
+                deleted_objects: 0,
+                deleted_bytes: 0,
+                delete_failures: 0,
+                sweep_duration_ms_total: 2,
+                gc_plan_write_runs: 1,
+                gc_plan_overwrite_non_empty: 0,
+                gc_plan_previous_sst_candidates: 0,
+                gc_plan_written_sst_candidates: 6,
+                gc_plan_take_runs: 2,
+                gc_plan_taken_sst_candidates: 6,
+                gc_plan_authorized_sst_candidates: 6,
+                gc_plan_blocked_sst_candidates: 0,
+                gc_plan_requeued_sst_candidates: 0,
+            },
+            persisted_plan_after_explicit_sweep: None,
+        };
+
+        let interpretation =
+            super::explain_gc_observation(&gc).expect("interpretation should exist");
+
+        assert!(interpretation.contains("physical estimate is non-zero"));
+        assert!(interpretation.contains("persisted plan is empty"));
+        assert!(interpretation.contains("earlier compaction-triggered sweeps"));
+    }
+
+    #[test]
+    fn gc_derived_artifact_reports_timing_shares_and_reclaim_rates() {
+        let assert_close = |actual: Option<f64>, expected: f64| {
+            let actual = actual.expect("value should be present");
+            assert!((actual - expected).abs() < 0.000_001);
+        };
+        let gc = super::GcObservationArtifact {
+            volume_before_gc: super::StorageVolumeArtifact {
+                sst_object_count: 16,
+                sst_bytes: 1_600,
+                ..super::StorageVolumeArtifact::default()
+            },
+            volume_after_gc: super::StorageVolumeArtifact {
+                sst_object_count: 10,
+                sst_bytes: 1_000,
+                ..super::StorageVolumeArtifact::default()
+            },
+            physical_stale_estimate_before_explicit_sweep: super::PhysicalStaleEstimateArtifact {
+                candidate_sst_objects: 6,
+                candidate_sst_bytes: 600,
+                live_sst_objects: 10,
+                live_sst_bytes: 1_000,
+                physical_sst_objects: 16,
+                physical_sst_bytes: 1_600,
+                stale_sst_byte_amplification_pct: 60.0,
+            },
+            physical_stale_estimate_after_explicit_sweep: super::PhysicalStaleEstimateArtifact {
+                candidate_sst_objects: 0,
+                candidate_sst_bytes: 0,
+                live_sst_objects: 10,
+                live_sst_bytes: 1_000,
+                physical_sst_objects: 10,
+                physical_sst_bytes: 1_000,
+                stale_sst_byte_amplification_pct: 0.0,
+            },
+            reclaimed_sst_objects: 6,
+            reclaimed_sst_bytes: 600,
+            persisted_plan_before_explicit_sweep: None,
+            explicit_sweep_result: super::GcSweepArtifact {
+                deleted_objects: 1,
+                deleted_bytes: 100,
+                delete_failures: 0,
+                duration_ms: 2,
+            },
+            cumulative_before_explicit_sweep: super::GcCountersArtifact {
+                sweep_runs: 3,
+                deleted_objects: 5,
+                deleted_bytes: 500,
+                delete_failures: 0,
+                sweep_duration_ms_total: 8,
+                gc_plan_write_runs: 1,
+                gc_plan_overwrite_non_empty: 0,
+                gc_plan_previous_sst_candidates: 0,
+                gc_plan_written_sst_candidates: 6,
+                gc_plan_take_runs: 1,
+                gc_plan_taken_sst_candidates: 6,
+                gc_plan_authorized_sst_candidates: 6,
+                gc_plan_blocked_sst_candidates: 0,
+                gc_plan_requeued_sst_candidates: 0,
+            },
+            cumulative_after_explicit_sweep: super::GcCountersArtifact {
+                sweep_runs: 4,
+                deleted_objects: 6,
+                deleted_bytes: 600,
+                delete_failures: 0,
+                sweep_duration_ms_total: 10,
+                gc_plan_write_runs: 1,
+                gc_plan_overwrite_non_empty: 0,
+                gc_plan_previous_sst_candidates: 0,
+                gc_plan_written_sst_candidates: 6,
+                gc_plan_take_runs: 2,
+                gc_plan_taken_sst_candidates: 6,
+                gc_plan_authorized_sst_candidates: 6,
+                gc_plan_blocked_sst_candidates: 0,
+                gc_plan_requeued_sst_candidates: 0,
+            },
+            persisted_plan_after_explicit_sweep: None,
+        };
+
+        let derived = super::GcDerivedArtifact::from_gc_observation(&gc, 40_000_000, 200_000_000);
+
+        assert_eq!(derived.sst_sweep_runs, 4);
+        assert_eq!(derived.sst_sweep_duration_ms_total, 10);
+        assert_eq!(derived.sst_deleted_objects_total, 6);
+        assert_eq!(derived.sst_deleted_bytes_total, 600);
+        assert_eq!(derived.sst_sweep_runs_before_explicit_sweep, 3);
+        assert_eq!(derived.sst_sweep_duration_ms_before_explicit_sweep, 8);
+        assert_eq!(derived.sst_deleted_objects_before_explicit_sweep, 5);
+        assert_eq!(derived.sst_deleted_bytes_before_explicit_sweep, 500);
+        assert_eq!(derived.explicit_sweep_runs, 1);
+        assert_eq!(derived.explicit_sweep_duration_ms, 2);
+        assert_eq!(derived.explicit_sweep_deleted_objects, 1);
+        assert_eq!(derived.explicit_sweep_deleted_bytes, 100);
+        assert_close(derived.sst_deleted_bytes_per_ms, 60.0);
+        assert_close(derived.sst_deleted_objects_per_ms, 0.6);
+        assert_close(derived.gc_time_share_pct_of_setup, 25.0);
+        assert_close(derived.gc_time_share_pct_of_total_elapsed, 5.0);
+    }
 }

--- a/benches/compaction/results/sst_gc_rerun_2026-03-19.md
+++ b/benches/compaction/results/sst_gc_rerun_2026-03-19.md
@@ -1,0 +1,125 @@
+# SST GC Timing Rerun (2026-03-22)
+
+- Date (UTC): `2026-03-22`
+- Base commit: `3b22656a5c4d590310c005b128ede1d901f3a962`
+- Working tree note: this rerun used the branch-local snapshot-pin / GC changes plus
+  benchmark-harness updates in `benches/compaction/common.rs` to remove the deleted
+  manifest-retention API and report active snapshot pins instead.
+- Backend: `local`
+- Kept artifact: `target/tonbo-bench/compaction_local-1774213761099-1116172.json`
+- Scenario set:
+  - `read_baseline`
+  - `read_compaction_quiesced`
+  - `read_compaction_quiesced_after_gc`
+  - `write_heavy_no_sst_sweep`
+  - `write_heavy_with_sst_sweep`
+  - `estimate_sweep_candidates`
+
+## Command
+
+```bash
+TONBO_BENCH_BACKEND=local \
+TONBO_BENCH_DATASET_SCALE=20 \
+TONBO_COMPACTION_BENCH_INGEST_BATCHES=640 \
+TONBO_COMPACTION_BENCH_ROWS_PER_BATCH=64 \
+TONBO_COMPACTION_BENCH_WAL_SYNC=always \
+TONBO_COMPACTION_BENCH_ENABLE_READ_WHILE_COMPACTION=0 \
+TONBO_COMPACTION_BENCH_ENABLE_WRITE_THROUGHPUT_VS_COMPACTION_FREQUENCY=0 \
+TONBO_COMPACTION_BENCH_ARTIFACT_ITERATIONS=4 \
+TONBO_COMPACTION_BENCH_CRITERION_SAMPLE_SIZE=10 \
+cargo bench -p tonbo --bench compaction_local -- \
+  'read_baseline|read_compaction_quiesced|read_compaction_quiesced_after_gc|write_heavy_no_sst_sweep|write_heavy_with_sst_sweep|estimate_sweep_candidates' \
+  --nocapture
+```
+
+## Primary Result
+
+The kept `scale=20` local rerun still shows GC time clearly, but it also shows that reclaim
+already happened before the explicit observation point in the read path and partly overlapped the
+write-path observation window:
+
+| Scenario | Sweep Runs | Sweep Duration (ms) | Total Deleted SST Objects | Total Deleted SST Bytes | Deleted Bytes per ms | Deleted Objects per ms | GC Share of Setup | GC Share of Measured Steady-State Time |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `read_compaction_quiesced_after_gc` | `36` | `2,498` | `230` | `251,362,341` | `100,625.44` | `0.09` | `3.15%` | `247.14%` |
+| `write_heavy_with_sst_sweep` | `3` | `199` | `18` | `19,727,917` | `99,135.26` | `0.09` | `0.22%` | `16.51%` |
+
+## Timing Placement
+
+| Scenario | Sweep Runs Before Explicit Sweep | Sweep Duration Before Explicit Sweep (ms) | Explicit Sweep Runs | Explicit Sweep Duration (ms) | Explicit Sweep Deleted Objects | Explicit Sweep Deleted Bytes |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `read_compaction_quiesced_after_gc` | `36` | `2,498` | `0` | `0` | `0` | `0` |
+| `write_heavy_with_sst_sweep` | `2` | `131` | `1` | `68` | `6` | `6,576,034` |
+
+The read-focused scenario still points to sweep work happening before the explicit observation
+point. The write-focused scenario now shows one additional sweep run during the observation window,
+but not as foreground delete work reported by the explicit sweep call itself.
+
+## Physical SST Footprint With vs Without Prior GC
+
+To make reclaim volume easier to interpret, the table below reconstructs the implied physical SST
+footprint at the observation point if the already-completed background sweeps had not run yet:
+
+`implied physical SST without prior GC = physical SST at observation point + cumulative deleted SST
+bytes/objects before the explicit observation point`
+
+| Scenario | Current Physical SST Objects | Current Physical SST Bytes | Deleted Before Explicit Sweep (Objects) | Deleted Before Explicit Sweep (Bytes) | Implied Physical SST Objects Without Prior GC | Implied Physical SST Bytes Without Prior GC | GC Reduction vs Implied No-GC Footprint |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `read_compaction_quiesced_after_gc` | `6` | `6,486,182` | `230` | `251,362,341` | `236` | `257,848,523` | `97.48%` |
+| `write_heavy_with_sst_sweep` | `196` | `214,772,250` | `12` | `13,151,883` | `208` | `227,924,133` | `5.77%` |
+
+For the write-focused scenario, the physical SST footprint then fell further during the observation
+window to `191` objects / `209,269,754` bytes even though the explicit sweep call itself reported
+zero deleted objects.
+
+## Setup vs Steady-State
+
+| Scenario | Setup Time (ms) | Measured Steady-State Time (ms) | Mean Latency (ms) |
+| --- | ---: | ---: | ---: |
+| `read_compaction_quiesced` | `82,813.446` | `1,021.403` | `255.351` |
+| `read_compaction_quiesced_after_gc` | `79,401.932` | `1,010.743` | `252.686` |
+| `write_heavy_no_sst_sweep` | `78,662.434` | `1,271.527` | `317.881` |
+| `write_heavy_with_sst_sweep` | `90,190.690` | `1,205.507` | `301.377` |
+
+Latency deltas in the paired GC scenarios remained small:
+
+| Comparison | Mean Latency Delta |
+| --- | ---: |
+| `read_compaction_quiesced_after_gc` vs `read_compaction_quiesced` | `-1.04%` |
+| `write_heavy_with_sst_sweep` vs `write_heavy_no_sst_sweep` | `-5.19%` |
+
+## Conclusions
+
+### Read GC scenario
+
+- Reclaim volume was still material: background sweeps deleted `251,362,341` bytes across `230`
+  SST objects.
+- Without that prior GC, the read-focused scenario would have been carrying about `257.8 MB` of
+  physical SST data instead of `6.5 MB` at the observation point.
+- Reclaim duration was measurable but still small relative to setup time: `2,498 ms` total, or
+  `3.15%` of setup wall-clock time.
+- Sweep efficiency remained high in storage terms: `100,625.44 bytes/ms`.
+- The paired steady-state read latency still does not establish a material foreground GC win:
+  `read_compaction_quiesced_after_gc` was only `1.04%` faster than `read_compaction_quiesced`.
+- The sweep work was not on the measured foreground path in this artifact: all `36` sweep runs had
+  already happened before the explicit observation point, and the explicit sweep itself did no
+  deletion work.
+
+### Write GC scenario
+
+- Reclaim volume was larger than in the prior report: cumulative sweeps deleted `19,727,917` bytes
+  across `18` SST objects, with `13,151,883` bytes / `12` objects already reclaimed before the
+  explicit observation point.
+- Relative to setup time, reclaim cost remained very small: `199 ms` total, or `0.22%` of setup
+  wall-clock time.
+- Sweep efficiency was similar to the read scenario: `99,135.26 bytes/ms`.
+- At the explicit observation point, prior background GC reduced the implied physical SST footprint
+  from about `227.9 MB` to `214.8 MB`; the footprint then dropped further to `209.3 MB` during the
+  observation window.
+- The steady-state write companion moved in the other direction from the previous report:
+  `write_heavy_with_sst_sweep` was `5.19%` faster than `write_heavy_no_sst_sweep`. That is still
+  too small and noisy to treat as a clear GC effect on its own, especially because Criterion did
+  not detect a significant change for either write scenario.
+- Unlike the read scenario, one additional sweep run was recorded during the observation window
+  (`68 ms`, `6` objects, `6,576,034` bytes), but the explicit sweep call itself still reported no
+  direct delete work. The artifact therefore points to sweep activity overlapping setup/observation
+  rather than the measured steady-state foreground operation.

--- a/benches/compaction/sst_gc_baseline.md
+++ b/benches/compaction/sst_gc_baseline.md
@@ -1,0 +1,109 @@
+# SST GC Baseline Harness
+
+This baseline uses the existing `compaction_local` Criterion bench to measure the
+pre-SST-GC state: compaction publishes replacement SSTs, but obsolete SST objects
+remain physically present because no SST sweep/delete path is enabled yet.
+
+## Scenarios
+
+- `read_compaction_quiesced`
+  - Reads from the current HEAD after compaction settles.
+  - This is the main read-latency baseline while obsolete SSTs accumulate.
+- `write_heavy_no_sst_sweep`
+  - Measures sustained write latency/throughput with compaction enabled and no SST sweep.
+- `estimate_sweep_candidates`
+  - Benchmarks the reclaim-estimation pass itself.
+  - The operation compares physical SST bytes/object counts against the current live manifest view.
+
+Optional comparison:
+
+- `read_baseline`
+  - Captures read cost before obsolete SSTs exist.
+  - Useful for directional comparison against `read_compaction_quiesced`.
+
+## What The Harness Records
+
+Each scenario artifact now includes:
+
+- End-to-end latency and throughput.
+- Read-path breakdowns for read scenarios.
+- Physical storage footprint before/after the setup workload.
+- Logical live SST footprint from `list_versions()`.
+- `physical_stale_estimate_before_compaction` and `physical_stale_estimate_ready`:
+  - `candidate_sst_objects`
+  - `candidate_sst_bytes`
+  - `stale_sst_byte_amplification_pct`
+- Request counters visible to the benchmark:
+  - read/write/list/remove/copy/link
+  - CAS load / CAS put
+  - head metadata
+  - request totals split by SST / WAL / manifest / other paths
+
+The physical stale estimate metrics are intentionally estimates. They do not delete or mutate SSTs.
+They quantify the physical-minus-live SST gap, not the persisted GC plan and not what an explicit sweep has necessarily deleted.
+
+## Environment Assumptions
+
+- Offline and deterministic by default on `TONBO_BENCH_BACKEND=local`.
+- Object-store runs are supported, but use a unique `TONBO_BENCH_OBJECT_PREFIX` for each run.
+- Recommended for saved baselines:
+  - `TONBO_COMPACTION_BENCH_WAL_SYNC=always`
+  - fixed `TONBO_BENCH_DATASET_SCALE`
+  - fixed `TONBO_COMPACTION_BENCH_INGEST_BATCHES`
+  - fixed `TONBO_COMPACTION_BENCH_ROWS_PER_BATCH`
+
+## Recommended Baseline Command
+
+```bash
+TONBO_BENCH_BACKEND=local \
+TONBO_BENCH_DATASET_SCALE=4 \
+TONBO_COMPACTION_BENCH_INGEST_BATCHES=640 \
+TONBO_COMPACTION_BENCH_ROWS_PER_BATCH=64 \
+TONBO_COMPACTION_BENCH_WAL_SYNC=always \
+TONBO_COMPACTION_BENCH_ENABLE_READ_WHILE_COMPACTION=0 \
+TONBO_COMPACTION_BENCH_ENABLE_WRITE_THROUGHPUT_VS_COMPACTION_FREQUENCY=0 \
+cargo bench -p tonbo --bench compaction_local -- \
+  --save-baseline sst_gc_pre_enablement_v1
+```
+
+To shorten a focused local validation run while iterating on the harness:
+
+```bash
+TONBO_COMPACTION_BENCH_ARTIFACT_ITERATIONS=4 \
+TONBO_COMPACTION_BENCH_CRITERION_SAMPLE_SIZE=10 \
+cargo bench -p tonbo --bench compaction_local -- estimate_sweep_candidates --nocapture
+```
+
+## Baseline Outputs To Save
+
+Save all of the following together:
+
+- Criterion baseline name:
+  - `sst_gc_pre_enablement_v1` or a dated successor
+- JSON artifact path printed by the bench:
+  - `target/tonbo-bench/compaction_local-<run_id>.json`
+- Git commit SHA
+- Local environment knobs used for the run
+- A short markdown summary capturing the retained artifact path, environment,
+  and the key latency/storage/reclaim fields listed below
+
+Minimum fields to copy from the artifact:
+
+- `summary.latency_ns.mean`, `p95`, `p99`
+- `summary.throughput`
+- `summary.io`
+- `setup.volume_before_compaction`, `setup.volume_ready`
+- `setup.logical_before_compaction`, `setup.logical_ready`
+- `setup.physical_stale_estimate_before_compaction`, `setup.physical_stale_estimate_ready`
+- `summary.physical_stale_estimate` for `estimate_sweep_candidates`
+
+## Interpreting The Baseline
+
+- `physical_stale_estimate_ready.candidate_sst_bytes > 0`
+  - confirms compaction has created reclaimable SST debt with no sweep enabled.
+- `manifest_request_ops`
+  - shows how much manifest coordination the workload already pays before SST GC exists.
+- `list_ops` in `estimate_sweep_candidates`
+  - approximates the object-store/list cost of a no-delete planning pass.
+- `read_compaction_quiesced` vs `read_baseline`
+  - separates read-visible benefits of compaction from the still-unreclaimed physical footprint.

--- a/benches/compaction_local.rs
+++ b/benches/compaction_local.rs
@@ -10,12 +10,13 @@ mod common;
 use common::{
     BenchBackend, BenchError, CompactionProfile, CompactionSweepPoint, CompactionTuning,
     ObjectStoreBenchConfig, ResolvedConfig, ScenarioDimensionsArtifact, ScenarioState,
-    ScenarioWorkload, StorageVolumeArtifact, VersionSummary, WriteWorkloadState, artifact_path,
-    benchmark_schema, build_artifact, build_run_id, build_runtime, ingest_workload,
-    latest_version_summary, latest_version_summary_if_any, open_benchmark_db,
-    open_object_store_benchmark_db, print_directional_report, read_all_rows, run_criterion,
-    scenario_root, snapshot_local_storage_volume, snapshot_object_store_storage_volume,
-    wait_for_compaction_quiesced, wait_for_first_compaction_observed, write_artifact_json,
+    ScenarioStorageTarget, ScenarioWorkload, StorageVolumeArtifact, VersionSummary,
+    WriteWorkloadState, artifact_path, benchmark_schema, build_artifact, build_run_id,
+    build_runtime, ingest_workload, latest_version_summary, latest_version_summary_if_any,
+    open_benchmark_db, open_object_store_benchmark_db, print_directional_report, read_all_rows,
+    run_criterion, run_gc_observation, scenario_root, snapshot_local_storage_volume,
+    snapshot_object_store_storage_volume, wait_for_compaction_quiesced,
+    wait_for_first_compaction_observed, write_artifact_json,
 };
 
 #[derive(Clone)]
@@ -106,6 +107,30 @@ async fn prepare_scenarios(
             prepare_read_compaction_quiesced(config, run_id, storage).await,
         )?;
     }
+    if should_prepare_scenario(&selected, "read_compaction_quiesced_after_gc") {
+        push_prepared_scenario(
+            &mut scenarios,
+            prepare_read_compaction_quiesced_after_gc(config, run_id, storage).await,
+        )?;
+    }
+    if should_prepare_scenario(&selected, "write_heavy_no_sst_sweep") {
+        push_prepared_scenario(
+            &mut scenarios,
+            prepare_write_heavy_no_sst_sweep(config, run_id, storage).await,
+        )?;
+    }
+    if should_prepare_scenario(&selected, "write_heavy_with_sst_sweep") {
+        push_prepared_scenario(
+            &mut scenarios,
+            prepare_write_heavy_with_sst_sweep(config, run_id, storage).await,
+        )?;
+    }
+    if should_prepare_scenario(&selected, "estimate_sweep_candidates") {
+        push_prepared_scenario(
+            &mut scenarios,
+            prepare_estimate_sweep_candidates(config, run_id, storage).await,
+        )?;
+    }
 
     let sweep_points = config.compaction_sweep_points();
     if config.enable_read_while_compaction {
@@ -138,10 +163,14 @@ async fn prepare_scenarios(
 }
 
 fn selected_scenario_filter() -> Option<HashSet<&'static str>> {
-    const KNOWN_SCENARIOS: [&str; 5] = [
+    const KNOWN_SCENARIOS: [&str; 9] = [
         "read_baseline",
         "read_after_first_compaction_observed",
         "read_compaction_quiesced",
+        "read_compaction_quiesced_after_gc",
+        "write_heavy_no_sst_sweep",
+        "write_heavy_with_sst_sweep",
+        "estimate_sweep_candidates",
         "read_while_compaction",
         "write_throughput_vs_compaction_frequency",
     ];
@@ -232,6 +261,7 @@ async fn prepare_read_baseline(
     run_id: &str,
     storage: &ScenarioStorage,
 ) -> Result<ScenarioState, BenchError> {
+    let setup_started = Instant::now();
     let scenario_id = "read_baseline";
     let scenario_variant_id = "default".to_string();
     let benchmark_id = scenario_id.to_string();
@@ -269,6 +299,7 @@ async fn prepare_read_baseline(
     let volume_ready = snapshot_scenario_volume(storage, run_id, &benchmark_id).await?;
     let setup_io = io_probe.snapshot();
     timing.emit(scenario_id);
+    let storage_target = storage_target(storage, run_id, &benchmark_id)?;
 
     Ok(ScenarioState {
         scenario_id,
@@ -276,18 +307,21 @@ async fn prepare_read_baseline(
         scenario_variant_id: scenario_variant_id.clone(),
         benchmark_id,
         workload: ScenarioWorkload::ReadOnly,
+        storage_target,
         dimensions: ScenarioDimensionsArtifact::baseline(
             scenario_variant_id,
             ScenarioWorkload::ReadOnly,
         ),
         db,
         io_probe,
+        setup_elapsed_ns: elapsed_ns(setup_started),
         setup_io,
         rows_per_op_hint: rows_per_scan,
         version_before_compaction: version_ready,
         version_ready,
         volume_before_compaction,
         volume_ready,
+        gc_observation: None,
         write_state: None,
     })
 }
@@ -303,6 +337,7 @@ async fn prepare_read_after_first_compaction_observed(
         storage,
         "read_after_first_compaction_observed",
         "Read After First Compaction Observed",
+        false,
         false,
     )
     .await
@@ -320,6 +355,24 @@ async fn prepare_read_compaction_quiesced(
         "read_compaction_quiesced",
         "Read Compaction Quiesced",
         true,
+        false,
+    )
+    .await
+}
+
+async fn prepare_read_compaction_quiesced_after_gc(
+    config: &ResolvedConfig,
+    run_id: &str,
+    storage: &ScenarioStorage,
+) -> Result<ScenarioState, BenchError> {
+    prepare_read_compaction_state(
+        config,
+        run_id,
+        storage,
+        "read_compaction_quiesced_after_gc",
+        "Read Compaction Quiesced After GC",
+        true,
+        true,
     )
     .await
 }
@@ -331,7 +384,9 @@ async fn prepare_read_compaction_state(
     scenario_id: &'static str,
     scenario_name: &'static str,
     wait_for_quiesced: bool,
+    run_gc_before_measurement: bool,
 ) -> Result<ScenarioState, BenchError> {
+    let setup_started = Instant::now();
     let scenario_variant_id = "default".to_string();
     let benchmark_id = scenario_id.to_string();
     let schema = benchmark_schema();
@@ -386,10 +441,19 @@ async fn prepare_read_compaction_state(
     }
     timing.record("wait_for_compaction_state", phase_started);
     let version_ready = latest_version_summary(&db).await?;
+    let storage_target = storage_target(storage, run_id, &benchmark_id)?;
+    let volume_ready = snapshot_scenario_volume(storage, run_id, &benchmark_id).await?;
+    let gc_observation = if run_gc_before_measurement {
+        let phase_started = Instant::now();
+        let observation = run_gc_observation(&db, &storage_target).await?;
+        timing.record("gc_sweep", phase_started);
+        Some(observation)
+    } else {
+        None
+    };
     let phase_started = Instant::now();
     let (rows_per_scan, _) = read_all_rows(&db).await?;
     timing.record("read_all_rows", phase_started);
-    let volume_ready = snapshot_scenario_volume(storage, run_id, &benchmark_id).await?;
     let setup_io = io_probe.snapshot();
     timing.emit(scenario_id);
 
@@ -399,18 +463,21 @@ async fn prepare_read_compaction_state(
         scenario_variant_id: scenario_variant_id.clone(),
         benchmark_id,
         workload: ScenarioWorkload::ReadOnly,
+        storage_target,
         dimensions: ScenarioDimensionsArtifact::baseline(
             scenario_variant_id,
             ScenarioWorkload::ReadOnly,
         ),
         db,
         io_probe,
+        setup_elapsed_ns: elapsed_ns(setup_started),
         setup_io,
         rows_per_op_hint: rows_per_scan,
         version_before_compaction,
         version_ready,
         volume_before_compaction,
         volume_ready,
+        gc_observation,
         write_state: None,
     })
 }
@@ -421,6 +488,7 @@ async fn prepare_read_while_compaction(
     point: &CompactionSweepPoint,
     storage: &ScenarioStorage,
 ) -> Result<ScenarioState, BenchError> {
+    let setup_started = Instant::now();
     let scenario_id = "read_while_compaction";
     let tuning = compaction_tuning(point, config.compaction_periodic_tick_ms);
     let scenario_variant_id = sweep_variant_id(point, tuning.periodic_tick_ms);
@@ -476,6 +544,7 @@ async fn prepare_read_while_compaction(
         config.seed ^ 0xA11CE,
         u64::try_from(config.ingest_batches).unwrap_or(u64::MAX),
     );
+    let storage_target = storage_target(storage, run_id, &benchmark_id)?;
 
     Ok(ScenarioState {
         scenario_id,
@@ -489,6 +558,7 @@ async fn prepare_read_while_compaction(
         scenario_variant_id: scenario_variant_id.clone(),
         benchmark_id,
         workload: ScenarioWorkload::ReadWhileCompaction,
+        storage_target,
         dimensions: ScenarioDimensionsArtifact::swept(
             scenario_variant_id,
             ScenarioWorkload::ReadWhileCompaction,
@@ -496,12 +566,14 @@ async fn prepare_read_while_compaction(
         ),
         db,
         io_probe,
+        setup_elapsed_ns: elapsed_ns(setup_started),
         setup_io,
         rows_per_op_hint: rows_per_scan,
         version_before_compaction,
         version_ready,
         volume_before_compaction,
         volume_ready,
+        gc_observation: None,
         write_state: Some(write_state),
     })
 }
@@ -513,6 +585,7 @@ async fn prepare_write_throughput_vs_compaction_frequency(
     periodic_tick_ms: u64,
     storage: &ScenarioStorage,
 ) -> Result<ScenarioState, BenchError> {
+    let setup_started = Instant::now();
     let scenario_id = "write_throughput_vs_compaction_frequency";
     let tuning = compaction_tuning(point, periodic_tick_ms);
     let scenario_variant_id = sweep_variant_id(point, periodic_tick_ms);
@@ -567,6 +640,7 @@ async fn prepare_write_throughput_vs_compaction_frequency(
         config.seed ^ 0xBEE5,
         u64::try_from(config.ingest_batches).unwrap_or(u64::MAX),
     );
+    let storage_target = storage_target(storage, run_id, &benchmark_id)?;
 
     Ok(ScenarioState {
         scenario_id,
@@ -581,6 +655,7 @@ async fn prepare_write_throughput_vs_compaction_frequency(
         scenario_variant_id: scenario_variant_id.clone(),
         benchmark_id,
         workload: ScenarioWorkload::WriteThroughput,
+        storage_target,
         dimensions: ScenarioDimensionsArtifact::swept(
             scenario_variant_id,
             ScenarioWorkload::WriteThroughput,
@@ -588,13 +663,215 @@ async fn prepare_write_throughput_vs_compaction_frequency(
         ),
         db,
         io_probe,
+        setup_elapsed_ns: elapsed_ns(setup_started),
         setup_io,
         rows_per_op_hint: config.rows_per_batch,
         version_before_compaction,
         version_ready,
         volume_before_compaction,
         volume_ready,
+        gc_observation: None,
         write_state: Some(write_state),
+    })
+}
+
+async fn prepare_write_heavy_no_sst_sweep(
+    config: &ResolvedConfig,
+    run_id: &str,
+    storage: &ScenarioStorage,
+) -> Result<ScenarioState, BenchError> {
+    prepare_write_heavy_state(
+        config,
+        run_id,
+        storage,
+        "write_heavy_no_sst_sweep",
+        "Write Heavy No SST Sweep",
+        false,
+    )
+    .await
+}
+
+async fn prepare_write_heavy_with_sst_sweep(
+    config: &ResolvedConfig,
+    run_id: &str,
+    storage: &ScenarioStorage,
+) -> Result<ScenarioState, BenchError> {
+    prepare_write_heavy_state(
+        config,
+        run_id,
+        storage,
+        "write_heavy_with_sst_sweep",
+        "Write Heavy With SST Sweep",
+        true,
+    )
+    .await
+}
+
+async fn prepare_write_heavy_state(
+    config: &ResolvedConfig,
+    run_id: &str,
+    storage: &ScenarioStorage,
+    scenario_id: &'static str,
+    scenario_name: &'static str,
+    run_gc_before_measurement: bool,
+) -> Result<ScenarioState, BenchError> {
+    let setup_started = Instant::now();
+    let scenario_variant_id = "default".to_string();
+    let benchmark_id = scenario_id.to_string();
+    let schema = benchmark_schema();
+    let io_probe = common::IoProbe::default();
+
+    let ingest_only_db = open_scenario_db(
+        storage,
+        &schema,
+        run_id,
+        &benchmark_id,
+        config,
+        &CompactionProfile::Disabled,
+        &io_probe,
+    )
+    .await?;
+    ingest_workload(&ingest_only_db, &schema, config).await?;
+    let volume_before_compaction = snapshot_scenario_volume(storage, run_id, &benchmark_id).await?;
+    let Some(version_before_compaction) = latest_version_summary_if_any(&ingest_only_db).await?
+    else {
+        return scenario_skipped(
+            scenario_id,
+            "ingest produced no manifest versions; increase TONBO_COMPACTION_BENCH_INGEST_BATCHES",
+        );
+    };
+    ensure_ssts_present(scenario_id, version_before_compaction)?;
+    drop(ingest_only_db);
+
+    let db = open_scenario_db(
+        storage,
+        &schema,
+        run_id,
+        &benchmark_id,
+        config,
+        &CompactionProfile::Default {
+            periodic_tick_ms: config.compaction_periodic_tick_ms,
+        },
+        &io_probe,
+    )
+    .await?;
+    wait_for_first_compaction_observed(&db, version_before_compaction, config).await?;
+    let version_ready = latest_version_summary(&db).await?;
+    let volume_ready = snapshot_scenario_volume(storage, run_id, &benchmark_id).await?;
+    let storage_target = storage_target(storage, run_id, &benchmark_id)?;
+    let gc_observation = if run_gc_before_measurement {
+        Some(run_gc_observation(&db, &storage_target).await?)
+    } else {
+        None
+    };
+    let setup_io = io_probe.snapshot();
+    let write_state = WriteWorkloadState::new(
+        Arc::clone(&schema),
+        config.rows_per_batch,
+        config.key_space,
+        config.seed ^ 0x594,
+        u64::try_from(config.ingest_batches).unwrap_or(u64::MAX),
+    );
+
+    Ok(ScenarioState {
+        scenario_id,
+        scenario_name: scenario_name.to_string(),
+        scenario_variant_id: scenario_variant_id.clone(),
+        benchmark_id,
+        workload: ScenarioWorkload::WriteThroughput,
+        storage_target,
+        dimensions: ScenarioDimensionsArtifact::baseline(
+            scenario_variant_id,
+            ScenarioWorkload::WriteThroughput,
+        ),
+        db,
+        io_probe,
+        setup_elapsed_ns: elapsed_ns(setup_started),
+        setup_io,
+        rows_per_op_hint: config.rows_per_batch,
+        version_before_compaction,
+        version_ready,
+        volume_before_compaction,
+        volume_ready,
+        gc_observation,
+        write_state: Some(write_state),
+    })
+}
+
+async fn prepare_estimate_sweep_candidates(
+    config: &ResolvedConfig,
+    run_id: &str,
+    storage: &ScenarioStorage,
+) -> Result<ScenarioState, BenchError> {
+    let setup_started = Instant::now();
+    let scenario_id = "estimate_sweep_candidates";
+    let scenario_variant_id = "default".to_string();
+    let benchmark_id = scenario_id.to_string();
+    let schema = benchmark_schema();
+    let io_probe = common::IoProbe::default();
+
+    let ingest_only_db = open_scenario_db(
+        storage,
+        &schema,
+        run_id,
+        &benchmark_id,
+        config,
+        &CompactionProfile::Disabled,
+        &io_probe,
+    )
+    .await?;
+    ingest_workload(&ingest_only_db, &schema, config).await?;
+    let volume_before_compaction = snapshot_scenario_volume(storage, run_id, &benchmark_id).await?;
+    let Some(version_before_compaction) = latest_version_summary_if_any(&ingest_only_db).await?
+    else {
+        return scenario_skipped(
+            scenario_id,
+            "ingest produced no manifest versions; increase TONBO_COMPACTION_BENCH_INGEST_BATCHES",
+        );
+    };
+    ensure_ssts_present(scenario_id, version_before_compaction)?;
+    drop(ingest_only_db);
+
+    let db = open_scenario_db(
+        storage,
+        &schema,
+        run_id,
+        &benchmark_id,
+        config,
+        &CompactionProfile::Default {
+            periodic_tick_ms: config.compaction_periodic_tick_ms,
+        },
+        &io_probe,
+    )
+    .await?;
+    wait_for_compaction_quiesced(&db, version_before_compaction, config).await?;
+    let version_ready = latest_version_summary(&db).await?;
+    let volume_ready = snapshot_scenario_volume(storage, run_id, &benchmark_id).await?;
+    let setup_io = io_probe.snapshot();
+    let storage_target = storage_target(storage, run_id, &benchmark_id)?;
+
+    Ok(ScenarioState {
+        scenario_id,
+        scenario_name: "Estimate Sweep Candidates".to_string(),
+        scenario_variant_id: scenario_variant_id.clone(),
+        benchmark_id,
+        workload: ScenarioWorkload::SweepEstimate,
+        storage_target,
+        dimensions: ScenarioDimensionsArtifact::baseline(
+            scenario_variant_id,
+            ScenarioWorkload::SweepEstimate,
+        ),
+        db,
+        io_probe,
+        setup_elapsed_ns: elapsed_ns(setup_started),
+        setup_io,
+        rows_per_op_hint: 1,
+        version_before_compaction,
+        version_ready,
+        volume_before_compaction,
+        volume_ready,
+        gc_observation: None,
+        write_state: None,
     })
 }
 
@@ -674,6 +951,10 @@ fn format_max_task_bytes(value: Option<usize>) -> String {
     }
 }
 
+fn elapsed_ns(started: Instant) -> u64 {
+    started.elapsed().as_nanos().min(u64::MAX as u128) as u64
+}
+
 fn ensure_ssts_present(scenario_id: &str, summary: VersionSummary) -> Result<(), BenchError> {
     if summary.sst_count == 0 {
         return scenario_skipped(
@@ -689,6 +970,29 @@ fn scenario_skipped<T>(scenario_id: &str, reason: impl Into<String>) -> Result<T
         scenario_id: scenario_id.to_string(),
         reason: reason.into(),
     })
+}
+
+fn storage_target(
+    storage: &ScenarioStorage,
+    run_id: &str,
+    benchmark_id: &str,
+) -> Result<ScenarioStorageTarget, BenchError> {
+    match storage.backend {
+        BenchBackend::Local => Ok(ScenarioStorageTarget::Local {
+            root: scenario_root(run_id, benchmark_id),
+        }),
+        BenchBackend::ObjectStore => storage
+            .object_store
+            .as_ref()
+            .map(|object_store| ScenarioStorageTarget::ObjectStore {
+                spec: object_store.object_spec(run_id, benchmark_id),
+            })
+            .ok_or_else(|| {
+                BenchError::Message(format!(
+                    "object store config missing for benchmark `{benchmark_id}`"
+                ))
+            }),
+    }
 }
 
 criterion_group!(benches, compaction_local);

--- a/docs/benchmark_program.md
+++ b/docs/benchmark_program.md
@@ -187,7 +187,7 @@ Use:
 - calculate write amp and cleanup lag
 - identify whether planner or executor is the bottleneck
 
-#### GC and retention
+#### GC and snapshot pinning
 
 Why:
 
@@ -200,12 +200,12 @@ Add:
 - obsolete object count pending delete
 - time from obsolete to reclaimed
 - delete request counts and latency
-- retained bytes due to snapshots or retention
+- protected bytes due to active snapshot pins
 
 Use:
 
 - explain physical amplification windows
-- set GC cadence and retention defaults
+- set GC cadence and snapshot-lifetime guidance
 - distinguish delayed reclaim from ineffective compaction
 
 #### Manifest and metadata path
@@ -297,7 +297,8 @@ Add:
 - compaction settings
 - page size
 - batch size
-- retention settings
+- WAL retention settings
+- snapshot / historical-read workload shape
 - git revision
 
 Use:
@@ -311,7 +312,7 @@ Use:
 2. WAL and commit-path timers
 3. Topology capture and harness/system metrics
 4. Minor and major compaction accounting
-5. GC and retention metrics
+5. GC and snapshot-pinning metrics
 6. Richer manifest and CAS instrumentation
 
 ### Minimum Instrumentation Required Before Each Scenario
@@ -572,7 +573,7 @@ Timing:
 
 ### 6. `gc_lag_storage_amplification_window`
 
-Why sixth: users eventually ask what cleanup and retention do to storage cost,
+Why sixth: users eventually ask what cleanup and active snapshot pins do to storage cost,
 object count, and read stability after compaction publishes new data.
 
 Tonbo why: it turns the current physical-byte caveat into an operational
@@ -586,9 +587,9 @@ Reference pattern:
 
 Workload:
 
-- Sustain overwrite and delete traffic through repeated compaction cycles with
-  retention windows like 0, 5, and 30 minutes while a light analytical read
-  load stays active.
+- Sustain overwrite and delete traffic through repeated compaction cycles while
+  varying the lifetime of concurrent read snapshots that pin historical
+  manifest versions.
 
 Metrics:
 
@@ -602,8 +603,9 @@ Metrics:
 Decision:
 
 - GC cadence
-- retention defaults
-- whether reader registry or stronger watermarking is required before broader
+- snapshot-lifetime guidance
+- whether in-process snapshot pinning is sufficient or stronger/durable
+  reader coordination is required before broader
   claims
 
 Timing:

--- a/docs/benchmark_results.md
+++ b/docs/benchmark_results.md
@@ -182,6 +182,41 @@ Therefore:
 - use logical live-set for compaction effectiveness,
 - use physical bytes for GC/debug interpretation.
 
+### Validated: GC can materially shrink physical SST footprint without showing a steady-state latency win
+
+The branch-local SST GC rerun in
+`benches/compaction/results/sst_gc_rerun_2026-03-19.md` adds the missing cleanup-cost view.
+
+What it validates:
+
+- in the kept local `scale=20` read-focused scenario, prior background sweeps deleted
+  `251,362,341` bytes across `230` obsolete SST objects before the final observation point,
+- those GC sweeps consumed `2,498 ms` of wall-clock time during setup, while total setup took
+  `79,402 ms`, so GC accounted for about `3.15%` of setup elapsed time,
+- without those earlier sweeps, the scenario would have been carrying `257,848,523` bytes of
+  physical SST data at the observation point, versus the `6,486,182` bytes actually present after
+  reclaim,
+- even with that large reduction in physical SST footprint, the paired steady-state read latency
+  only moved by about `-1.04%` in the final cleaned-up state.
+
+Interpretation:
+
+- GC can be highly valuable for physical storage cost and bounded object count,
+- in this scenario, a much larger amount of dead physical SST data did not produce a measurable
+  steady-state read-latency penalty,
+- that benefit does not by itself imply a measurable steady-state latency win in this harness,
+- and the observed sweep work in this run landed on the compaction/setup path rather than in the
+  measured foreground operation.
+
+The same rerun also refined the write-side conclusion:
+
+- cumulative SST reclaim still remained small relative to setup cost in the write-heavy scenario,
+- the paired write run moved to `-5.19%` mean latency for `write_heavy_with_sst_sweep` relative to
+  `write_heavy_no_sst_sweep`,
+- but that shift is still too small and noisy to treat as a clear foreground GC win on its own,
+- and the artifact shows one additional sweep overlapping the observation window rather than a
+  stable measured write-path speedup caused by explicit foreground reclaim.
+
 ## Inconclusive Or Blocked Conclusions
 
 ### Inconclusive: object-store root cause
@@ -265,3 +300,4 @@ Treat the documents below as appendices and raw evidence, not as the primary PR 
 - `benches/compaction/results/compaction_local_baseline.md`
 - `benches/compaction/results/compaction_directional_matrix_2026-02-27.md`
 - `benches/compaction/results/compaction_directional_phase_split_2026-03-01.md`
+- `benches/compaction/results/sst_gc_rerun_2026-03-19.md`

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -235,8 +235,8 @@ Major compaction merges L0..Ln SSTs when level thresholds are exceeded. The proc
 
 Tonbo's GC is **manifest-driven and snapshot-safe**, designed for object storage:
 
-- **Reachability by manifest:** only delete WAL/SST objects **not referenced** by the HEAD manifest or any **retained versions** (time-travel).
-- **Snapshot grace:** respect active snapshot timestamps so **no in-use object** is collected.
+- **Reachability by manifest:** only delete WAL/SST objects **not referenced** by the HEAD manifest or any **active in-process snapshot pins**.
+- **Snapshot grace:** respect active snapshot pins so **no in-use object** is collected.
 - **Write-new only:** incomplete/unpublished objects are never visible and can be safely removed; GC targets **superseded SSTs**, **old WAL fragments**, and **orphaned uploads**.
 - **Asynchronous & idempotent:** runs in the background (via compactor or a small GC worker) as a simple **plan -> sweep** routine; safe to retry, no local state.
 - **Serverless-friendly:** correctness lives in **object storage + manifest**; GC reduces read amplification and object/list costs without centralized coordination.
@@ -414,7 +414,7 @@ async fn run_transaction() -> Result<(), Box<dyn std::error::Error>> {
 ### Recovery & GC
 
 - **Recovery**: load the latest good manifest; replay ordered WAL fragments into the mutable memtable so WAL-backed rows participate in the read path immediately; ignore objects not referenced by any committed manifest.
-- **GC**: manifest drives retirement of obsolete WAL/SST generations with retention windows and safety checks.
+- **GC**: manifest drives retirement of obsolete WAL/SST generations using HEAD reachability, WAL floors, and active snapshot pins.
 
 ### Invariants
 
@@ -431,7 +431,7 @@ Tonbo makes **time-travel, rollback, and dataset freezing** first-class by publi
 
 * **Snapshot (read)**: a stable `(manifest_version, read_ts, schema_set)` view; sessions pin it for reproducible scans. *Implemented via `snapshot_at()` and `list_versions()` APIs.*
 * **Checkpoint (write)**: `flush -> L0 -> CAS publish` atomically switches **SST visibility + catalog edits**. *Basic checkpoint flow works.* Named tags (e.g., `episode:123`) are planned (#554).
-* **Time travel**: address by **version / timestamp** within retention. *Implemented.* Addressing by tag and **pins** to prevent GC are planned (#554).
+* **Time travel**: address by **version / timestamp**. *Implemented.* Live snapshots hold in-process pins that keep referenced SSTs safe from GC; named tags are planned (#554).
 * **Export / restore**: materialize a tagged version; optionally move `HEAD` back to a prior version. *Planned feature.*
 
 ### Catalog-aware DDL
@@ -439,7 +439,7 @@ Tonbo makes **time-travel, rollback, and dataset freezing** first-class by publi
 * **Additive (safe)**: add NULLable columns, widen types, add indexes -> publish at checkpoint; old files read missing cols as NULL/default.
 * **Destructive** (drop/rename/narrow/vector-dim change):
   * **Soft drop (default)**: hide in catalog at checkpoint; background compaction rewrites; old snapshots remain readable until GC.
-  * **Hard drop (compliance)**: checkpoint carries a rewrite plan; compactor rewrites immediately; tighten retention to retire prior versions early.
+  * **Hard drop (compliance)**: checkpoint carries a rewrite plan; compactor rewrites immediately; prior files become reclaimable once no live snapshot still pins them.
 
 ### Sidecar indexes (planned)
 
@@ -450,7 +450,7 @@ Tonbo makes **time-travel, rollback, and dataset freezing** first-class by publi
 
 ### Ops defaults
 
-* Retention window (e.g., 7–30 days); **pin** episodes/releases.
+* Use explicit checkpoints/tags for durable rollback points; live reads rely on in-process snapshot pins.
 * Checkpoint before destructive DDL and at episode/task boundaries.
 * Compaction publishes new versions; old versions readable until GC.
 
@@ -614,7 +614,7 @@ Tonbo’s **manifest** is the authoritative source of truth that coordinates **s
 - **Atomic, monotonic versions:** readers never see partial updates; HEAD only moves forward.
 - **Idempotent commits:** duplicate publishes do not corrupt state.
 - **Append-only correctness:** all durable state is new objects + manifest switches.
-- **Time travel & retention:** keep recent versions for rollback/analysis; GC removes unreachable generations when safe.
+- **Time travel & snapshot pins:** historical versions stay queryable while their manifest entries exist; GC removes generations not reachable from HEAD or any live snapshot pin.
 
 ### Why it fits distributed serverless
 

--- a/docs/rethink-summary.md
+++ b/docs/rethink-summary.md
@@ -89,7 +89,7 @@ Rethinking Tonbo pivots the engine to a single Arrow‑first, runtime columnar c
 
 - **Previous:** In-memory `read_ts` only; no durable checkpoints; u32 wrap risk.
 - **Current:** u64 `Timestamp`; `snapshot_at()` and `list_versions()` APIs; manifest-backed snapshots survive restart; uniform MVCC columns (`_commit_ts`); WAL floor tracking.
-- **Remaining:** Named checkpoints with tags (#554); reader registry for GC watermarks (#547); version retention policies.
+- **Remaining:** Named checkpoints with tags (#554); extend snapshot pinning beyond the current in-process scope for cross-process GC safety (#547).
 
 ## Risks
 

--- a/docs/rfcs/0007-manifest.md
+++ b/docs/rfcs/0007-manifest.md
@@ -64,14 +64,14 @@ These fields allow compaction and read-path pruning without inspecting Parquet c
 
 ### Catalog Registration and Table Definitions
 
-Registration mints a `TableId` and records a `TableDefinition` (name, schema fingerprint, primary key columns, retention policy, schema version). If a table already exists under the same name, schema and key layout must match or registration fails. A corresponding head entry is created so writers can publish versions immediately.
+Registration mints a `TableId` and records a `TableDefinition` (name, schema fingerprint, primary key columns, schema version). If a table already exists under the same name, schema and key layout must match or registration fails. A corresponding head entry is created so writers can publish versions immediately.
 
 ### Sessions and Workflow
 
 - **Write path:** assemble a `VersionState` (SST adds/removes, WAL segments, stats, tombstone watermark) and CAS-apply it alongside the updated table head (including WAL floor). CAS success defines global ordering; conflicts are retried with refreshed state.
 - **Read path:** fetch table head, then load the referenced `VersionState` and matching catalog metadata to build a snapshot for planning/reads.
 - **Recovery:** adopt orphaned manifest segments if present, reload catalog + heads, and replay WAL only at or above the recorded WAL floor.
-- **GC:** compute GC plans from retained versions and published floors; gc-plan manifest stores planned deletions to coordinate execution.
+- **GC:** compute GC plans from the current head, active snapshot pins, and published floors; gc-plan manifest stores planned deletions to coordinate execution.
 
 ### API Surface
 
@@ -82,10 +82,10 @@ The manifest module exposes operations for table lifecycle and version managemen
 | `open` | Initialize manifest from existing catalog and version stores |
 | `init_catalog` | Bootstrap empty catalog if none exists |
 | `register_table` | Register a new table or validate existing table matches definition |
-| `table_meta` | Fetch logical metadata (name, schema, retention) for a table |
+| `table_meta` | Fetch logical metadata (name, schema) for a table |
 | `apply_version_edits` | Atomically publish SST adds/removes and WAL floor updates |
 | `snapshot_latest` | Get current version state for read planning |
-| `list_versions` | Enumerate retained versions for debugging or time-travel |
+| `list_versions` | Enumerate committed versions for debugging or time-travel |
 | `recover_orphans` | Adopt orphaned segments after crash recovery |
 | `compactor` | Access GC/compaction planning APIs |
 
@@ -107,7 +107,7 @@ Each prefix uses fusio-manifest’s standard directory structure and CAS semanti
 
 - Writers and compactors publish SST additions/removals together with WAL segment references; table heads record the minimum WAL sequence (floor) required for recovery.
 - Recovery replays WAL at or above the recorded floor and ignores objects not referenced by any manifest version.
-- GC consumes manifest state (retained versions + floors) to decide which SSTs/WAL segments can be deleted safely; gc-plan records planned deletions to coordinate execution.
+- GC consumes manifest state (HEAD reachability, active snapshot pins, and WAL floors) to decide which SSTs/WAL segments can be deleted safely; gc-plan records planned deletions to coordinate execution.
 
 ## Risks
 

--- a/src/compaction/driver.rs
+++ b/src/compaction/driver.rs
@@ -4,6 +4,7 @@
 //! execution, and reconciliation without requiring the full DB type.
 
 use std::{
+    io::ErrorKind,
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -12,8 +13,11 @@ use std::{
 };
 
 use fusio::{
+    DynFs, Read,
     dynamic::{MaybeSend, MaybeSync},
+    error::Error as FsError,
     executor::{Executor, Instant, RwLock, Timer},
+    path::Path,
 };
 use futures::{FutureExt, StreamExt, channel::mpsc, future::AbortHandle, lock::Mutex};
 use tracing::instrument;
@@ -25,14 +29,16 @@ use crate::{
         metrics::{
             CompactionCascadeDecision, CompactionIoStats, CompactionJobSnapshot, CompactionMetrics,
             CompactionQueueDropContext, CompactionQueueDropReason, CompactionTriggerReason,
+            SstGcCandidateInspection, SstGcInspection, SstGcStatus, SstSweepSummary,
         },
         orchestrator,
         planner::{CompactionPlanner, CompactionTask},
         scheduler::{CompactionScheduleError, CompactionScheduler, ScheduledCompaction},
     },
-    db::{CasBackoffConfig, CascadeConfig},
+    db::{CasBackoffConfig, CascadeConfig, SnapshotPinRegistry},
     manifest::{ManifestError, ManifestFs, ManifestResult, TableId, TonboManifest, WalSegmentRef},
     observability::{log_debug, log_info, log_warn},
+    ondisk::sstable::manifest_storage_path,
     wal::{WalConfig as RuntimeWalConfig, WalHandle, manifest_ext},
 };
 
@@ -132,6 +138,9 @@ where
     pub(crate) wal_handle: Option<WalHandle<E>>,
     pub(crate) runtime: Arc<E>,
     pub(crate) cas_backoff: CasBackoffConfig,
+    sst_fs: Arc<dyn DynFs>,
+    sst_root: Path,
+    snapshot_pins: Arc<SnapshotPinRegistry>,
     compaction_metrics: Option<Arc<CompactionMetrics>>,
 }
 
@@ -174,6 +183,7 @@ where
     <FS as fusio::fs::Fs>::File: fusio::durability::FileCommit,
 {
     /// Create a new compaction driver with the given manifest and configuration.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         manifest: TonboManifest<FS, E>,
         table_id: TableId,
@@ -181,6 +191,9 @@ where
         wal_handle: Option<WalHandle<E>>,
         runtime: Arc<E>,
         cas_backoff: CasBackoffConfig,
+        sst_fs: Arc<dyn DynFs>,
+        sst_root: Path,
+        snapshot_pins: Arc<SnapshotPinRegistry>,
         compaction_metrics: Option<Arc<CompactionMetrics>>,
     ) -> Self {
         Self {
@@ -190,6 +203,9 @@ where
             wal_handle,
             runtime,
             cas_backoff,
+            sst_fs,
+            sst_root,
+            snapshot_pins,
             compaction_metrics,
         }
     }
@@ -247,6 +263,169 @@ where
         }
     }
 
+    /// Sweep staged SST GC candidates that are currently unreachable from the manifest root set.
+    ///
+    /// The single-process safety contract is:
+    /// 1. never delete an SST object still reachable from the current root set,
+    /// 2. treat missing objects as already reclaimed, and
+    /// 3. re-queue any candidate that hits a non-missing delete failure so a later sweep can retry
+    ///    idempotently.
+    pub(crate) async fn sweep_authorized_ssts(&self) -> ManifestResult<SstSweepSummary> {
+        let started_at = self.runtime.now();
+        let Some(plan) = self.manifest.peek_gc_plan(self.table_id).await? else {
+            return Ok(SstSweepSummary::default());
+        };
+        let active_pins = self.snapshot_pins.active_versions();
+        let root_set = self
+            .manifest
+            .current_root_set_with_pins(self.table_id, &active_pins)
+            .await?;
+        let auth = plan.authorization_summary(&root_set);
+        let (authorized_ssts, blocked_ssts) = plan.clone().split_sst_candidates(&root_set);
+        log_debug!(
+            component = "manifest",
+            event = "gc_plan_authorized_for_sweep",
+            table_id = ?self.table_id,
+            protected_versions = auth.protected_versions,
+            protected_sst_objects = auth.protected_sst_objects,
+            staged_sst_candidates = auth.staged_sst_candidates,
+            authorized_sst_candidates = auth.authorized_sst_candidates,
+            filtered_sst_candidates = auth.blocked_sst_candidates,
+            obsolete_wal_segments = auth.obsolete_wal_segments,
+        );
+
+        let mut summary = SstSweepSummary::default();
+        let mut reclaimed_ssts = Vec::new();
+        let blocked_sst_count = blocked_ssts.len() as u64;
+
+        let attempted_candidates = authorized_ssts.len();
+        for candidate in authorized_ssts {
+            match self.sweep_candidate(&candidate, &mut summary).await {
+                Ok(()) => reclaimed_ssts.push(candidate),
+                Err(_requeue_candidate) => {}
+            }
+        }
+
+        let requeued_sst_candidates = blocked_sst_count.saturating_add(
+            attempted_candidates
+                .saturating_sub(reclaimed_ssts.len())
+                .try_into()
+                .unwrap_or(u64::MAX),
+        );
+        if let Some(metrics) = self.compaction_metrics.as_ref() {
+            metrics.record_gc_plan_take(
+                auth.staged_sst_candidates,
+                auth.authorized_sst_candidates,
+                auth.blocked_sst_candidates,
+                requeued_sst_candidates,
+            );
+        }
+
+        if attempted_candidates == 0 {
+            return Ok(summary);
+        }
+
+        summary.duration_ms = self
+            .runtime
+            .now()
+            .duration_since(started_at)
+            .as_millis()
+            .try_into()
+            .unwrap_or(u64::MAX);
+
+        if !reclaimed_ssts.is_empty() {
+            self.manifest
+                .remove_gc_sst_candidates(self.table_id, &reclaimed_ssts)
+                .await?;
+        }
+
+        if let Some(metrics) = self.compaction_metrics.as_ref() {
+            metrics.record_sst_sweep(summary);
+        }
+        log_info!(
+            component = "compaction",
+            event = "sst_sweep_completed",
+            table_id = ?self.table_id,
+            deleted_objects = summary.deleted_objects,
+            deleted_bytes = summary.deleted_bytes,
+            delete_failures = summary.delete_failures,
+            duration_ms = summary.duration_ms,
+        );
+        Ok(summary)
+    }
+
+    /// Inspect the staged SST GC plan relative to the current manifest root set.
+    pub(crate) async fn sst_gc_status(&self) -> ManifestResult<Option<SstGcStatus>> {
+        let active_pins = self.snapshot_pins.active_versions();
+        let Some(summary) = self
+            .manifest
+            .inspect_gc_plan_authorization_with_pins(self.table_id, &active_pins)
+            .await?
+        else {
+            return Ok(None);
+        };
+        Ok(Some(SstGcStatus {
+            staged_sst_candidates: summary.staged_sst_candidates,
+            authorized_sst_candidates: summary.authorized_sst_candidates,
+            blocked_sst_candidates: summary.blocked_sst_candidates,
+            obsolete_wal_segments: summary.obsolete_wal_segments,
+            protected_versions: summary.protected_versions,
+            active_snapshot_versions: summary.active_snapshot_versions,
+            protected_sst_objects: summary.protected_sst_objects,
+        }))
+    }
+
+    /// Inspect the exact persisted SST GC plan and its current authorization state.
+    pub(crate) async fn inspect_sst_gc_plan(&self) -> ManifestResult<Option<SstGcInspection>> {
+        let Some(plan) = self.manifest.peek_gc_plan(self.table_id).await? else {
+            return Ok(None);
+        };
+        let active_pins = self.snapshot_pins.active_versions();
+        let root_set = self
+            .manifest
+            .current_root_set_with_pins(self.table_id, &active_pins)
+            .await?;
+        let summary = plan.authorization_summary(&root_set);
+        let mut candidates = plan
+            .obsolete_ssts
+            .iter()
+            .map(|candidate| {
+                let authorized = !root_set.contains_path(&candidate.data_path)
+                    && candidate
+                        .delete_path
+                        .as_ref()
+                        .is_none_or(|path| !root_set.contains_path(path));
+                SstGcCandidateInspection {
+                    sst_id: candidate.id.raw(),
+                    level: candidate.level,
+                    data_path: candidate.data_path.as_ref().to_string(),
+                    delete_path: candidate
+                        .delete_path
+                        .as_ref()
+                        .map(|path| path.as_ref().to_string()),
+                    authorized,
+                }
+            })
+            .collect::<Vec<_>>();
+        candidates.sort_by(|lhs, rhs| {
+            lhs.data_path
+                .cmp(&rhs.data_path)
+                .then_with(|| lhs.delete_path.cmp(&rhs.delete_path))
+                .then_with(|| lhs.level.cmp(&rhs.level))
+                .then_with(|| lhs.sst_id.cmp(&rhs.sst_id))
+        });
+        Ok(Some(SstGcInspection {
+            staged_sst_candidates: summary.staged_sst_candidates,
+            authorized_sst_candidates: summary.authorized_sst_candidates,
+            blocked_sst_candidates: summary.blocked_sst_candidates,
+            obsolete_wal_segments: summary.obsolete_wal_segments,
+            protected_versions: summary.protected_versions,
+            active_snapshot_versions: summary.active_snapshot_versions,
+            protected_sst_objects: summary.protected_sst_objects,
+            candidates,
+        }))
+    }
+
     /// Get the WAL floor currently recorded in the manifest.
     async fn manifest_wal_floor(&self) -> Option<WalSegmentRef> {
         self.manifest.wal_floor(self.table_id).await.ok().flatten()
@@ -256,6 +435,105 @@ where
     #[cfg(all(test, feature = "tokio"))]
     pub(crate) async fn wal_floor_seq(&self) -> Option<u64> {
         self.manifest_wal_floor().await.map(|ref_| ref_.seq())
+    }
+
+    async fn sweep_candidate(
+        &self,
+        candidate: &crate::manifest::GcSstRef,
+        summary: &mut SstSweepSummary,
+    ) -> Result<(), crate::manifest::GcSstRef> {
+        let mut success = true;
+        let data_path = self.resolve_sst_path(&candidate.data_path);
+        if self
+            .delete_object_if_present(&data_path, summary)
+            .await
+            .is_err()
+        {
+            success = false;
+        }
+        if let Some(delete_path) = candidate.delete_path.as_ref() {
+            let delete_path = self.resolve_sst_path(delete_path);
+            if self
+                .delete_object_if_present(&delete_path, summary)
+                .await
+                .is_err()
+            {
+                success = false;
+            }
+        }
+
+        if success {
+            Ok(())
+        } else {
+            Err(candidate.clone())
+        }
+    }
+
+    fn resolve_sst_path(&self, relative: &Path) -> Path {
+        if self.sst_root == Path::default() {
+            return relative.clone();
+        }
+
+        let candidate = relative.as_ref();
+        let root = self.sst_root.as_ref().trim_end_matches('/');
+        if candidate.starts_with(root) {
+            return relative.clone();
+        }
+        if let Some(root_without_leading_slash) = root.strip_prefix('/')
+            && candidate.starts_with(root_without_leading_slash)
+        {
+            return Path::from(format!("/{candidate}"));
+        }
+
+        Path::from(format!("{root}/{candidate}"))
+    }
+
+    async fn delete_object_if_present(
+        &self,
+        path: &Path,
+        summary: &mut SstSweepSummary,
+    ) -> Result<(), ()> {
+        let bytes = match self.object_size_if_present(path).await {
+            Ok(size) => size,
+            Err(err) => {
+                log_warn!(
+                    component = "compaction",
+                    event = "sst_sweep_size_probe_failed",
+                    table_id = ?self.table_id,
+                    path = path.as_ref(),
+                    error = ?err,
+                );
+                None
+            }
+        };
+
+        match self.sst_fs.remove(path).await {
+            Ok(()) => {
+                summary.deleted_objects = summary.deleted_objects.saturating_add(1);
+                summary.deleted_bytes = summary.deleted_bytes.saturating_add(bytes.unwrap_or(0));
+                Ok(())
+            }
+            Err(err) if is_missing_fs_error(&err) => Ok(()),
+            Err(err) => {
+                summary.delete_failures = summary.delete_failures.saturating_add(1);
+                log_warn!(
+                    component = "compaction",
+                    event = "sst_sweep_delete_failed",
+                    table_id = ?self.table_id,
+                    path = path.as_ref(),
+                    error = ?err,
+                );
+                Err(())
+            }
+        }
+    }
+
+    async fn object_size_if_present(&self, path: &Path) -> Result<Option<u64>, FsError> {
+        match self.sst_fs.open(path).await {
+            Ok(file) => file.size().await.map(Some),
+            Err(err) if is_missing_fs_error(&err) => Ok(None),
+            Err(err) => Err(err),
+        }
     }
 
     /// Build a compaction plan based on the latest manifest snapshot.
@@ -429,6 +707,46 @@ where
         }
     }
 
+    fn normalize_manifest_paths(&self, outcome: &mut CompactionOutcome) {
+        outcome.add_ssts = outcome
+            .add_ssts
+            .iter()
+            .map(|entry| {
+                let data_path = manifest_storage_path(&self.sst_root, entry.data_path());
+                let delete_path = entry
+                    .delete_path()
+                    .map(|path| manifest_storage_path(&self.sst_root, path));
+                crate::manifest::SstEntry::new(
+                    entry.sst_id().clone(),
+                    entry.stats().cloned(),
+                    entry.wal_segments().map(|ids| ids.to_vec()),
+                    data_path,
+                    delete_path,
+                )
+            })
+            .collect();
+        outcome.remove_ssts = outcome
+            .remove_ssts
+            .iter()
+            .map(|desc| {
+                let mut normalized =
+                    crate::ondisk::sstable::SsTableDescriptor::new(desc.id().clone(), desc.level());
+                if let Some(stats) = desc.stats().cloned() {
+                    normalized = normalized.with_stats(stats);
+                }
+                normalized = normalized.with_wal_ids(desc.wal_ids().map(|ids| ids.to_vec()));
+                if let Some(data_path) = desc.data_path() {
+                    normalized = normalized.with_storage_paths(
+                        manifest_storage_path(&self.sst_root, data_path),
+                        desc.delete_path()
+                            .map(|path| manifest_storage_path(&self.sst_root, path)),
+                    );
+                }
+                normalized
+            })
+            .collect();
+    }
+
     /// End-to-end compaction orchestrator (plan -> resolve -> execute -> apply manifest).
     #[cfg(all(test, feature = "tokio"))]
     #[instrument(
@@ -466,7 +784,7 @@ where
                 return Ok(None);
             };
 
-            let inputs = orchestrator::resolve_inputs(version, &task)?;
+            let inputs = orchestrator::resolve_inputs(&self.sst_root, version, &task)?;
             let input_stats = CompactionIoStats::from_descriptors(&inputs);
             let input_count = inputs.len();
             let source_level = task.source_level;
@@ -530,6 +848,7 @@ where
                 &existing_wal_segments,
                 wal_floor,
             );
+            self.normalize_manifest_paths(&mut outcome);
             let gc_plan = orchestrator::gc_plan_from_outcome(&outcome)?;
             let edits = outcome.to_version_edits();
             if edits.is_empty() {
@@ -563,10 +882,19 @@ where
                 Ok(_) => {
                     self.prune_wal_below_floor().await;
                     if let Some(plan) = gc_plan {
-                        self.manifest
-                            .record_gc_plan(self.table_id, plan)
+                        // Compaction only stages GC candidates here. Any future SST sweeper must
+                        // re-authorize against the latest manifest root set before deleting.
+                        self.persist_gc_plan(plan)
                             .await
                             .map_err(CompactionError::Manifest)?;
+                    }
+                    if let Err(err) = self.sweep_authorized_ssts().await {
+                        log_warn!(
+                            component = "compaction",
+                            event = "sst_sweep_failed",
+                            table_id = ?self.table_id,
+                            error = ?err,
+                        );
                     }
                     let started_at = job_started_at.unwrap_or_else(|| self.runtime.now());
                     let duration = self.runtime.now().duration_since(started_at);
@@ -690,7 +1018,7 @@ where
             }
 
             let existing_wal_segments: Vec<WalSegmentRef> = version.wal_segments().to_vec();
-            let inputs = orchestrator::resolve_inputs(version, &scheduled.task)?;
+            let inputs = orchestrator::resolve_inputs(&self.sst_root, version, &scheduled.task)?;
             let input_stats = CompactionIoStats::from_descriptors(&inputs);
             let input_count = inputs.len();
             let source_level = scheduled.task.source_level;
@@ -754,6 +1082,7 @@ where
                 &existing_wal_segments,
                 wal_floor,
             );
+            self.normalize_manifest_paths(&mut outcome);
             let gc_plan = orchestrator::gc_plan_from_outcome(&outcome)?;
             let edits = outcome.to_version_edits();
             if edits.is_empty() {
@@ -788,10 +1117,19 @@ where
                 Ok(_) => {
                     self.prune_wal_below_floor().await;
                     if let Some(plan) = gc_plan {
-                        self.manifest
-                            .record_gc_plan(self.table_id, plan)
+                        // Compaction only stages GC candidates here. Any future SST sweeper must
+                        // re-authorize against the latest manifest root set before deleting.
+                        self.persist_gc_plan(plan)
                             .await
                             .map_err(CompactionError::Manifest)?;
+                    }
+                    if let Err(err) = self.sweep_authorized_ssts().await {
+                        log_warn!(
+                            component = "compaction",
+                            event = "sst_sweep_failed",
+                            table_id = ?self.table_id,
+                            error = ?err,
+                        );
                     }
                     let started_at = job_started_at.unwrap_or_else(|| self.runtime.now());
                     let duration = self.runtime.now().duration_since(started_at);
@@ -980,6 +1318,27 @@ where
                     break;
                 }
             }
+        }
+        Ok(())
+    }
+
+    async fn persist_gc_plan(&self, plan: crate::manifest::GcPlanState) -> ManifestResult<()> {
+        let (previous, written) = self.manifest.merge_gc_plan(self.table_id, plan).await?;
+        if let Some(metrics) = self.compaction_metrics.as_ref() {
+            metrics.record_gc_plan_write(
+                previous
+                    .as_ref()
+                    .map_or(0, |plan| plan.obsolete_ssts.len() as u64),
+                previous
+                    .as_ref()
+                    .map_or(0, |plan| plan.obsolete_wal_segments.len() as u64),
+                written
+                    .as_ref()
+                    .map_or(0, |plan| plan.obsolete_ssts.len() as u64),
+                written
+                    .as_ref()
+                    .map_or(0, |plan| plan.obsolete_wal_segments.len() as u64),
+            );
         }
         Ok(())
     }
@@ -1261,4 +1620,28 @@ where
         });
         CompactionHandle::new(abort, Some(handle), Some(tick_tx))
     }
+}
+
+fn is_missing_fs_error(err: &FsError) -> bool {
+    match err {
+        FsError::Io(io) => io.kind() == ErrorKind::NotFound,
+        FsError::Path(inner) | FsError::Remote(inner) | FsError::Other(inner) => {
+            inner
+                .downcast_ref::<std::io::Error>()
+                .is_some_and(|io| io.kind() == ErrorKind::NotFound)
+                || matches_missing_message(inner.to_string().as_str())
+        }
+        FsError::Unsupported { .. }
+        | FsError::PreconditionFailed
+        | FsError::CastError
+        | FsError::Wasm { .. } => false,
+        _ => false,
+    }
+}
+
+fn matches_missing_message(message: &str) -> bool {
+    message.contains("NotFound")
+        || message.contains("not found")
+        || message.contains("NoSuchKey")
+        || message.contains("does not exist")
 }

--- a/src/compaction/metrics.rs
+++ b/src/compaction/metrics.rs
@@ -148,8 +148,108 @@ pub struct CompactionMetricsSnapshot {
     pub tombstones_out: u64,
     /// Total duration for completed jobs (milliseconds).
     pub duration_ms_total: u64,
+    /// Number of SST sweep runs executed.
+    pub sst_sweep_runs: u64,
+    /// Total SST objects physically deleted by the sweeper.
+    pub sst_deleted_objects: u64,
+    /// Total bytes physically deleted by the sweeper.
+    pub sst_deleted_bytes: u64,
+    /// Total time spent in SST sweep runs (milliseconds).
+    pub sst_sweep_duration_ms_total: u64,
+    /// Total SST object delete failures observed by the sweeper.
+    pub sst_delete_failures: u64,
+    /// Number of manifest GC-plan writes performed.
+    pub gc_plan_write_runs: u64,
+    /// Number of writes that replaced a non-empty previously persisted GC plan.
+    pub gc_plan_overwrite_non_empty: u64,
+    /// Total staged SST candidates present before GC-plan writes.
+    pub gc_plan_previous_sst_candidates: u64,
+    /// Total staged WAL candidates present before GC-plan writes.
+    pub gc_plan_previous_wal_candidates: u64,
+    /// Total staged SST candidates written into persisted GC plans.
+    pub gc_plan_written_sst_candidates: u64,
+    /// Total staged WAL candidates written into persisted GC plans.
+    pub gc_plan_written_wal_candidates: u64,
+    /// Number of sweep passes that successfully took a persisted GC plan.
+    pub gc_plan_take_runs: u64,
+    /// Total SST candidates observed when sweep passes took a persisted GC plan.
+    pub gc_plan_taken_sst_candidates: u64,
+    /// Total SST candidates authorized across sweep passes.
+    pub gc_plan_authorized_sst_candidates: u64,
+    /// Total SST candidates blocked across sweep passes.
+    pub gc_plan_blocked_sst_candidates: u64,
+    /// Total SST candidates re-queued after sweep passes.
+    pub gc_plan_requeued_sst_candidates: u64,
     /// Last observed job summary, if any.
     pub last_job: Option<CompactionJobSnapshot>,
+}
+
+/// Summary of a single SST sweep pass.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SstSweepSummary {
+    /// SST objects physically removed during this pass.
+    pub deleted_objects: u64,
+    /// Bytes physically reclaimed during this pass.
+    pub deleted_bytes: u64,
+    /// Non-missing delete failures encountered during this pass.
+    pub delete_failures: u64,
+    /// Wall-clock duration for this pass in milliseconds.
+    pub duration_ms: u64,
+}
+
+/// Snapshot of staged SST GC state relative to the current manifest root set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SstGcStatus {
+    /// Total staged SST candidates currently recorded in the manifest GC plan.
+    pub staged_sst_candidates: u64,
+    /// SST candidates currently authorized for physical deletion.
+    pub authorized_sst_candidates: u64,
+    /// SST candidates still blocked by the manifest root set.
+    pub blocked_sst_candidates: u64,
+    /// WAL candidates still staged alongside the SST plan.
+    pub obsolete_wal_segments: u64,
+    /// Total manifest versions currently protecting SST objects.
+    pub protected_versions: u64,
+    /// Unique manifest versions currently pinned by live in-process snapshots.
+    pub active_snapshot_versions: u64,
+    /// Physical SST objects currently protected by the manifest root set.
+    pub protected_sst_objects: u64,
+}
+
+/// Deterministic view of a single staged SST GC candidate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SstGcCandidateInspection {
+    /// Identifier of the staged SST candidate.
+    pub sst_id: u64,
+    /// Compaction level recorded in the plan.
+    pub level: u32,
+    /// Relative data-object path persisted in the GC plan.
+    pub data_path: String,
+    /// Relative delete-sidecar path persisted in the GC plan, when present.
+    pub delete_path: Option<String>,
+    /// Whether the candidate is currently authorized for deletion.
+    pub authorized: bool,
+}
+
+/// Deterministic inspection of the persisted SST GC plan.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SstGcInspection {
+    /// Total staged SST candidates currently recorded in the manifest GC plan.
+    pub staged_sst_candidates: u64,
+    /// SST candidates currently authorized for physical deletion.
+    pub authorized_sst_candidates: u64,
+    /// SST candidates still blocked by the manifest root set.
+    pub blocked_sst_candidates: u64,
+    /// WAL candidates still staged alongside the SST plan.
+    pub obsolete_wal_segments: u64,
+    /// Total manifest versions currently protecting SST objects.
+    pub protected_versions: u64,
+    /// Unique manifest versions currently pinned by live in-process snapshots.
+    pub active_snapshot_versions: u64,
+    /// Physical SST objects currently protected by the manifest root set.
+    pub protected_sst_objects: u64,
+    /// Deterministic ordered candidate list.
+    pub candidates: Vec<SstGcCandidateInspection>,
 }
 
 /// Source of a compaction tick.
@@ -271,6 +371,22 @@ pub struct CompactionMetrics {
     tombstones_in: AtomicU64,
     tombstones_out: AtomicU64,
     duration_ms_total: AtomicU64,
+    sst_sweep_runs: AtomicU64,
+    sst_deleted_objects: AtomicU64,
+    sst_deleted_bytes: AtomicU64,
+    sst_sweep_duration_ms_total: AtomicU64,
+    sst_delete_failures: AtomicU64,
+    gc_plan_write_runs: AtomicU64,
+    gc_plan_overwrite_non_empty: AtomicU64,
+    gc_plan_previous_sst_candidates: AtomicU64,
+    gc_plan_previous_wal_candidates: AtomicU64,
+    gc_plan_written_sst_candidates: AtomicU64,
+    gc_plan_written_wal_candidates: AtomicU64,
+    gc_plan_take_runs: AtomicU64,
+    gc_plan_taken_sst_candidates: AtomicU64,
+    gc_plan_authorized_sst_candidates: AtomicU64,
+    gc_plan_blocked_sst_candidates: AtomicU64,
+    gc_plan_requeued_sst_candidates: AtomicU64,
     last_job_present: AtomicU64,
     last_job_source_level: AtomicU64,
     last_job_target_level: AtomicU64,
@@ -332,6 +448,22 @@ impl CompactionMetrics {
             tombstones_in: AtomicU64::new(0),
             tombstones_out: AtomicU64::new(0),
             duration_ms_total: AtomicU64::new(0),
+            sst_sweep_runs: AtomicU64::new(0),
+            sst_deleted_objects: AtomicU64::new(0),
+            sst_deleted_bytes: AtomicU64::new(0),
+            sst_sweep_duration_ms_total: AtomicU64::new(0),
+            sst_delete_failures: AtomicU64::new(0),
+            gc_plan_write_runs: AtomicU64::new(0),
+            gc_plan_overwrite_non_empty: AtomicU64::new(0),
+            gc_plan_previous_sst_candidates: AtomicU64::new(0),
+            gc_plan_previous_wal_candidates: AtomicU64::new(0),
+            gc_plan_written_sst_candidates: AtomicU64::new(0),
+            gc_plan_written_wal_candidates: AtomicU64::new(0),
+            gc_plan_take_runs: AtomicU64::new(0),
+            gc_plan_taken_sst_candidates: AtomicU64::new(0),
+            gc_plan_authorized_sst_candidates: AtomicU64::new(0),
+            gc_plan_blocked_sst_candidates: AtomicU64::new(0),
+            gc_plan_requeued_sst_candidates: AtomicU64::new(0),
             last_job_present: AtomicU64::new(0),
             last_job_source_level: AtomicU64::new(0),
             last_job_target_level: AtomicU64::new(0),
@@ -403,6 +535,36 @@ impl CompactionMetrics {
             tombstones_in: self.tombstones_in.load(Ordering::Relaxed),
             tombstones_out: self.tombstones_out.load(Ordering::Relaxed),
             duration_ms_total: self.duration_ms_total.load(Ordering::Relaxed),
+            sst_sweep_runs: self.sst_sweep_runs.load(Ordering::Relaxed),
+            sst_deleted_objects: self.sst_deleted_objects.load(Ordering::Relaxed),
+            sst_deleted_bytes: self.sst_deleted_bytes.load(Ordering::Relaxed),
+            sst_sweep_duration_ms_total: self.sst_sweep_duration_ms_total.load(Ordering::Relaxed),
+            sst_delete_failures: self.sst_delete_failures.load(Ordering::Relaxed),
+            gc_plan_write_runs: self.gc_plan_write_runs.load(Ordering::Relaxed),
+            gc_plan_overwrite_non_empty: self.gc_plan_overwrite_non_empty.load(Ordering::Relaxed),
+            gc_plan_previous_sst_candidates: self
+                .gc_plan_previous_sst_candidates
+                .load(Ordering::Relaxed),
+            gc_plan_previous_wal_candidates: self
+                .gc_plan_previous_wal_candidates
+                .load(Ordering::Relaxed),
+            gc_plan_written_sst_candidates: self
+                .gc_plan_written_sst_candidates
+                .load(Ordering::Relaxed),
+            gc_plan_written_wal_candidates: self
+                .gc_plan_written_wal_candidates
+                .load(Ordering::Relaxed),
+            gc_plan_take_runs: self.gc_plan_take_runs.load(Ordering::Relaxed),
+            gc_plan_taken_sst_candidates: self.gc_plan_taken_sst_candidates.load(Ordering::Relaxed),
+            gc_plan_authorized_sst_candidates: self
+                .gc_plan_authorized_sst_candidates
+                .load(Ordering::Relaxed),
+            gc_plan_blocked_sst_candidates: self
+                .gc_plan_blocked_sst_candidates
+                .load(Ordering::Relaxed),
+            gc_plan_requeued_sst_candidates: self
+                .gc_plan_requeued_sst_candidates
+                .load(Ordering::Relaxed),
             last_job,
         }
     }
@@ -547,6 +709,70 @@ impl CompactionMetrics {
         if self.emit_logs {
             self.log_job("aborted", job);
         }
+    }
+
+    /// Record an SST sweeper pass.
+    pub(crate) fn record_sst_sweep(&self, sweep: SstSweepSummary) {
+        add_saturating(&self.sst_sweep_runs, 1);
+        add_saturating(&self.sst_deleted_objects, sweep.deleted_objects);
+        add_saturating(&self.sst_deleted_bytes, sweep.deleted_bytes);
+        add_saturating(&self.sst_sweep_duration_ms_total, sweep.duration_ms);
+        add_saturating(&self.sst_delete_failures, sweep.delete_failures);
+        if self.emit_logs {
+            log_info!(
+                component = "compaction",
+                event = "sst_sweep_summary",
+                deleted_objects = sweep.deleted_objects,
+                deleted_bytes = sweep.deleted_bytes,
+                delete_failures = sweep.delete_failures,
+                duration_ms = sweep.duration_ms,
+            );
+        }
+    }
+
+    /// Record a persisted GC-plan write.
+    pub(crate) fn record_gc_plan_write(
+        &self,
+        previous_sst_candidates: u64,
+        previous_wal_candidates: u64,
+        written_sst_candidates: u64,
+        written_wal_candidates: u64,
+    ) {
+        add_saturating(&self.gc_plan_write_runs, 1);
+        if previous_sst_candidates > 0 || previous_wal_candidates > 0 {
+            add_saturating(&self.gc_plan_overwrite_non_empty, 1);
+        }
+        add_saturating(
+            &self.gc_plan_previous_sst_candidates,
+            previous_sst_candidates,
+        );
+        add_saturating(
+            &self.gc_plan_previous_wal_candidates,
+            previous_wal_candidates,
+        );
+        add_saturating(&self.gc_plan_written_sst_candidates, written_sst_candidates);
+        add_saturating(&self.gc_plan_written_wal_candidates, written_wal_candidates);
+    }
+
+    /// Record how a sweep pass consumed a persisted GC plan.
+    pub(crate) fn record_gc_plan_take(
+        &self,
+        staged_sst_candidates: u64,
+        authorized_sst_candidates: u64,
+        blocked_sst_candidates: u64,
+        requeued_sst_candidates: u64,
+    ) {
+        add_saturating(&self.gc_plan_take_runs, 1);
+        add_saturating(&self.gc_plan_taken_sst_candidates, staged_sst_candidates);
+        add_saturating(
+            &self.gc_plan_authorized_sst_candidates,
+            authorized_sst_candidates,
+        );
+        add_saturating(&self.gc_plan_blocked_sst_candidates, blocked_sst_candidates);
+        add_saturating(
+            &self.gc_plan_requeued_sst_candidates,
+            requeued_sst_candidates,
+        );
     }
 
     fn set_last_job(&self, job: CompactionJobSnapshot) {

--- a/src/compaction/orchestrator.rs
+++ b/src/compaction/orchestrator.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     id::FileId,
     manifest::{GcPlanState, GcSstRef, ManifestError, VersionState, WalSegmentRef},
-    ondisk::sstable::{SsTableDescriptor, SsTableId},
+    ondisk::sstable::{SsTableDescriptor, SsTableId, storage_path_from_manifest},
 };
 
 /// Plan compaction from a version snapshot.
@@ -52,6 +52,7 @@ where
 /// Looks up each input SST in the version state and builds full descriptors
 /// with stats, WAL IDs, and storage paths.
 pub(crate) fn resolve_inputs(
+    sst_root: &fusio::path::Path,
     version: &VersionState,
     task: &CompactionTask,
 ) -> Result<Vec<SsTableDescriptor>, CompactionError> {
@@ -73,8 +74,12 @@ pub(crate) fn resolve_inputs(
             descriptor = descriptor.with_stats(stats);
         }
         descriptor = descriptor.with_wal_ids(entry.wal_segments().map(|ids| ids.to_vec()));
-        descriptor =
-            descriptor.with_storage_paths(entry.data_path().clone(), entry.delete_path().cloned());
+        descriptor = descriptor.with_storage_paths(
+            storage_path_from_manifest(sst_root, entry.data_path()),
+            entry
+                .delete_path()
+                .map(|path| storage_path_from_manifest(sst_root, path)),
+        );
         descriptors.push(descriptor);
     }
     Ok(descriptors)
@@ -196,9 +201,11 @@ pub(crate) fn reconcile_wal_segments(
     outcome.obsolete_wal_segments = obsolete_wal_segments;
 }
 
-/// Build a GC plan from a compaction outcome.
+/// Build staged GC candidates from a compaction outcome.
 ///
-/// Returns `None` if there are no obsolete SSTs or WAL segments to clean up.
+/// Returns `None` if there are no obsolete SSTs or WAL segments to stage. The resulting
+/// [`GcPlanState`] is only a hint queue; a future sweeper must re-check the current manifest
+/// root set before deleting any SST object.
 pub(crate) fn gc_plan_from_outcome(
     outcome: &CompactionOutcome,
 ) -> Result<Option<GcPlanState>, CompactionError> {

--- a/src/db/builder.rs
+++ b/src/db/builder.rs
@@ -1134,6 +1134,7 @@ where
             commit_ack_mode,
             mem,
             layout.dyn_fs(),
+            layout.sst_route()?.path,
             manifest,
             manifest_table,
             table_meta,
@@ -1307,8 +1308,8 @@ impl CompactionOptions {
 
     /// Attach compaction metrics to record per-job and scheduler counters.
     #[must_use]
-    #[allow(dead_code)]
-    pub(crate) fn compaction_metrics(mut self, metrics: Arc<CompactionMetrics>) -> Self {
+    #[doc(hidden)]
+    pub fn compaction_metrics(mut self, metrics: Arc<CompactionMetrics>) -> Self {
         self.compaction_metrics = Some(metrics);
         self
     }
@@ -1724,6 +1725,7 @@ where
                 mode_config,
                 Arc::clone(&executor),
                 fs_dyn,
+                layout.sst_route()?.path,
                 wal_cfg.clone(),
                 manifest,
                 manifest_table,

--- a/src/db/compaction.rs
+++ b/src/db/compaction.rs
@@ -6,14 +6,18 @@ use std::sync::Arc;
 
 use fusio::executor::{Executor, Timer};
 
-use crate::{compaction::CompactionDriver, db::DbInner, manifest::ManifestFs};
 #[cfg(all(test, feature = "tokio"))]
+use crate::compaction::{
+    executor::{CompactionError, CompactionExecutor, CompactionOutcome},
+    planner::CompactionPlanner,
+};
 use crate::{
     compaction::{
-        executor::{CompactionError, CompactionExecutor, CompactionOutcome},
-        planner::CompactionPlanner,
+        CompactionDriver,
+        metrics::{CompactionMetricsSnapshot, SstGcInspection, SstGcStatus, SstSweepSummary},
     },
-    manifest::ManifestResult,
+    db::DbInner,
+    manifest::{ManifestFs, ManifestResult},
 };
 
 impl<FS, E> DbInner<FS, E>
@@ -46,6 +50,9 @@ where
             self.wal_handle().cloned(),
             Arc::clone(&self.executor),
             self.cas_backoff.clone(),
+            Arc::clone(&self.fs),
+            self.sst_root.clone(),
+            Arc::clone(&self.snapshot_pins),
             self.compaction_metrics.clone(),
         )
     }
@@ -87,5 +94,27 @@ where
         self.compaction_driver()
             .run_compaction(planner, executor)
             .await
+    }
+
+    /// Sweep unreachable manifest-published SST objects for the current table.
+    pub(crate) async fn sweep_manifest_ssts(&self) -> ManifestResult<SstSweepSummary> {
+        self.compaction_driver().sweep_authorized_ssts().await
+    }
+
+    /// Snapshot staged SST GC authorization state for the current table.
+    pub(crate) async fn sst_gc_status(&self) -> ManifestResult<Option<SstGcStatus>> {
+        self.compaction_driver().sst_gc_status().await
+    }
+
+    /// Inspect the exact persisted SST GC plan for the current table.
+    pub(crate) async fn inspect_sst_gc_plan(&self) -> ManifestResult<Option<SstGcInspection>> {
+        self.compaction_driver().inspect_sst_gc_plan().await
+    }
+
+    /// Snapshot current compaction metrics if this DB was configured to collect them.
+    pub(crate) fn compaction_metrics_snapshot(&self) -> Option<CompactionMetricsSnapshot> {
+        self.compaction_metrics
+            .as_ref()
+            .map(|metrics| metrics.snapshot())
     }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -5,7 +5,7 @@
 //! engine while we focus on a single runtime representation.
 
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     sync::{
         Arc, Mutex, MutexGuard,
         atomic::{AtomicBool, Ordering},
@@ -20,6 +20,7 @@ use fusio::{
     DynFs,
     executor::{Executor, Timer},
     mem::fs::InMemoryFs,
+    path::Path,
 };
 use futures::lock::Mutex as AsyncMutex;
 use lockable::LockableHashMap;
@@ -43,7 +44,13 @@ pub use scan::{DEFAULT_SCAN_BATCH_ROWS, ScanBuilder, ScanSetupProfile};
 pub(crate) use wal::{TxnWalPublishContext, WalFrameRange};
 
 pub use crate::{
-    compaction::planner::{CompactionStrategy, LeveledPlannerConfig},
+    compaction::{
+        metrics::{
+            CompactionMetrics, CompactionMetricsSnapshot, SstGcInspection, SstGcStatus,
+            SstSweepSummary,
+        },
+        planner::{CompactionStrategy, LeveledPlannerConfig},
+    },
     inmem::policy::{BatchesThreshold, NeverSeal, SealPolicy},
     mode::DynModeConfig,
     query::{Expr, ScalarValue},
@@ -58,13 +65,16 @@ use crate::{
     key::KeyOwned,
     manifest::{
         ManifestError, ManifestFs, SstEntry, TableId, TableMeta, TonboManifest, VersionEdit,
-        WalSegmentRef,
+        VersionState, WalSegmentRef,
     },
     mvcc::{CommitClock, ReadView, Timestamp},
     ondisk::{
         bloom::{BloomFilterCache, default_bloom_cache},
         metadata::{ParquetMetadataCache, default_parquet_metadata_cache},
-        sstable::{SsTable, SsTableBuilder, SsTableConfig, SsTableDescriptor, SsTableError},
+        sstable::{
+            SsTable, SsTableBuilder, SsTableConfig, SsTableDescriptor, SsTableError,
+            manifest_storage_path,
+        },
     },
     transaction::{Snapshot as TxSnapshot, SnapshotError, TransactionDurability, TransactionError},
     wal::{
@@ -92,6 +102,89 @@ pub struct Version {
     pub sst_bytes: u64,
     /// Number of compaction levels with data.
     pub level_count: usize,
+}
+
+fn version_from_state(state: VersionState) -> Version {
+    let sst_count = state.ssts.iter().map(|level| level.len()).sum();
+    let sst_bytes = state
+        .ssts
+        .iter()
+        .flatten()
+        .filter_map(|entry| entry.stats().map(|stats| stats.bytes))
+        .fold(0u64, |acc, bytes| {
+            acc.saturating_add(u64::try_from(bytes).unwrap_or(u64::MAX))
+        });
+    Version {
+        timestamp: state.commit_timestamp,
+        sst_count,
+        sst_bytes,
+        level_count: state.ssts.iter().filter(|level| !level.is_empty()).count(),
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct SnapshotPinRegistry {
+    pins: Mutex<BTreeMap<Timestamp, usize>>,
+}
+
+impl SnapshotPinRegistry {
+    fn pin(self: &Arc<Self>, manifest_ts: Timestamp) -> SnapshotPinGuard {
+        let mut guard = self
+            .pins
+            .lock()
+            .expect("snapshot pin registry mutex poisoned");
+        let count = guard.entry(manifest_ts).or_insert(0);
+        *count = count.saturating_add(1);
+        drop(guard);
+        SnapshotPinGuard {
+            inner: Arc::new(SnapshotPinGuardInner {
+                registry: Arc::clone(self),
+                manifest_ts,
+            }),
+        }
+    }
+
+    pub(crate) fn active_versions(&self) -> Vec<Timestamp> {
+        self.pins
+            .lock()
+            .expect("snapshot pin registry mutex poisoned")
+            .keys()
+            .copied()
+            .collect()
+    }
+
+    fn release(&self, manifest_ts: Timestamp) {
+        let mut guard = self
+            .pins
+            .lock()
+            .expect("snapshot pin registry mutex poisoned");
+        let Some(count) = guard.get_mut(&manifest_ts) else {
+            return;
+        };
+        if *count <= 1 {
+            guard.remove(&manifest_ts);
+        } else {
+            *count -= 1;
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SnapshotPinGuard {
+    #[allow(dead_code)]
+    inner: Arc<SnapshotPinGuardInner>,
+}
+
+#[derive(Debug)]
+struct SnapshotPinGuardInner {
+    registry: Arc<SnapshotPinRegistry>,
+    manifest_ts: Timestamp,
+}
+
+impl Drop for SnapshotPinGuardInner {
+    fn drop(&mut self) {
+        self.registry.release(self.manifest_ts);
+    }
 }
 
 /// State bundle for opportunistic minor compaction.
@@ -408,6 +501,36 @@ where
     pub async fn list_versions(&self, limit: usize) -> Result<Vec<Version>, ManifestError> {
         self.inner.list_versions(limit).await
     }
+
+    /// Run one authorized SST sweep against the current manifest root set.
+    #[doc(hidden)]
+    pub async fn sweep_sst_objects(&self) -> Result<SstSweepSummary, DBError> {
+        self.inner
+            .sweep_manifest_ssts()
+            .await
+            .map_err(DBError::from)
+    }
+
+    /// Snapshot compaction metrics if this DB was configured to collect them.
+    #[doc(hidden)]
+    pub fn compaction_metrics_snapshot(&self) -> Option<CompactionMetricsSnapshot> {
+        self.inner.compaction_metrics_snapshot()
+    }
+
+    /// Inspect staged SST GC state for the current table.
+    #[doc(hidden)]
+    pub async fn sst_gc_status(&self) -> Result<Option<SstGcStatus>, DBError> {
+        self.inner.sst_gc_status().await.map_err(DBError::from)
+    }
+
+    /// Inspect the exact persisted SST GC plan for the current table.
+    #[doc(hidden)]
+    pub async fn inspect_sst_gc_plan(&self) -> Result<Option<SstGcInspection>, DBError> {
+        self.inner
+            .inspect_sst_gc_plan()
+            .await
+            .map_err(DBError::from)
+    }
 }
 
 impl<E> DB<InMemoryFs, E>
@@ -470,6 +593,8 @@ where
     pub(crate) executor: Arc<E>,
     /// Unified filesystem access for SSTable reads, WAL, and other I/O operations.
     fs: Arc<dyn DynFs>,
+    /// Root directory prefix for SST objects referenced by manifest paths.
+    sst_root: Path,
     // Optional WAL handle when durability is enabled.
     wal: Option<WalHandle<E>>,
     /// Pending WAL configuration captured before the writer is installed.
@@ -488,6 +613,8 @@ where
     pruner_cache: Arc<E::Mutex<PrunerCache>>,
     /// Cached Parquet metadata for SST pruning.
     metadata_cache: Arc<E::Mutex<ParquetMetadataCache>>,
+    /// In-process manifest-version pins held by live snapshots.
+    snapshot_pins: Arc<SnapshotPinRegistry>,
     /// WAL frame bounds covering the current mutable memtable, if any.
     mutable_wal_range: Arc<Mutex<Option<WalFrameRange>>>,
     /// Per-key transactional locks (wired once transactional writes arrive).
@@ -531,6 +658,8 @@ where
     pub(crate) executor: Arc<E>,
     /// Unified filesystem access for SSTable reads, WAL, and other I/O operations.
     fs: Arc<dyn DynFs>,
+    /// Root directory prefix for SST objects referenced by manifest paths.
+    sst_root: Path,
     // Optional WAL handle when durability is enabled.
     wal: Option<WalHandle<E>>,
     /// Pending WAL configuration captured before the writer is installed.
@@ -549,6 +678,8 @@ where
     pruner_cache: Arc<E::Mutex<PrunerCache>>,
     /// Cached Parquet metadata for SST pruning.
     metadata_cache: Arc<E::Mutex<ParquetMetadataCache>>,
+    /// In-process manifest-version pins held by live snapshots.
+    snapshot_pins: Arc<SnapshotPinRegistry>,
     /// WAL frame bounds covering the current mutable memtable, if any.
     mutable_wal_range: Arc<Mutex<Option<WalFrameRange>>>,
     /// Per-key transactional locks (wired once transactional writes arrive).
@@ -608,6 +739,25 @@ where
         Arc::clone(&self.metadata_cache)
     }
 
+    #[allow(dead_code)]
+    pub(crate) fn active_snapshot_pins(&self) -> Vec<Timestamp> {
+        self.snapshot_pins.active_versions()
+    }
+
+    fn pin_snapshot_version(&self, manifest_ts: Timestamp) -> SnapshotPinGuard {
+        self.snapshot_pins.pin(manifest_ts)
+    }
+
+    fn snapshot_pin_for_manifest(
+        &self,
+        manifest_snapshot: &crate::manifest::TableSnapshot,
+    ) -> Option<SnapshotPinGuard> {
+        manifest_snapshot
+            .latest_version
+            .as_ref()
+            .map(|version| self.pin_snapshot_version(version.commit_timestamp()))
+    }
+
     /// Acquire a read guard to the mutable memtable (for testing/inspection).
     #[cfg(all(test, feature = "tokio"))]
     pub(crate) fn mem_read(&self) -> crate::inmem::mutable::memtable::TestMemRef<'_> {
@@ -640,6 +790,7 @@ where
         commit_ack_mode: CommitAckMode,
         mem: DynMem,
         fs: Arc<dyn DynFs>,
+        sst_root: Path,
         manifest: TonboManifest<FS, E>,
         manifest_table: TableId,
         table_meta: TableMeta,
@@ -656,6 +807,7 @@ where
             policy: crate::inmem::policy::default_policy(),
             executor,
             fs,
+            sst_root,
             wal: None,
             wal_config,
             table_meta,
@@ -665,6 +817,7 @@ where
             bloom_cache: default_bloom_cache::<E>(),
             pruner_cache: Arc::new(E::mutex(HashMap::new())),
             metadata_cache: default_parquet_metadata_cache::<E>(),
+            snapshot_pins: Arc::new(SnapshotPinRegistry::default()),
             mutable_wal_range: Arc::new(Mutex::new(None)),
             _key_locks: Arc::new(LockableHashMap::new()),
             compaction_worker: None,
@@ -683,6 +836,7 @@ where
         config: DynModeConfig,
         executor: Arc<E>,
         fs: Arc<dyn DynFs>,
+        sst_root: Path,
         wal_cfg: RuntimeWalConfig,
         manifest: TonboManifest<FS, E>,
         manifest_table: TableId,
@@ -692,6 +846,7 @@ where
             config,
             executor,
             fs,
+            sst_root,
             wal_cfg,
             manifest,
             manifest_table,
@@ -705,6 +860,7 @@ where
         config: DynModeConfig,
         executor: Arc<E>,
         fs: Arc<dyn DynFs>,
+        sst_root: Path,
         wal_cfg: RuntimeWalConfig,
         manifest: TonboManifest<FS, E>,
         manifest_table: TableId,
@@ -725,6 +881,7 @@ where
             commit_ack_mode,
             mem,
             fs,
+            sst_root,
             manifest,
             manifest_table,
             table_meta,
@@ -823,12 +980,14 @@ where
             .manifest
             .snapshot_latest_with_fallback(self.manifest_table, &self.table_meta)
             .await?;
+        let manifest_pin = self.snapshot_pin_for_manifest(&manifest_snapshot);
         let next_ts = self.commit_clock.peek();
         let read_ts = next_ts.saturating_sub(1);
         let read_view = ReadView::new(read_ts);
         Ok(TxSnapshot::from_table_snapshot(
             read_view,
             manifest_snapshot,
+            manifest_pin,
         ))
     }
 
@@ -868,17 +1027,31 @@ where
             self.manifest
                 .snapshot_at_version(self.manifest_table, version.commit_timestamp)
                 .await?
-        } else {
-            // No version at or before the timestamp - use latest with MVCC filtering
+        } else if versions.is_empty() {
+            // No committed manifest versions exist yet, so only the current in-memory/head view can
+            // answer the request.
             self.manifest
                 .snapshot_latest_with_fallback(self.manifest_table, &self.table_meta)
                 .await?
+        } else {
+            return Err(ManifestError::VersionUnavailable {
+                requested: timestamp,
+                oldest_available: versions
+                    .last()
+                    .map(|version| version.commit_timestamp)
+                    .ok_or(ManifestError::Invariant(
+                        "committed manifest versions unexpectedly missing",
+                    ))?,
+            }
+            .into());
         };
 
         let read_view = ReadView::new(timestamp);
+        let manifest_pin = self.snapshot_pin_for_manifest(&manifest_snapshot);
         Ok(TxSnapshot::from_table_snapshot(
             read_view,
             manifest_snapshot,
+            manifest_pin,
         ))
     }
 
@@ -899,31 +1072,21 @@ where
     /// }
     /// ```
     pub async fn list_versions(&self, limit: usize) -> Result<Vec<Version>, ManifestError> {
-        let states = self
+        let mut states = self
             .manifest
             .list_versions(self.manifest_table, limit)
             .await?;
+        if states.is_empty() {
+            let snapshot = self
+                .manifest
+                .snapshot_latest_with_fallback(self.manifest_table, &self.table_meta)
+                .await?;
+            if let Some(latest) = snapshot.latest_version {
+                states.push(latest);
+            }
+        }
 
-        Ok(states
-            .into_iter()
-            .map(|s| {
-                let sst_count = s.ssts.iter().map(|level| level.len()).sum();
-                let sst_bytes = s
-                    .ssts
-                    .iter()
-                    .flatten()
-                    .filter_map(|entry| entry.stats().map(|stats| stats.bytes))
-                    .fold(0u64, |acc, bytes| {
-                        acc.saturating_add(u64::try_from(bytes).unwrap_or(u64::MAX))
-                    });
-                Version {
-                    timestamp: s.commit_timestamp,
-                    sst_count,
-                    sst_bytes,
-                    level_count: s.ssts.iter().filter(|level| !level.is_empty()).count(),
-                }
-            })
-            .collect())
+        Ok(states.into_iter().map(version_from_state).collect())
     }
 
     /// Allocate the next commit timestamp for WAL/autocommit flows.
@@ -1148,7 +1311,11 @@ where
                         "sst descriptor missing data path",
                     ))
                 })?;
-                let delete_path = descriptor_ref.delete_path().cloned();
+                let data_path = manifest_storage_path(&self.sst_root, &data_path);
+                let delete_path = descriptor_ref
+                    .delete_path()
+                    .cloned()
+                    .map(|path| manifest_storage_path(&self.sst_root, &path));
                 let stats = descriptor_ref.stats().cloned();
                 let sst_entry = SstEntry::new(
                     descriptor_ref.id().clone(),
@@ -1256,6 +1423,7 @@ where
             commit_ack_mode,
             mem,
             fs,
+            Path::default(),
             manifest,
             manifest_table,
             table_meta,

--- a/src/db/scan.rs
+++ b/src/db/scan.rs
@@ -41,7 +41,7 @@ use crate::{
         scan::{DeleteStreamWithExtractor, SstableScan, UnpinExec},
         sstable::{
             ParquetStreamOptions, SsTableError, open_parquet_stream_with_metadata,
-            split_predicate_for_row_filter, validate_page_indexes,
+            split_predicate_for_row_filter, storage_path_from_manifest, validate_page_indexes,
         },
     },
     query::{
@@ -299,7 +299,7 @@ impl TxSnapshot {
             }
             let (mut selection, requires_residual) = prune_sst_selection(
                 &prune_ctx,
-                entry.data_path(),
+                &storage_path_from_manifest(&db.sst_root, entry.data_path()),
                 predicate,
                 read_ts,
                 &predicate_scan_schema,
@@ -316,7 +316,7 @@ impl TxSnapshot {
             if let Some(delete_path) = entry.delete_path() {
                 let delete_selection = plan_delete_sidecar_selection(
                     Arc::clone(&prune_ctx.fs),
-                    delete_path,
+                    &storage_path_from_manifest(&db.sst_root, delete_path),
                     &key_schema,
                     Arc::clone(&prune_ctx.metadata_cache),
                     prune_ctx.executor.clone(),
@@ -730,7 +730,7 @@ where
                     ));
                 }
             };
-            let data_path = sst.entry.data_path().clone();
+            let data_path = storage_path_from_manifest(&self.sst_root, sst.entry.data_path());
             let executor: E = (**self.executor()).clone();
 
             let projected_schema = Arc::clone(&selection.projected_schema);
@@ -762,7 +762,7 @@ where
                         selection: "missing delete sidecar selection",
                     })
                 })?;
-                let delete_path = delete_path.clone();
+                let delete_path = storage_path_from_manifest(&self.sst_root, delete_path);
                 let options = ParquetStreamOptions {
                     projection: Some(delete_selection.projection.clone()),
                     row_groups: None,

--- a/src/db/tests/core/compaction.rs
+++ b/src/db/tests/core/compaction.rs
@@ -13,13 +13,15 @@ use std::{
 use arrow_array::RecordBatch;
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
 use fusio::{
-    DynFs,
+    DynFs, Error as FusioError, Write,
     disk::LocalFs,
     dynamic::{MaybeSend, MaybeSendFuture, MaybeSync},
     executor::{Executor, Instant, NoopExecutor, Timer, tokio::TokioExecutor},
+    fs::{CasCondition, FileMeta, FileSystemTag, Fs, FsCas, OpenOptions},
     mem::fs::InMemoryFs,
     path::Path,
 };
+use fusio_manifest::ObjectHead;
 use futures::{StreamExt, future::AbortHandle};
 use tokio::{sync::Mutex, time::sleep};
 use typed_arrow_dyn::{DynCell, DynRow};
@@ -58,10 +60,115 @@ use crate::{
     mvcc::Timestamp,
     ondisk::sstable::{SsTableBuilder, SsTableConfig, SsTableDescriptor, SsTableId, SsTableReader},
     schema::SchemaBuilder,
-    test::build_batch,
+    test::{build_batch, config_with_pk},
 };
 
 type SleepHook = Arc<dyn Fn(Duration) -> Pin<Box<dyn MaybeSendFuture<Output = ()>>> + Send + Sync>;
+
+#[derive(Clone)]
+struct FailOnceRemoveFs {
+    inner: LocalFs,
+    fail_path: Arc<String>,
+    failed_once: Arc<AtomicBool>,
+}
+
+impl FailOnceRemoveFs {
+    fn new(fail_path: impl Into<String>) -> Self {
+        Self {
+            inner: LocalFs {},
+            fail_path: Arc::new(fail_path.into()),
+            failed_once: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    fn has_failed_once(&self) -> bool {
+        self.failed_once.load(Ordering::SeqCst)
+    }
+}
+
+impl Fs for FailOnceRemoveFs {
+    type File = <LocalFs as Fs>::File;
+
+    fn file_system(&self) -> FileSystemTag {
+        Fs::file_system(&self.inner)
+    }
+
+    async fn open_options(
+        &self,
+        path: &Path,
+        options: OpenOptions,
+    ) -> Result<Self::File, FusioError> {
+        Fs::open_options(&self.inner, path, options).await
+    }
+
+    async fn create_dir_all(path: &Path) -> Result<(), FusioError> {
+        <LocalFs as Fs>::create_dir_all(path).await
+    }
+
+    async fn list(
+        &self,
+        path: &Path,
+    ) -> Result<
+        impl futures::Stream<Item = Result<FileMeta, FusioError>> + fusio::dynamic::MaybeSend,
+        FusioError,
+    > {
+        Fs::list(&self.inner, path).await
+    }
+
+    async fn remove(&self, path: &Path) -> Result<(), FusioError> {
+        if path.as_ref() == self.fail_path.as_str()
+            && !self.failed_once.swap(true, Ordering::SeqCst)
+        {
+            return Err(std::io::Error::other("injected sweep delete failure").into());
+        }
+        Fs::remove(&self.inner, path).await
+    }
+
+    async fn copy(&self, from: &Path, to: &Path) -> Result<(), FusioError> {
+        Fs::copy(&self.inner, from, to).await
+    }
+
+    async fn link(&self, from: &Path, to: &Path) -> Result<(), FusioError> {
+        Fs::link(&self.inner, from, to).await
+    }
+}
+
+impl FsCas for FailOnceRemoveFs {
+    fn load_with_tag(
+        &self,
+        path: &Path,
+    ) -> Pin<Box<dyn MaybeSendFuture<Output = Result<Option<(Vec<u8>, String)>, FusioError>> + '_>>
+    {
+        self.inner.load_with_tag(path)
+    }
+
+    fn put_conditional(
+        &self,
+        path: &Path,
+        payload: &[u8],
+        content_type: Option<&str>,
+        metadata: Option<Vec<(String, String)>>,
+        condition: CasCondition,
+    ) -> Pin<Box<dyn MaybeSendFuture<Output = Result<String, FusioError>> + '_>> {
+        self.inner
+            .put_conditional(path, payload, content_type, metadata, condition)
+    }
+}
+
+impl ObjectHead for FailOnceRemoveFs {
+    fn head_metadata<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> Pin<
+        Box<
+            dyn MaybeSendFuture<
+                    Output = Result<Option<std::collections::HashMap<String, String>>, FusioError>,
+                > + 'a,
+        >,
+    > {
+        self.inner.head_metadata(path)
+    }
+}
 
 #[derive(Clone)]
 struct RecordingExecutor {
@@ -126,6 +233,63 @@ impl Executor for RecordingExecutor {
     {
         <TokioExecutor as Executor>::rw_lock(value)
     }
+}
+
+fn local_sst_path<FS, E>(db: &DbInner<FS, E>, relative: &str) -> Path
+where
+    FS: crate::manifest::ManifestFs<E>,
+    E: Executor + Timer + Clone + 'static,
+    <FS as fusio::fs::Fs>::File: fusio::durability::FileCommit,
+{
+    Path::from(format!("{}/{}", db.sst_root.as_ref(), relative))
+}
+
+async fn write_local_sst_object(
+    path: &Path,
+    bytes: &[u8],
+) -> Result<(), Box<dyn std::error::Error>> {
+    let parent = std::path::Path::new(path.as_ref())
+        .parent()
+        .ok_or("sst object missing parent directory")?;
+    fs::create_dir_all(parent)?;
+    let fs = LocalFs {};
+    let mut file = Fs::open_options(
+        &fs,
+        path,
+        OpenOptions::default().create(true).truncate(true),
+    )
+    .await?;
+    let (write_res, _) = file.write_all(bytes.to_vec()).await;
+    write_res?;
+    file.close().await?;
+    Ok(())
+}
+
+async fn local_sst_exists(path: &Path) -> bool {
+    Fs::open(&LocalFs {}, path).await.is_ok()
+}
+
+fn count_local_sst_objects(root: &std::path::Path) -> Result<u64, Box<dyn std::error::Error>> {
+    fn visit(path: &std::path::Path, count: &mut u64) -> Result<(), std::io::Error> {
+        for entry in fs::read_dir(path)? {
+            let entry = entry?;
+            let file_type = entry.file_type()?;
+            if file_type.is_dir() {
+                visit(&entry.path(), count)?;
+            } else if entry
+                .path()
+                .extension()
+                .is_some_and(|extension| extension == "parquet")
+            {
+                *count = count.saturating_add(1);
+            }
+        }
+        Ok(())
+    }
+
+    let mut count = 0u64;
+    visit(root, &mut count)?;
+    Ok(count)
 }
 
 impl Timer for RecordingExecutor {
@@ -885,16 +1049,24 @@ async fn compaction_updates_manifest_wal_and_records_gc_plan()
         vec![wal_a.clone()],
         "should surface obsolete wal segments"
     );
+    let _historical = db.snapshot_at(Timestamp::new(1)).await?;
 
     let plan = db
         .inner()
         .manifest
-        .take_gc_plan(db.inner().manifest_table)
+        .take_gc_plan_for_authorized_sweep_with_pins(
+            db.inner().manifest_table,
+            &db.inner().active_snapshot_pins(),
+        )
         .await?
         .expect("gc plan recorded");
     assert_eq!(plan.obsolete_wal_segments.len(), 1);
     assert_eq!(plan.obsolete_wal_segments[0].file_id(), wal_a.file_id());
-    assert_eq!(plan.obsolete_ssts.len(), 2);
+    assert_eq!(
+        plan.obsolete_ssts.len(),
+        0,
+        "active historical snapshots should keep replaced SSTs protected",
+    );
     Ok(())
 }
 
@@ -991,16 +1163,19 @@ async fn compaction_preserves_manifest_wal_when_metadata_missing()
         outcome.obsolete_wal_segments.is_empty(),
         "should not surface obsolete wal segments when manifest set is preserved"
     );
+    let _historical = db.snapshot_at(Timestamp::new(1)).await?;
 
-    let plan = db
-        .inner()
-        .manifest
-        .take_gc_plan(db.inner().manifest_table)
-        .await?
-        .expect("gc plan recorded");
     assert!(
-        plan.obsolete_wal_segments.is_empty(),
-        "gc plan should not mark wal segments obsolete"
+        db.inner()
+            .manifest
+            .take_gc_plan_for_authorized_sweep_with_pins(
+                db.inner().manifest_table,
+                &db.inner().active_snapshot_pins(),
+            )
+            .await?
+            .is_none(),
+        "historically pinned SSTs should consume the staged GC plan when no WAL segments are \
+         obsolete",
     );
     Ok(())
 }
@@ -1178,20 +1353,1635 @@ async fn compaction_e2e_merges_and_advances_wal_floor() -> Result<(), Box<dyn st
         Some(wal_a.file_id()),
         "wal floor should align to first retained segment"
     );
+    let _historical = db.snapshot_at(Timestamp::new(1)).await?;
+
+    assert!(
+        db.inner()
+            .manifest
+            .take_gc_plan_for_authorized_sweep_with_pins(
+                db.inner().manifest_table,
+                &db.inner().active_snapshot_pins(),
+            )
+            .await?
+            .is_none(),
+        "active historical snapshots should keep replaced SSTs out of the authorized sweep set",
+    );
+
+    fs::remove_dir_all(&temp_root)?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn blocked_gc_candidates_survive_later_compactions_that_stage_more_work()
+-> Result<(), Box<dyn std::error::Error>> {
+    let db: DB<InMemoryFs, NoopExecutor> = DB::new(
+        SchemaBuilder::from_schema(Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("v", DataType::Int32, false),
+        ])))
+        .primary_key("id")
+        .build()
+        .expect("schema builder"),
+        Arc::new(NoopExecutor),
+    )
+    .await
+    .expect("db init");
+
+    db.inner()
+        .manifest
+        .apply_version_edits(
+            db.inner().manifest_table,
+            &[VersionEdit::AddSsts {
+                level: 0,
+                entries: vec![
+                    SstEntry::new(
+                        SsTableId::new(1),
+                        None,
+                        None,
+                        Path::from("L0/1.parquet"),
+                        None,
+                    ),
+                    SstEntry::new(
+                        SsTableId::new(2),
+                        None,
+                        None,
+                        Path::from("L0/2.parquet"),
+                        None,
+                    ),
+                ],
+            }],
+        )
+        .await?;
+    let _historical = db.snapshot_at(Timestamp::new(1)).await?;
+
+    let first = db
+        .inner()
+        .run_compaction_task(
+            &OneShotPlanner::new(CompactionTask {
+                source_level: 0,
+                target_level: 1,
+                input: vec![CompactionInput {
+                    level: 0,
+                    sst_id: SsTableId::new(1),
+                }],
+                key_range: None,
+            }),
+            &StaticExecutor {
+                outputs: vec![
+                    SsTableDescriptor::new(SsTableId::new(3), 1)
+                        .with_storage_paths(Path::from("L1/3.parquet"), None),
+                ],
+                wal_segments: Vec::new(),
+                target_level: 1,
+            },
+        )
+        .await?
+        .expect("first compaction outcome");
+    assert_eq!(first.remove_ssts.len(), 1);
+
+    let second = db
+        .inner()
+        .run_compaction_task(
+            &OneShotPlanner::new(CompactionTask {
+                source_level: 0,
+                target_level: 1,
+                input: vec![CompactionInput {
+                    level: 0,
+                    sst_id: SsTableId::new(2),
+                }],
+                key_range: None,
+            }),
+            &StaticExecutor {
+                outputs: vec![
+                    SsTableDescriptor::new(SsTableId::new(4), 1)
+                        .with_storage_paths(Path::from("L1/4.parquet"), None),
+                ],
+                wal_segments: Vec::new(),
+                target_level: 1,
+            },
+        )
+        .await?
+        .expect("second compaction outcome");
+    assert_eq!(second.remove_ssts.len(), 1);
+
+    let inspection = db
+        .inspect_sst_gc_plan()
+        .await?
+        .expect("blocked gc plan should remain staged");
+    assert_eq!(inspection.staged_sst_candidates, 2);
+    assert_eq!(inspection.authorized_sst_candidates, 0);
+    assert_eq!(inspection.blocked_sst_candidates, 2);
+    assert_eq!(
+        inspection
+            .candidates
+            .iter()
+            .map(|candidate| candidate.sst_id)
+            .collect::<Vec<_>>(),
+        vec![1, 2]
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn authorized_gc_plan_for_sweep_filters_reachable_ssts_from_current_root_set()
+-> Result<(), Box<dyn std::error::Error>> {
+    let db: DB<InMemoryFs, NoopExecutor> = DB::new(
+        SchemaBuilder::from_schema(Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("v", DataType::Int32, false),
+        ])))
+        .primary_key("id")
+        .build()
+        .expect("schema builder"),
+        Arc::new(NoopExecutor),
+    )
+    .await
+    .expect("db init");
+
+    db.inner()
+        .manifest
+        .apply_version_edits(
+            db.inner().manifest_table,
+            &[VersionEdit::AddSsts {
+                level: 1,
+                entries: vec![SstEntry::new(
+                    SsTableId::new(1),
+                    None,
+                    None,
+                    Path::from("L1/1.parquet"),
+                    None,
+                )],
+            }],
+        )
+        .await?;
+
+    db.inner()
+        .manifest
+        .record_gc_plan(
+            db.inner().manifest_table,
+            crate::manifest::GcPlanState {
+                obsolete_ssts: vec![
+                    crate::manifest::GcSstRef {
+                        id: SsTableId::new(1),
+                        level: 1,
+                        data_path: Path::from("L1/1.parquet"),
+                        delete_path: None,
+                    },
+                    crate::manifest::GcSstRef {
+                        id: SsTableId::new(99),
+                        level: 0,
+                        data_path: Path::from("L0/99.parquet"),
+                        delete_path: None,
+                    },
+                ],
+                obsolete_wal_segments: Vec::new(),
+            },
+        )
+        .await?;
 
     let plan = db
         .inner()
         .manifest
-        .take_gc_plan(db.inner().manifest_table)
+        .take_gc_plan_for_authorized_sweep(db.inner().manifest_table)
         .await?
-        .expect("gc plan recorded");
-    assert_eq!(plan.obsolete_wal_segments.len(), 0);
+        .expect("filtered gc plan");
+    assert_eq!(plan.obsolete_ssts.len(), 1);
+    assert_eq!(plan.obsolete_ssts[0].id, SsTableId::new(99));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn authorized_gc_plan_for_sweep_drops_sst_only_plan_when_candidate_is_live()
+-> Result<(), Box<dyn std::error::Error>> {
+    let db: DB<InMemoryFs, NoopExecutor> = DB::new(
+        SchemaBuilder::from_schema(Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("v", DataType::Int32, false),
+        ])))
+        .primary_key("id")
+        .build()
+        .expect("schema builder"),
+        Arc::new(NoopExecutor),
+    )
+    .await
+    .expect("db init");
+
+    db.inner()
+        .manifest
+        .apply_version_edits(
+            db.inner().manifest_table,
+            &[VersionEdit::AddSsts {
+                level: 2,
+                entries: vec![SstEntry::new(
+                    SsTableId::new(7),
+                    None,
+                    None,
+                    Path::from("L2/7.parquet"),
+                    None,
+                )],
+            }],
+        )
+        .await?;
+
+    db.inner()
+        .manifest
+        .record_gc_plan(
+            db.inner().manifest_table,
+            crate::manifest::GcPlanState {
+                obsolete_ssts: vec![crate::manifest::GcSstRef {
+                    id: SsTableId::new(7),
+                    level: 2,
+                    data_path: Path::from("L2/7.parquet"),
+                    delete_path: None,
+                }],
+                obsolete_wal_segments: Vec::new(),
+            },
+        )
+        .await?;
+
     assert!(
-        !plan.obsolete_ssts.is_empty(),
-        "gc plan should record obsolete ssts"
+        db.inner()
+            .manifest
+            .take_gc_plan_for_authorized_sweep(db.inner().manifest_table)
+            .await?
+            .is_none(),
+        "root-set filtering should not authorize deleting a live SST",
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn authorized_gc_plan_for_sweep_rechecks_root_set_after_candidate_becomes_live()
+-> Result<(), Box<dyn std::error::Error>> {
+    let db: DB<InMemoryFs, NoopExecutor> = DB::new(
+        SchemaBuilder::from_schema(Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("v", DataType::Int32, false),
+        ])))
+        .primary_key("id")
+        .build()
+        .expect("schema builder"),
+        Arc::new(NoopExecutor),
+    )
+    .await
+    .expect("db init");
+
+    db.inner()
+        .manifest
+        .record_gc_plan(
+            db.inner().manifest_table,
+            crate::manifest::GcPlanState {
+                obsolete_ssts: vec![crate::manifest::GcSstRef {
+                    id: SsTableId::new(42),
+                    level: 1,
+                    data_path: Path::from("L1/42.parquet"),
+                    delete_path: None,
+                }],
+                obsolete_wal_segments: Vec::new(),
+            },
+        )
+        .await?;
+
+    db.inner()
+        .manifest
+        .apply_version_edits(
+            db.inner().manifest_table,
+            &[VersionEdit::AddSsts {
+                level: 1,
+                entries: vec![SstEntry::new(
+                    SsTableId::new(42),
+                    None,
+                    None,
+                    Path::from("L1/42.parquet"),
+                    None,
+                )],
+            }],
+        )
+        .await?;
+
+    assert!(
+        db.inner()
+            .manifest
+            .take_gc_plan_for_authorized_sweep(db.inner().manifest_table)
+            .await?
+            .is_none(),
+        "sweep authorization must reject a staged SST candidate that is live in the current root \
+         set",
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn authorized_gc_plan_for_sweep_preserves_historically_pinned_sst_objects()
+-> Result<(), Box<dyn std::error::Error>> {
+    let db: DB<InMemoryFs, NoopExecutor> = DB::new(
+        SchemaBuilder::from_schema(Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("v", DataType::Int32, false),
+        ])))
+        .primary_key("id")
+        .build()
+        .expect("schema builder"),
+        Arc::new(NoopExecutor),
+    )
+    .await
+    .expect("db init");
+
+    let historical_data = Path::from("L0/5.parquet");
+    let historical_delete = Path::from("L0/5.delete.parquet");
+    let head_data = Path::from("L1/6.parquet");
+
+    db.inner()
+        .manifest
+        .apply_version_edits(
+            db.inner().manifest_table,
+            &[VersionEdit::AddSsts {
+                level: 0,
+                entries: vec![SstEntry::new(
+                    SsTableId::new(5),
+                    None,
+                    None,
+                    historical_data.clone(),
+                    Some(historical_delete.clone()),
+                )],
+            }],
+        )
+        .await?;
+
+    db.inner()
+        .manifest
+        .apply_version_edits(
+            db.inner().manifest_table,
+            &[
+                VersionEdit::RemoveSsts {
+                    level: 0,
+                    sst_ids: vec![SsTableId::new(5)],
+                },
+                VersionEdit::AddSsts {
+                    level: 1,
+                    entries: vec![SstEntry::new(
+                        SsTableId::new(6),
+                        None,
+                        None,
+                        head_data.clone(),
+                        None,
+                    )],
+                },
+            ],
+        )
+        .await?;
+    let _historical = db.snapshot_at(Timestamp::new(1)).await?;
+
+    let root_set = db
+        .inner()
+        .manifest
+        .current_root_set_with_pins(
+            db.inner().manifest_table,
+            &db.inner().active_snapshot_pins(),
+        )
+        .await?;
+    assert_eq!(root_set.protected_version_count(), 2);
+    assert_eq!(root_set.protected_object_count(), 3);
+
+    db.inner()
+        .manifest
+        .record_gc_plan(
+            db.inner().manifest_table,
+            crate::manifest::GcPlanState {
+                obsolete_ssts: vec![crate::manifest::GcSstRef {
+                    id: SsTableId::new(5),
+                    level: 0,
+                    data_path: historical_data,
+                    delete_path: Some(historical_delete),
+                }],
+                obsolete_wal_segments: Vec::new(),
+            },
+        )
+        .await?;
+
+    assert!(
+        db.inner()
+            .manifest
+            .take_gc_plan_for_authorized_sweep_with_pins(
+                db.inner().manifest_table,
+                &db.inner().active_snapshot_pins(),
+            )
+            .await?
+            .is_none(),
+        "active historical snapshots must keep their SST objects protected",
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn snapshot_at_reports_oldest_available_version_when_request_predates_history()
+-> Result<(), Box<dyn std::error::Error>> {
+    let db: DB<InMemoryFs, NoopExecutor> = DB::new(
+        SchemaBuilder::from_schema(Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("v", DataType::Int32, false),
+        ])))
+        .primary_key("id")
+        .build()
+        .expect("schema builder"),
+        Arc::new(NoopExecutor),
+    )
+    .await
+    .expect("db init");
+
+    for (sst_id, level) in [(1u64, 0u32), (2, 1), (3, 2)] {
+        db.inner()
+            .manifest
+            .apply_version_edits(
+                db.inner().manifest_table,
+                &[VersionEdit::AddSsts {
+                    level,
+                    entries: vec![SstEntry::new(
+                        SsTableId::new(sst_id),
+                        None,
+                        None,
+                        Path::from(format!("L{level}/{sst_id}.parquet")),
+                        None,
+                    )],
+                }],
+            )
+            .await?;
+    }
+
+    let err = db
+        .snapshot_at(Timestamp::new(0))
+        .await
+        .expect_err("timestamp before the first committed version should be unavailable");
+    assert!(matches!(
+        err,
+        crate::transaction::SnapshotError::Manifest(ManifestError::VersionUnavailable {
+            requested,
+            oldest_available,
+        }) if requested == Timestamp::new(0) && oldest_available == Timestamp::new(1)
+    ));
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn historical_snapshot_remains_stable_after_newer_manifest_commits()
+-> Result<(), Box<dyn std::error::Error>> {
+    let db: DB<InMemoryFs, NoopExecutor> = DB::new(
+        SchemaBuilder::from_schema(Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("v", DataType::Int32, false),
+        ])))
+        .primary_key("id")
+        .build()
+        .expect("schema builder"),
+        Arc::new(NoopExecutor),
+    )
+    .await
+    .expect("db init");
+
+    db.inner()
+        .manifest
+        .apply_version_edits(
+            db.inner().manifest_table,
+            &[VersionEdit::AddSsts {
+                level: 0,
+                entries: vec![SstEntry::new(
+                    SsTableId::new(1),
+                    None,
+                    None,
+                    Path::from("L0/1.parquet"),
+                    None,
+                )],
+            }],
+        )
+        .await?;
+
+    let historical = db.snapshot_at(Timestamp::new(1)).await?;
+
+    db.inner()
+        .manifest
+        .apply_version_edits(
+            db.inner().manifest_table,
+            &[
+                VersionEdit::RemoveSsts {
+                    level: 0,
+                    sst_ids: vec![SsTableId::new(1)],
+                },
+                VersionEdit::AddSsts {
+                    level: 1,
+                    entries: vec![SstEntry::new(
+                        SsTableId::new(2),
+                        None,
+                        None,
+                        Path::from("L1/2.parquet"),
+                        None,
+                    )],
+                },
+            ],
+        )
+        .await?;
+
+    assert_eq!(
+        historical
+            .latest_version()
+            .map(VersionState::commit_timestamp),
+        Some(Timestamp::new(1))
+    );
+    assert_eq!(db.inner().active_snapshot_pins(), vec![Timestamp::new(1)]);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn multiple_concurrent_snapshots_pin_multiple_manifest_versions()
+-> Result<(), Box<dyn std::error::Error>> {
+    let db: DB<InMemoryFs, NoopExecutor> = DB::new(
+        SchemaBuilder::from_schema(Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("v", DataType::Int32, false),
+        ])))
+        .primary_key("id")
+        .build()
+        .expect("schema builder"),
+        Arc::new(NoopExecutor),
+    )
+    .await
+    .expect("db init");
+
+    for (sst_id, level) in [(1u64, 0u32), (2, 1)] {
+        db.inner()
+            .manifest
+            .apply_version_edits(
+                db.inner().manifest_table,
+                &[VersionEdit::AddSsts {
+                    level,
+                    entries: vec![SstEntry::new(
+                        SsTableId::new(sst_id),
+                        None,
+                        None,
+                        Path::from(format!("L{level}/{sst_id}.parquet")),
+                        None,
+                    )],
+                }],
+            )
+            .await?;
+    }
+
+    let _v1 = db.snapshot_at(Timestamp::new(1)).await?;
+    let _v2 = db.begin_snapshot().await?;
+
+    let root_set = db
+        .inner()
+        .manifest
+        .current_root_set_with_pins(
+            db.inner().manifest_table,
+            &db.inner().active_snapshot_pins(),
+        )
+        .await?;
+    assert_eq!(root_set.protected_version_count(), 2);
+    assert_eq!(root_set.active_snapshot_version_count(), 2);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn latest_snapshot_pinning_tracks_head_without_regressing_reads()
+-> Result<(), Box<dyn std::error::Error>> {
+    let db: DB<InMemoryFs, NoopExecutor> = DB::new(
+        SchemaBuilder::from_schema(Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("v", DataType::Int32, false),
+        ])))
+        .primary_key("id")
+        .build()
+        .expect("schema builder"),
+        Arc::new(NoopExecutor),
+    )
+    .await
+    .expect("db init");
+
+    db.inner()
+        .manifest
+        .apply_version_edits(
+            db.inner().manifest_table,
+            &[VersionEdit::AddSsts {
+                level: 0,
+                entries: vec![SstEntry::new(
+                    SsTableId::new(1),
+                    None,
+                    None,
+                    Path::from("L0/1.parquet"),
+                    None,
+                )],
+            }],
+        )
+        .await?;
+
+    let latest = db.begin_snapshot().await?;
+    assert_eq!(
+        latest.latest_version().map(VersionState::commit_timestamp),
+        Some(Timestamp::new(1))
+    );
+    assert_eq!(db.inner().active_snapshot_pins(), vec![Timestamp::new(1)]);
+
+    drop(latest);
+    assert!(db.inner().active_snapshot_pins().is_empty());
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sweep_manifest_ssts_reclaims_obsolete_candidate_after_snapshot_pin_drops()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root_dir = workspace_temp_dir("snapshot-pin-sst-reclaim");
+    let root_str = root_dir.to_string_lossy().into_owned();
+    let executor = Arc::new(TokioExecutor::default());
+
+    let db = DB::<LocalFs, TokioExecutor>::builder(config_with_pk(
+        vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("v", DataType::Int32, false),
+        ],
+        &["id"],
+    ))
+    .on_disk(root_str.clone())?
+    .open_with_executor(Arc::clone(&executor))
+    .await?
+    .into_inner();
+
+    let obsolete_path = local_sst_path(&db, "L0/obsolete.parquet");
+    let head_path = local_sst_path(&db, "L1/head.parquet");
+    write_local_sst_object(&obsolete_path, b"obsolete").await?;
+    write_local_sst_object(&head_path, b"head").await?;
+
+    db.manifest
+        .apply_version_edits(
+            db.manifest_table,
+            &[VersionEdit::AddSsts {
+                level: 0,
+                entries: vec![SstEntry::new(
+                    SsTableId::new(5),
+                    None,
+                    None,
+                    Path::from("L0/obsolete.parquet"),
+                    None,
+                )],
+            }],
+        )
+        .await?;
+
+    db.manifest
+        .apply_version_edits(
+            db.manifest_table,
+            &[
+                VersionEdit::RemoveSsts {
+                    level: 0,
+                    sst_ids: vec![SsTableId::new(5)],
+                },
+                VersionEdit::AddSsts {
+                    level: 1,
+                    entries: vec![SstEntry::new(
+                        SsTableId::new(6),
+                        None,
+                        None,
+                        Path::from("L1/head.parquet"),
+                        None,
+                    )],
+                },
+            ],
+        )
+        .await?;
+
+    let historical = db.snapshot_at(Timestamp::new(1)).await?;
+    let root_set = db
+        .manifest
+        .current_root_set_with_pins(db.manifest_table, &db.active_snapshot_pins())
+        .await?;
+    assert_eq!(root_set.protected_version_count(), 2);
+    assert_eq!(root_set.active_snapshot_version_count(), 1);
+    assert!(root_set.contains_path(&Path::from("L0/obsolete.parquet")));
+    assert!(root_set.contains_path(&Path::from("L1/head.parquet")));
+
+    db.manifest
+        .record_gc_plan(
+            db.manifest_table,
+            crate::manifest::GcPlanState {
+                obsolete_ssts: vec![crate::manifest::GcSstRef {
+                    id: SsTableId::new(5),
+                    level: 0,
+                    data_path: Path::from("L0/obsolete.parquet"),
+                    delete_path: None,
+                }],
+                obsolete_wal_segments: Vec::new(),
+            },
+        )
+        .await?;
+
+    let blocked = db.sweep_manifest_ssts().await?;
+    assert_eq!(blocked.deleted_objects, 0);
+    assert_eq!(blocked.deleted_bytes, 0);
+    assert!(local_sst_exists(&obsolete_path).await);
+
+    drop(historical);
+
+    let root_set = db
+        .manifest
+        .current_root_set_with_pins(db.manifest_table, &db.active_snapshot_pins())
+        .await?;
+    assert_eq!(root_set.protected_version_count(), 1);
+    assert!(!root_set.contains_path(&Path::from("L0/obsolete.parquet")));
+
+    let summary = db.sweep_manifest_ssts().await?;
+    assert_eq!(summary.deleted_objects, 1);
+    assert_eq!(summary.deleted_bytes, 8);
+    assert_eq!(summary.delete_failures, 0);
+    assert!(!local_sst_exists(&obsolete_path).await);
+    assert!(local_sst_exists(&head_path).await);
+    assert!(
+        db.manifest
+            .take_gc_plan_for_authorized_sweep(db.manifest_table)
+            .await?
+            .is_none(),
+        "reclaimed candidate should fully drain the staged plan",
     );
 
-    fs::remove_dir_all(&temp_root)?;
+    if let Err(err) = fs::remove_dir_all(&root_dir) {
+        eprintln!("failed to clean temp dir {:?}: {err}", &root_dir);
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sweep_manifest_ssts_requeues_historically_blocked_candidates_and_reports_status()
+-> Result<(), Box<dyn std::error::Error>> {
+    let db: DB<InMemoryFs, NoopExecutor> = DB::new(
+        SchemaBuilder::from_schema(Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("v", DataType::Int32, false),
+        ])))
+        .primary_key("id")
+        .build()
+        .expect("schema builder"),
+        Arc::new(NoopExecutor),
+    )
+    .await
+    .expect("db init");
+
+    db.inner()
+        .manifest
+        .apply_version_edits(
+            db.inner().manifest_table,
+            &[VersionEdit::AddSsts {
+                level: 0,
+                entries: vec![SstEntry::new(
+                    SsTableId::new(5),
+                    None,
+                    None,
+                    Path::from("L0/5.parquet"),
+                    Some(Path::from("L0/5.delete.parquet")),
+                )],
+            }],
+        )
+        .await?;
+
+    db.inner()
+        .manifest
+        .apply_version_edits(
+            db.inner().manifest_table,
+            &[
+                VersionEdit::RemoveSsts {
+                    level: 0,
+                    sst_ids: vec![SsTableId::new(5)],
+                },
+                VersionEdit::AddSsts {
+                    level: 1,
+                    entries: vec![SstEntry::new(
+                        SsTableId::new(6),
+                        None,
+                        None,
+                        Path::from("L1/6.parquet"),
+                        None,
+                    )],
+                },
+            ],
+        )
+        .await?;
+
+    db.inner()
+        .manifest
+        .record_gc_plan(
+            db.inner().manifest_table,
+            crate::manifest::GcPlanState {
+                obsolete_ssts: vec![crate::manifest::GcSstRef {
+                    id: SsTableId::new(5),
+                    level: 0,
+                    data_path: Path::from("L0/5.parquet"),
+                    delete_path: Some(Path::from("L0/5.delete.parquet")),
+                }],
+                obsolete_wal_segments: Vec::new(),
+            },
+        )
+        .await?;
+    let _historical = db.snapshot_at(Timestamp::new(1)).await?;
+
+    let summary = db.inner().sweep_manifest_ssts().await?;
+    assert_eq!(summary.deleted_objects, 0);
+    assert_eq!(summary.deleted_bytes, 0);
+    assert_eq!(summary.delete_failures, 0);
+
+    let status = db
+        .sst_gc_status()
+        .await?
+        .expect("blocked gc candidates should stay staged");
+    assert_eq!(status.staged_sst_candidates, 1);
+    assert_eq!(status.authorized_sst_candidates, 0);
+    assert_eq!(status.blocked_sst_candidates, 1);
+    assert_eq!(status.protected_versions, 2);
+    assert_eq!(status.active_snapshot_versions, 1);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sweep_manifest_ssts_deletes_only_unreachable_objects_and_records_metrics()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp_root = workspace_temp_dir("sst-sweep-live-vs-unreachable");
+    let root_str = temp_root.to_string_lossy().into_owned();
+
+    let mut db = DB::<LocalFs, TokioExecutor>::builder(config_with_pk(
+        vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("v", DataType::Int32, false),
+        ],
+        &["id"],
+    ))
+    .on_disk(root_str)?
+    .open_with_executor(Arc::new(TokioExecutor::default()))
+    .await?
+    .into_inner();
+    let metrics = Arc::new(CompactionMetrics::new());
+    db.compaction_metrics = Some(Arc::clone(&metrics));
+
+    db.manifest
+        .apply_version_edits(
+            db.manifest_table,
+            &[VersionEdit::AddSsts {
+                level: 1,
+                entries: vec![SstEntry::new(
+                    SsTableId::new(1),
+                    None,
+                    None,
+                    Path::from("L1/live.parquet"),
+                    None,
+                )],
+            }],
+        )
+        .await?;
+
+    let live_path = local_sst_path(&db, "L1/live.parquet");
+    let obsolete_data = local_sst_path(&db, "L0/obsolete.parquet");
+    let obsolete_delete = local_sst_path(&db, "L0/obsolete.delete.parquet");
+    write_local_sst_object(&live_path, b"live").await?;
+    write_local_sst_object(&obsolete_data, b"obsolete-data").await?;
+    write_local_sst_object(&obsolete_delete, b"obsolete-delete").await?;
+
+    db.manifest
+        .record_gc_plan(
+            db.manifest_table,
+            crate::manifest::GcPlanState {
+                obsolete_ssts: vec![
+                    crate::manifest::GcSstRef {
+                        id: SsTableId::new(1),
+                        level: 1,
+                        data_path: Path::from("L1/live.parquet"),
+                        delete_path: None,
+                    },
+                    crate::manifest::GcSstRef {
+                        id: SsTableId::new(9),
+                        level: 0,
+                        data_path: Path::from("L0/obsolete.parquet"),
+                        delete_path: Some(Path::from("L0/obsolete.delete.parquet")),
+                    },
+                ],
+                obsolete_wal_segments: Vec::new(),
+            },
+        )
+        .await?;
+
+    let summary = db.sweep_manifest_ssts().await?;
+    assert_eq!(summary.deleted_objects, 2);
+    assert_eq!(summary.deleted_bytes, 28);
+    assert_eq!(summary.delete_failures, 0);
+    assert!(local_sst_exists(&live_path).await);
+    assert!(!local_sst_exists(&obsolete_data).await);
+    assert!(!local_sst_exists(&obsolete_delete).await);
+
+    let snapshot = metrics.snapshot();
+    assert_eq!(snapshot.sst_sweep_runs, 1);
+    assert_eq!(snapshot.sst_deleted_objects, 2);
+    assert_eq!(snapshot.sst_deleted_bytes, 28);
+    assert_eq!(snapshot.sst_delete_failures, 0);
+    assert!(snapshot.sst_sweep_duration_ms_total >= summary.duration_ms);
+
+    fs::remove_dir_all(temp_root)?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sweep_manifest_ssts_is_idempotent_when_candidates_are_replayed()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp_root = workspace_temp_dir("sst-sweep-idempotent");
+    let root_str = temp_root.to_string_lossy().into_owned();
+
+    let db = DB::<LocalFs, TokioExecutor>::builder(config_with_pk(
+        vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("v", DataType::Int32, false),
+        ],
+        &["id"],
+    ))
+    .on_disk(root_str)?
+    .open_with_executor(Arc::new(TokioExecutor::default()))
+    .await?
+    .into_inner();
+
+    let obsolete_data = local_sst_path(&db, "L0/replay.parquet");
+    let obsolete_delete = local_sst_path(&db, "L0/replay.delete.parquet");
+    write_local_sst_object(&obsolete_data, b"payload").await?;
+    write_local_sst_object(&obsolete_delete, b"delete").await?;
+
+    let gc_plan = crate::manifest::GcPlanState {
+        obsolete_ssts: vec![crate::manifest::GcSstRef {
+            id: SsTableId::new(11),
+            level: 0,
+            data_path: Path::from("L0/replay.parquet"),
+            delete_path: Some(Path::from("L0/replay.delete.parquet")),
+        }],
+        obsolete_wal_segments: Vec::new(),
+    };
+    db.manifest
+        .record_gc_plan(db.manifest_table, gc_plan.clone())
+        .await?;
+
+    let first = db.sweep_manifest_ssts().await?;
+    assert_eq!(first.deleted_objects, 2);
+    assert_eq!(first.deleted_bytes, 13);
+    assert_eq!(first.delete_failures, 0);
+
+    db.manifest
+        .record_gc_plan(db.manifest_table, gc_plan)
+        .await?;
+    let second = db.sweep_manifest_ssts().await?;
+    assert_eq!(second.deleted_objects, 0);
+    assert_eq!(second.deleted_bytes, 0);
+    assert_eq!(second.delete_failures, 0);
+
+    fs::remove_dir_all(temp_root)?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sweep_manifest_ssts_preserves_live_objects_across_repeated_replays()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp_root = workspace_temp_dir("sst-sweep-live-replayed");
+    let root_str = temp_root.to_string_lossy().into_owned();
+
+    let db = DB::<LocalFs, TokioExecutor>::builder(config_with_pk(
+        vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("v", DataType::Int32, false),
+        ],
+        &["id"],
+    ))
+    .on_disk(root_str)?
+    .open_with_executor(Arc::new(TokioExecutor::default()))
+    .await?
+    .into_inner();
+
+    db.manifest
+        .apply_version_edits(
+            db.manifest_table,
+            &[VersionEdit::AddSsts {
+                level: 1,
+                entries: vec![SstEntry::new(
+                    SsTableId::new(1),
+                    None,
+                    None,
+                    Path::from("L1/live.parquet"),
+                    None,
+                )],
+            }],
+        )
+        .await?;
+
+    let live_path = local_sst_path(&db, "L1/live.parquet");
+    let obsolete_path = local_sst_path(&db, "L0/obsolete.parquet");
+    write_local_sst_object(&live_path, b"live").await?;
+    write_local_sst_object(&obsolete_path, b"obsolete").await?;
+
+    let replayed_gc_plan = crate::manifest::GcPlanState {
+        obsolete_ssts: vec![
+            crate::manifest::GcSstRef {
+                id: SsTableId::new(1),
+                level: 1,
+                data_path: Path::from("L1/live.parquet"),
+                delete_path: None,
+            },
+            crate::manifest::GcSstRef {
+                id: SsTableId::new(9),
+                level: 0,
+                data_path: Path::from("L0/obsolete.parquet"),
+                delete_path: None,
+            },
+        ],
+        obsolete_wal_segments: Vec::new(),
+    };
+
+    db.manifest
+        .record_gc_plan(db.manifest_table, replayed_gc_plan.clone())
+        .await?;
+    let first = db.sweep_manifest_ssts().await?;
+    assert_eq!(first.deleted_objects, 1);
+    assert_eq!(first.deleted_bytes, 8);
+    assert_eq!(first.delete_failures, 0);
+    assert!(local_sst_exists(&live_path).await);
+    assert!(!local_sst_exists(&obsolete_path).await);
+
+    db.manifest
+        .record_gc_plan(db.manifest_table, replayed_gc_plan)
+        .await?;
+    let second = db.sweep_manifest_ssts().await?;
+    assert_eq!(second.deleted_objects, 0);
+    assert_eq!(second.deleted_bytes, 0);
+    assert_eq!(second.delete_failures, 0);
+    assert!(local_sst_exists(&live_path).await);
+
+    fs::remove_dir_all(temp_root)?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn merge_gc_plan_preserves_prior_candidates_and_deduplicates()
+-> Result<(), Box<dyn std::error::Error>> {
+    let db: DB<InMemoryFs, NoopExecutor> = DB::new(
+        SchemaBuilder::from_schema(Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("v", DataType::Int32, false),
+        ])))
+        .primary_key("id")
+        .build()
+        .expect("schema builder"),
+        Arc::new(NoopExecutor),
+    )
+    .await
+    .expect("db init");
+
+    db.inner()
+        .manifest
+        .merge_gc_plan(
+            db.inner().manifest_table,
+            crate::manifest::GcPlanState {
+                obsolete_ssts: vec![
+                    crate::manifest::GcSstRef {
+                        id: SsTableId::new(1),
+                        level: 0,
+                        data_path: Path::from("L0/1.parquet"),
+                        delete_path: None,
+                    },
+                    crate::manifest::GcSstRef {
+                        id: SsTableId::new(2),
+                        level: 1,
+                        data_path: Path::from("L1/2.parquet"),
+                        delete_path: Some(Path::from("L1/2.delete.parquet")),
+                    },
+                ],
+                obsolete_wal_segments: Vec::new(),
+            },
+        )
+        .await?;
+    let first = db
+        .inspect_sst_gc_plan()
+        .await?
+        .expect("first persisted plan");
+    assert_eq!(first.staged_sst_candidates, 2);
+    assert_eq!(
+        first
+            .candidates
+            .iter()
+            .map(|candidate| candidate.sst_id)
+            .collect::<Vec<_>>(),
+        vec![1, 2]
+    );
+
+    db.inner()
+        .manifest
+        .merge_gc_plan(
+            db.inner().manifest_table,
+            crate::manifest::GcPlanState {
+                obsolete_ssts: vec![
+                    crate::manifest::GcSstRef {
+                        id: SsTableId::new(2),
+                        level: 1,
+                        data_path: Path::from("L1/2.parquet"),
+                        delete_path: Some(Path::from("L1/2.delete.parquet")),
+                    },
+                    crate::manifest::GcSstRef {
+                        id: SsTableId::new(9),
+                        level: 2,
+                        data_path: Path::from("L2/9.parquet"),
+                        delete_path: None,
+                    },
+                ],
+                obsolete_wal_segments: vec![WalSegmentRef::new(
+                    7,
+                    FileIdGenerator::default().generate(),
+                    0,
+                    0,
+                )],
+            },
+        )
+        .await?;
+    let second = db
+        .inspect_sst_gc_plan()
+        .await?
+        .expect("second persisted plan");
+    assert_eq!(second.staged_sst_candidates, 3);
+    assert_eq!(
+        second
+            .candidates
+            .iter()
+            .map(|candidate| candidate.sst_id)
+            .collect::<Vec<_>>(),
+        vec![1, 2, 9]
+    );
+    assert_eq!(second.obsolete_wal_segments, 1);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn physical_stale_sst_debt_can_exist_while_persisted_gc_plan_is_empty()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root_dir = workspace_temp_dir("physical-stale-debt-plan-empty");
+    let root_str = root_dir.to_string_lossy().into_owned();
+
+    let db = DB::<LocalFs, TokioExecutor>::builder(config_with_pk(
+        vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("v", DataType::Int32, false),
+        ],
+        &["id"],
+    ))
+    .on_disk(root_str)?
+    .open_with_executor(Arc::new(TokioExecutor::default()))
+    .await?
+    .into_inner();
+
+    db.manifest
+        .apply_version_edits(
+            db.manifest_table,
+            &[VersionEdit::AddSsts {
+                level: 1,
+                entries: vec![SstEntry::new(
+                    SsTableId::new(7),
+                    None,
+                    None,
+                    Path::from("L1/live.parquet"),
+                    None,
+                )],
+            }],
+        )
+        .await?;
+
+    let live_path = local_sst_path(&db, "L1/live.parquet");
+    let stale_path = local_sst_path(&db, "L0/stale.parquet");
+    write_local_sst_object(&live_path, b"live").await?;
+    write_local_sst_object(&stale_path, b"stale").await?;
+
+    let physical_sst_objects = count_local_sst_objects(&root_dir)?;
+    let live_sst_objects = db
+        .manifest
+        .snapshot_latest(db.manifest_table)
+        .await?
+        .latest_version
+        .expect("latest version")
+        .ssts()
+        .iter()
+        .map(Vec::len)
+        .sum::<usize>();
+
+    assert_eq!(physical_sst_objects, 2);
+    assert_eq!(live_sst_objects, 1);
+    assert!(
+        db.inspect_sst_gc_plan().await?.is_none(),
+        "no persisted GC plan should still be visible in this scenario",
+    );
+
+    fs::remove_dir_all(root_dir)?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn compaction_can_drain_gc_plan_before_later_observation_point()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root_dir = workspace_temp_dir("compaction-drains-gc-plan-early");
+    let root_str = root_dir.to_string_lossy().into_owned();
+
+    let mut inner = DB::<LocalFs, TokioExecutor>::builder(config_with_pk(
+        vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("v", DataType::Int32, false),
+        ],
+        &["id"],
+    ))
+    .on_disk(root_str)?
+    .open_with_executor(Arc::new(TokioExecutor::default()))
+    .await?
+    .into_inner();
+    let metrics = Arc::new(CompactionMetrics::new());
+    inner.compaction_metrics = Some(Arc::clone(&metrics));
+
+    inner
+        .manifest
+        .apply_version_edits(
+            inner.manifest_table,
+            &[VersionEdit::AddSsts {
+                level: 0,
+                entries: vec![
+                    SstEntry::new(
+                        SsTableId::new(1),
+                        None,
+                        None,
+                        Path::from("L0/1.parquet"),
+                        None,
+                    ),
+                    SstEntry::new(
+                        SsTableId::new(2),
+                        None,
+                        None,
+                        Path::from("L0/2.parquet"),
+                        None,
+                    ),
+                ],
+            }],
+        )
+        .await?;
+
+    let obsolete_one = local_sst_path(&inner, "L0/1.parquet");
+    let obsolete_two = local_sst_path(&inner, "L0/2.parquet");
+    write_local_sst_object(&obsolete_one, b"one").await?;
+    write_local_sst_object(&obsolete_two, b"two").await?;
+
+    let planner = OneShotPlanner::new(CompactionTask {
+        source_level: 0,
+        target_level: 1,
+        input: vec![
+            CompactionInput {
+                level: 0,
+                sst_id: SsTableId::new(1),
+            },
+            CompactionInput {
+                level: 0,
+                sst_id: SsTableId::new(2),
+            },
+        ],
+        key_range: None,
+    });
+    let executor = StaticExecutor {
+        outputs: vec![
+            SsTableDescriptor::new(SsTableId::new(3), 1)
+                .with_storage_paths(Path::from("L1/3.parquet"), None),
+        ],
+        wal_segments: Vec::new(),
+        target_level: 1,
+    };
+
+    inner
+        .run_compaction_task(&planner, &executor)
+        .await?
+        .expect("compaction outcome");
+
+    assert!(
+        inner.inspect_sst_gc_plan().await?.is_none(),
+        "the compaction path should have already staged and drained the plan",
+    );
+    assert!(!local_sst_exists(&obsolete_one).await);
+    assert!(!local_sst_exists(&obsolete_two).await);
+
+    let snapshot = metrics.snapshot();
+    assert_eq!(snapshot.gc_plan_write_runs, 1);
+    assert_eq!(snapshot.gc_plan_written_sst_candidates, 2);
+    assert_eq!(snapshot.gc_plan_take_runs, 1);
+    assert_eq!(snapshot.gc_plan_taken_sst_candidates, 2);
+    assert_eq!(snapshot.gc_plan_authorized_sst_candidates, 2);
+    assert_eq!(snapshot.gc_plan_blocked_sst_candidates, 0);
+    assert_eq!(snapshot.sst_sweep_runs, 1);
+
+    fs::remove_dir_all(root_dir)?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sweep_manifest_ssts_requeues_partial_delete_failures_and_recovers_on_retry()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp_root = workspace_temp_dir("sst-sweep-partial-retry");
+    let root_str = temp_root.to_string_lossy().into_owned();
+    let failing_delete_path = temp_root
+        .join("sst")
+        .join("L0")
+        .join("partial.delete.parquet");
+    let failing_delete_path = Path::from_filesystem_path(&failing_delete_path)?;
+    let failing_fs = Arc::new(FailOnceRemoveFs::new(
+        failing_delete_path.as_ref().to_string(),
+    ));
+
+    let mut db = DB::<FailOnceRemoveFs, TokioExecutor>::builder(config_with_pk(
+        vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("v", DataType::Int32, false),
+        ],
+        &["id"],
+    ))
+    .on_durable_fs(Arc::clone(&failing_fs), root_str)?
+    .open_with_executor(Arc::new(TokioExecutor::default()))
+    .await?
+    .into_inner();
+    let metrics = Arc::new(CompactionMetrics::new());
+    db.compaction_metrics = Some(Arc::clone(&metrics));
+
+    let obsolete_data = local_sst_path(&db, "L0/partial.parquet");
+    let obsolete_delete = local_sst_path(&db, "L0/partial.delete.parquet");
+    write_local_sst_object(&obsolete_data, b"partial-data").await?;
+    write_local_sst_object(&obsolete_delete, b"partial-delete").await?;
+
+    let gc_plan = crate::manifest::GcPlanState {
+        obsolete_ssts: vec![crate::manifest::GcSstRef {
+            id: SsTableId::new(17),
+            level: 0,
+            data_path: Path::from("L0/partial.parquet"),
+            delete_path: Some(Path::from("L0/partial.delete.parquet")),
+        }],
+        obsolete_wal_segments: Vec::new(),
+    };
+
+    db.manifest
+        .record_gc_plan(db.manifest_table, gc_plan.clone())
+        .await?;
+    let first = db.sweep_manifest_ssts().await?;
+    assert_eq!(first.deleted_objects, 1);
+    assert_eq!(first.deleted_bytes, 12);
+    assert_eq!(first.delete_failures, 1);
+    assert!(failing_fs.has_failed_once());
+    assert!(!local_sst_exists(&obsolete_data).await);
+    assert!(local_sst_exists(&obsolete_delete).await);
+
+    let residual = db.inspect_sst_gc_plan().await?.expect("re-queued gc plan");
+    assert_eq!(residual.staged_sst_candidates, 1);
+    assert_eq!(residual.authorized_sst_candidates, 1);
+    assert_eq!(residual.blocked_sst_candidates, 0);
+    assert_eq!(residual.obsolete_wal_segments, 0);
+    assert_eq!(residual.candidates[0].sst_id, 17);
+    assert!(residual.candidates[0].authorized);
+
+    let second = db.sweep_manifest_ssts().await?;
+    assert_eq!(second.deleted_objects, 1);
+    assert_eq!(second.deleted_bytes, 14);
+    assert_eq!(second.delete_failures, 0);
+    assert!(!local_sst_exists(&obsolete_data).await);
+    assert!(!local_sst_exists(&obsolete_delete).await);
+    assert!(
+        db.inspect_sst_gc_plan().await?.is_none(),
+        "retry should fully drain the staged SST candidate once the delete succeeds",
+    );
+
+    let snapshot = metrics.snapshot();
+    assert_eq!(snapshot.sst_sweep_runs, 2);
+    assert_eq!(snapshot.sst_deleted_objects, 2);
+    assert_eq!(snapshot.sst_deleted_bytes, 26);
+    assert_eq!(snapshot.sst_delete_failures, 1);
+
+    fs::remove_dir_all(temp_root)?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sweep_manifest_ssts_keeps_blocked_candidates_durable_when_nothing_is_authorized()
+-> Result<(), Box<dyn std::error::Error>> {
+    let db: DB<InMemoryFs, NoopExecutor> = DB::new(
+        SchemaBuilder::from_schema(Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("v", DataType::Int32, false),
+        ])))
+        .primary_key("id")
+        .build()
+        .expect("schema builder"),
+        Arc::new(NoopExecutor),
+    )
+    .await
+    .expect("db init");
+
+    db.inner()
+        .manifest
+        .apply_version_edits(
+            db.inner().manifest_table,
+            &[VersionEdit::AddSsts {
+                level: 1,
+                entries: vec![SstEntry::new(
+                    SsTableId::new(44),
+                    None,
+                    None,
+                    Path::from("L1/44.parquet"),
+                    None,
+                )],
+            }],
+        )
+        .await?;
+
+    db.inner()
+        .manifest
+        .record_gc_plan(
+            db.inner().manifest_table,
+            crate::manifest::GcPlanState {
+                obsolete_ssts: vec![crate::manifest::GcSstRef {
+                    id: SsTableId::new(44),
+                    level: 1,
+                    data_path: Path::from("L1/44.parquet"),
+                    delete_path: None,
+                }],
+                obsolete_wal_segments: Vec::new(),
+            },
+        )
+        .await?;
+
+    let summary = db.inner().sweep_manifest_ssts().await?;
+    assert_eq!(summary.deleted_objects, 0);
+    assert_eq!(summary.deleted_bytes, 0);
+    assert_eq!(summary.delete_failures, 0);
+
+    let persisted = db
+        .inspect_sst_gc_plan()
+        .await?
+        .expect("blocked candidate should remain durable");
+    assert_eq!(persisted.staged_sst_candidates, 1);
+    assert_eq!(persisted.authorized_sst_candidates, 0);
+    assert_eq!(persisted.blocked_sst_candidates, 1);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sweep_manifest_ssts_treats_missing_files_as_already_reclaimed_and_requeues_wal()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp_root = workspace_temp_dir("sst-sweep-missing");
+    let root_str = temp_root.to_string_lossy().into_owned();
+
+    let db = DB::<LocalFs, TokioExecutor>::builder(config_with_pk(
+        vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("v", DataType::Int32, false),
+        ],
+        &["id"],
+    ))
+    .on_disk(root_str)?
+    .open_with_executor(Arc::new(TokioExecutor::default()))
+    .await?
+    .into_inner();
+
+    let file_ids = FileIdGenerator::default();
+    let wal_ref = WalSegmentRef::new(7, file_ids.generate(), 0, 0);
+    db.manifest
+        .record_gc_plan(
+            db.manifest_table,
+            crate::manifest::GcPlanState {
+                obsolete_ssts: vec![crate::manifest::GcSstRef {
+                    id: SsTableId::new(77),
+                    level: 0,
+                    data_path: Path::from("L0/missing.parquet"),
+                    delete_path: Some(Path::from("L0/missing.delete.parquet")),
+                }],
+                obsolete_wal_segments: vec![wal_ref.clone()],
+            },
+        )
+        .await?;
+
+    let summary = db.sweep_manifest_ssts().await?;
+    assert_eq!(summary.deleted_objects, 0);
+    assert_eq!(summary.deleted_bytes, 0);
+    assert_eq!(summary.delete_failures, 0);
+
+    let residual = db
+        .manifest
+        .take_gc_plan_for_authorized_sweep(db.manifest_table)
+        .await?
+        .expect("wal candidates should be re-queued");
+    assert!(residual.obsolete_ssts.is_empty());
+    assert_eq!(residual.obsolete_wal_segments, vec![wal_ref]);
+
+    fs::remove_dir_all(temp_root)?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sweep_manifest_ssts_reclaims_legacy_absolute_candidate_paths()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp_root = workspace_temp_dir("sst-sweep-legacy-absolute-paths");
+    let root_str = temp_root.to_string_lossy().into_owned();
+
+    let db = DB::<LocalFs, TokioExecutor>::builder(config_with_pk(
+        vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("v", DataType::Int32, false),
+        ],
+        &["id"],
+    ))
+    .on_disk(root_str)?
+    .open_with_executor(Arc::new(TokioExecutor::default()))
+    .await?
+    .into_inner();
+
+    let obsolete_path = local_sst_path(&db, "L0/legacy-absolute.parquet");
+    write_local_sst_object(&obsolete_path, b"legacy").await?;
+
+    db.manifest
+        .record_gc_plan(
+            db.manifest_table,
+            crate::manifest::GcPlanState {
+                obsolete_ssts: vec![crate::manifest::GcSstRef {
+                    id: SsTableId::new(99),
+                    level: 0,
+                    data_path: obsolete_path.clone(),
+                    delete_path: None,
+                }],
+                obsolete_wal_segments: Vec::new(),
+            },
+        )
+        .await?;
+
+    let summary = db.sweep_manifest_ssts().await?;
+    assert_eq!(summary.deleted_objects, 1);
+    assert_eq!(summary.deleted_bytes, 6);
+    assert_eq!(summary.delete_failures, 0);
+    assert!(!local_sst_exists(&obsolete_path).await);
+
+    fs::remove_dir_all(temp_root)?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn hidden_db_gc_hooks_expose_sweep_summary_and_metrics()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp_root = workspace_temp_dir("sst-sweep-hidden-db-hooks");
+    let root_str = temp_root.to_string_lossy().into_owned();
+
+    let mut inner = DB::<LocalFs, TokioExecutor>::builder(config_with_pk(
+        vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("v", DataType::Int32, false),
+        ],
+        &["id"],
+    ))
+    .on_disk(root_str)?
+    .open_with_executor(Arc::new(TokioExecutor::default()))
+    .await?
+    .into_inner();
+    let metrics = Arc::new(CompactionMetrics::new());
+    inner.compaction_metrics = Some(Arc::clone(&metrics));
+
+    let obsolete_path = local_sst_path(&inner, "L0/hook.parquet");
+    write_local_sst_object(&obsolete_path, b"hook").await?;
+    inner
+        .manifest
+        .record_gc_plan(
+            inner.manifest_table,
+            crate::manifest::GcPlanState {
+                obsolete_ssts: vec![crate::manifest::GcSstRef {
+                    id: SsTableId::new(88),
+                    level: 0,
+                    data_path: Path::from("L0/hook.parquet"),
+                    delete_path: None,
+                }],
+                obsolete_wal_segments: Vec::new(),
+            },
+        )
+        .await?;
+
+    let db = DB::from_inner(Arc::new(inner));
+    let summary = db.sweep_sst_objects().await?;
+    assert_eq!(summary.deleted_objects, 1);
+    assert_eq!(summary.deleted_bytes, 4);
+    assert_eq!(summary.delete_failures, 0);
+
+    let snapshot = db
+        .compaction_metrics_snapshot()
+        .expect("compaction metrics snapshot");
+    assert_eq!(snapshot.sst_sweep_runs, 1);
+    assert_eq!(snapshot.sst_deleted_objects, 1);
+    assert_eq!(snapshot.sst_deleted_bytes, 4);
+    assert_eq!(snapshot.sst_delete_failures, 0);
+
+    fs::remove_dir_all(temp_root)?;
     Ok(())
 }
 
@@ -2754,7 +4544,8 @@ fn resolve_compaction_inputs_keeps_levels() {
         key_range: None,
     };
 
-    let resolved = orchestrator::resolve_inputs(&version, &task).expect("resolve");
+    let resolved =
+        orchestrator::resolve_inputs(&Path::default(), &version, &task).expect("resolve");
     assert_eq!(resolved.len(), 2);
     assert_eq!(resolved[0].level(), 0);
     assert_eq!(resolved[1].level(), 1);

--- a/src/db/tests/core/compaction_correctness.rs
+++ b/src/db/tests/core/compaction_correctness.rs
@@ -863,26 +863,11 @@ impl ModelRunner {
                 self.trace.push(Op::Reopen);
                 let _ = self.harness.try_flush_immutables_to_l0().await?;
                 self.harness.reopen().await?;
-                if let Some(snapshot_ts) = self.active_snapshot_ts {
-                    let snapshot = self
-                        .harness
-                        .db
-                        .snapshot_at(Timestamp::new(snapshot_ts))
-                        .await?;
-                    let ctx = self.failure_context(Some(snapshot_ts));
-                    assert_oracle_matches(
-                        "model_based_reopen",
-                        snapshot_ts,
-                        &snapshot,
-                        &self.oracle,
-                        &self.harness.db,
-                        Some(&ctx),
-                    )
-                    .await?;
-                    self.active_snapshot = Some(snapshot);
-                } else {
-                    self.active_snapshot = None;
-                }
+                // Reopen models a process restart. Historical snapshot protection on this branch
+                // is intentionally in-process only, so any live pinned snapshot must be treated as
+                // dropped across reopen.
+                self.active_snapshot_ts = None;
+                self.active_snapshot = None;
             }
         }
         Ok(())
@@ -1032,6 +1017,21 @@ async fn model_runner_reads_use_pinned_snapshot_until_mutation()
     assert!(runner.active_snapshot.is_some());
 
     runner.apply_op(OpKind::Put).await?;
+    assert!(runner.active_snapshot_ts.is_none());
+    assert!(runner.active_snapshot.is_none());
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn model_runner_reopen_clears_active_snapshot() -> Result<(), Box<dyn std::error::Error>> {
+    let mut runner = ModelRunner::new(17, "compaction-correctness-model-reopen-clear").await?;
+
+    runner.apply_op(OpKind::Snapshot).await?;
+    assert!(runner.active_snapshot_ts.is_some());
+    assert!(runner.active_snapshot.is_some());
+
+    runner.apply_op(OpKind::Reopen).await?;
     assert!(runner.active_snapshot_ts.is_none());
     assert!(runner.active_snapshot.is_none());
 

--- a/src/db/tests/core/recovery.rs
+++ b/src/db/tests/core/recovery.rs
@@ -79,6 +79,7 @@ async fn recover_with_manifest_preserves_table_id() -> Result<(), Box<dyn std::e
         .await
         .expect("register table");
     let manifest_table = table_meta.table_id;
+    let sst_root = Path::default();
 
     let (schema, delete_schema, commit_ack_mode, mem) = build_dyn_components(build_config)?;
     let db_fs: Arc<dyn DynFs> = Arc::new(fs.clone());
@@ -88,6 +89,7 @@ async fn recover_with_manifest_preserves_table_id() -> Result<(), Box<dyn std::e
         commit_ack_mode,
         mem,
         db_fs,
+        sst_root.clone(),
         manifest,
         manifest_table,
         table_meta.clone(),
@@ -117,6 +119,7 @@ async fn recover_with_manifest_preserves_table_id() -> Result<(), Box<dyn std::e
         recover_config,
         Arc::clone(&executor),
         recover_fs,
+        sst_root,
         wal_cfg.clone(),
         manifest,
         manifest_table,
@@ -233,6 +236,7 @@ async fn recover_replays_commit_timestamps_and_advances_clock() {
         config,
         executor.clone(),
         test_fs,
+        Path::default(),
         cfg,
         manifest,
         manifest_table,

--- a/src/manifest/bootstrap.rs
+++ b/src/manifest/bootstrap.rs
@@ -18,7 +18,8 @@ use super::{
     ManifestFs,
     codec::{CatalogCodec, GcPlanCodec, ManifestCodec, VersionCodec},
     domain::{
-        GcPlanState, TableDefinition, TableHead, TableId, TableMeta, VersionState, WalSegmentRef,
+        CurrentRootSet, GcAuthorizationSummary, GcPlanState, TableDefinition, TableHead, TableId,
+        TableMeta, VersionState, WalSegmentRef,
     },
     driver::{Manifest, ManifestError, ManifestResult, Stores, VersionSnapshot},
     version::VersionEdit,
@@ -214,6 +215,7 @@ where
         Ok(meta)
     }
 
+    #[cfg(test)]
     pub(crate) async fn record_gc_plan(
         &self,
         table: TableId,
@@ -222,9 +224,109 @@ where
         self.gc_plan.put_gc_plan(table, plan).await
     }
 
-    #[cfg(all(test, feature = "tokio"))]
-    pub(crate) async fn take_gc_plan(&self, table: TableId) -> ManifestResult<Option<GcPlanState>> {
-        self.gc_plan.take_gc_plan(table).await
+    pub(crate) async fn merge_gc_plan(
+        &self,
+        table: TableId,
+        plan: GcPlanState,
+    ) -> ManifestResult<(Option<GcPlanState>, Option<GcPlanState>)> {
+        self.gc_plan
+            .update_gc_plan(table, move |current| {
+                let mut merged = current.unwrap_or_default();
+                merged.merge(plan);
+                (!merged.is_empty()).then_some(merged)
+            })
+            .await
+    }
+
+    pub(crate) async fn remove_gc_sst_candidates(
+        &self,
+        table: TableId,
+        reclaimed: &[crate::manifest::GcSstRef],
+    ) -> ManifestResult<(Option<GcPlanState>, Option<GcPlanState>)> {
+        self.gc_plan
+            .update_gc_plan(table, |current| {
+                let mut plan = current?;
+                plan.remove_sst_candidates(reclaimed);
+                (!plan.is_empty()).then_some(plan)
+            })
+            .await
+    }
+
+    pub(crate) async fn peek_gc_plan(&self, table: TableId) -> ManifestResult<Option<GcPlanState>> {
+        self.gc_plan.peek_gc_plan(table).await
+    }
+
+    /// Take staged GC candidates and authorize SST reclamation against the current root set.
+    ///
+    /// In the single-process model the latest manifest root set is the only source of truth for
+    /// whether an SST is still live. `GcPlanState` remains a hint queue; this helper filters out
+    /// any SST candidate that has become reachable again before a sweeper acts on it. Callers that
+    /// only process part of the returned plan must re-queue any residual SST or WAL candidates.
+    #[allow(dead_code)]
+    pub(crate) async fn take_gc_plan_for_authorized_sweep(
+        &self,
+        table: TableId,
+    ) -> ManifestResult<Option<GcPlanState>> {
+        self.take_gc_plan_for_authorized_sweep_with_pins(table, &[])
+            .await
+    }
+
+    pub(crate) async fn take_gc_plan_for_authorized_sweep_with_pins(
+        &self,
+        table: TableId,
+        active_pins: &[Timestamp],
+    ) -> ManifestResult<Option<GcPlanState>> {
+        let Some(plan) = self.gc_plan.peek_gc_plan(table).await? else {
+            return Ok(None);
+        };
+        let staged_sst_count = plan.obsolete_ssts.len();
+        let root_set = self
+            .version
+            .current_root_set_with_pins(table, active_pins)
+            .await?;
+        let plan = plan.authorize_with_root_set(&root_set);
+        let authorized_sst_count = plan.obsolete_ssts.len();
+        log_debug!(
+            component = "manifest",
+            event = "gc_plan_authorized_for_sweep",
+            table_id = ?table,
+            protected_versions = root_set.protected_version_count(),
+            protected_sst_objects = root_set.protected_object_count(),
+            staged_sst_candidates = staged_sst_count,
+            authorized_sst_candidates = authorized_sst_count,
+            filtered_sst_candidates = staged_sst_count.saturating_sub(authorized_sst_count),
+            obsolete_wal_segments = plan.obsolete_wal_segments.len(),
+        );
+        if plan.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(plan))
+        }
+    }
+
+    /// Inspect the current GC plan against the latest manifest root set without mutating it.
+    #[allow(dead_code)]
+    pub(crate) async fn inspect_gc_plan_authorization(
+        &self,
+        table: TableId,
+    ) -> ManifestResult<Option<GcAuthorizationSummary>> {
+        self.inspect_gc_plan_authorization_with_pins(table, &[])
+            .await
+    }
+
+    pub(crate) async fn inspect_gc_plan_authorization_with_pins(
+        &self,
+        table: TableId,
+        active_pins: &[Timestamp],
+    ) -> ManifestResult<Option<GcAuthorizationSummary>> {
+        let Some(plan) = self.gc_plan.peek_gc_plan(table).await? else {
+            return Ok(None);
+        };
+        let root_set = self
+            .version
+            .current_root_set_with_pins(table, active_pins)
+            .await?;
+        Ok(Some(plan.authorization_summary(&root_set)))
     }
 
     /// List committed versions of a table, ordered newest-first.
@@ -236,6 +338,23 @@ where
         limit: usize,
     ) -> ManifestResult<Vec<VersionState>> {
         self.version.list_versions(table, limit).await
+    }
+
+    /// Build the current manifest root set that protects SST objects from GC.
+    #[allow(dead_code)]
+    pub(crate) async fn current_root_set(&self, table: TableId) -> ManifestResult<CurrentRootSet> {
+        self.current_root_set_with_pins(table, &[]).await
+    }
+
+    #[allow(dead_code)]
+    pub(crate) async fn current_root_set_with_pins(
+        &self,
+        table: TableId,
+        active_pins: &[Timestamp],
+    ) -> ManifestResult<CurrentRootSet> {
+        self.version
+            .current_root_set_with_pins(table, active_pins)
+            .await
     }
 
     /// Snapshot a specific historical version by its manifest timestamp.
@@ -432,6 +551,12 @@ mod tests {
     use futures::TryStreamExt;
 
     use super::*;
+    use crate::{
+        id::FileIdGenerator,
+        manifest::{SstEntry, TableDefinition, VersionEdit},
+        mvcc::Timestamp,
+        ondisk::sstable::{SsTableId, SsTableStats},
+    };
 
     #[tokio::test(flavor = "multi_thread")]
     async fn init_disk_manifest_smoke() {
@@ -485,5 +610,119 @@ mod tests {
                 .all(|meta| meta.path.as_ref().starts_with(leases_dir.as_ref())),
             "all lease files should live under the leases/ prefix"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn manifest_history_remains_queryable_while_root_set_defaults_to_head() {
+        let manifest = init_in_memory_manifest(TokioExecutor::default())
+            .await
+            .expect("manifest");
+        let file_ids = FileIdGenerator::default();
+        let table = manifest
+            .register_table(
+                &file_ids,
+                &TableDefinition {
+                    name: "manifest-history".into(),
+                    schema_fingerprint: "fingerprint".into(),
+                    primary_key_columns: vec!["id".into()],
+                    schema_version: 1,
+                },
+            )
+            .await
+            .expect("register table")
+            .table_id;
+
+        manifest
+            .apply_version_edits(
+                table,
+                &[VersionEdit::AddSsts {
+                    level: 0,
+                    entries: vec![SstEntry::new(
+                        SsTableId::new(1),
+                        Some(SsTableStats::default()),
+                        None,
+                        FusioPath::from("L0/1.parquet"),
+                        None,
+                    )],
+                }],
+            )
+            .await
+            .expect("first version");
+        manifest
+            .apply_version_edits(
+                table,
+                &[
+                    VersionEdit::RemoveSsts {
+                        level: 0,
+                        sst_ids: vec![SsTableId::new(1)],
+                    },
+                    VersionEdit::AddSsts {
+                        level: 1,
+                        entries: vec![SstEntry::new(
+                            SsTableId::new(2),
+                            Some(SsTableStats::default()),
+                            None,
+                            FusioPath::from("L1/2.parquet"),
+                            None,
+                        )],
+                    },
+                ],
+            )
+            .await
+            .expect("second version");
+        manifest
+            .apply_version_edits(
+                table,
+                &[
+                    VersionEdit::RemoveSsts {
+                        level: 1,
+                        sst_ids: vec![SsTableId::new(2)],
+                    },
+                    VersionEdit::AddSsts {
+                        level: 2,
+                        entries: vec![SstEntry::new(
+                            SsTableId::new(3),
+                            Some(SsTableStats::default()),
+                            None,
+                            FusioPath::from("L2/3.parquet"),
+                            None,
+                        )],
+                    },
+                ],
+            )
+            .await
+            .expect("third version");
+
+        let versions = manifest
+            .list_versions(table, 10)
+            .await
+            .expect("list versions");
+        assert_eq!(
+            versions
+                .iter()
+                .map(VersionState::commit_timestamp)
+                .collect::<Vec<_>>(),
+            vec![Timestamp::new(3), Timestamp::new(2), Timestamp::new(1)]
+        );
+
+        let snapshot = manifest
+            .snapshot_at_version(table, Timestamp::new(1))
+            .await
+            .expect("historical version should remain available");
+        assert_eq!(
+            snapshot
+                .latest_version
+                .as_ref()
+                .map(VersionState::commit_timestamp),
+            Some(Timestamp::new(1))
+        );
+
+        let root_set = manifest.current_root_set(table).await.expect("root set");
+        assert_eq!(root_set.protected_version_count(), 1);
+        assert!(
+            !root_set.contains_path(&FusioPath::from("L0/1.parquet")),
+            "historical SSTs should not be protected unless a live snapshot pins them",
+        );
+        assert!(root_set.contains_path(&FusioPath::from("L2/3.parquet")));
     }
 }

--- a/src/manifest/domain.rs
+++ b/src/manifest/domain.rs
@@ -1,7 +1,6 @@
 use std::{
     cmp::Ordering,
-    collections::{BTreeMap, HashSet},
-    time::Duration,
+    collections::{BTreeMap, BTreeSet, HashSet},
 };
 
 use fusio::path::Path;
@@ -117,6 +116,212 @@ pub(crate) enum GcPlanValue {
     Plan(GcPlanState),
 }
 
+/// Why a committed manifest version is still protected from SST reclamation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProtectedVersionKind {
+    /// The version currently referenced by the table head.
+    Head,
+    /// A live in-process snapshot depends on this historical manifest version.
+    ActiveSnapshotPin,
+}
+
+/// Manifest version that currently protects one or more SST objects from GC.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ProtectedVersionRef {
+    manifest_ts: Timestamp,
+    kind: ProtectedVersionKind,
+}
+
+impl ProtectedVersionRef {
+    pub(crate) fn new(manifest_ts: Timestamp, kind: ProtectedVersionKind) -> Self {
+        Self { manifest_ts, kind }
+    }
+
+    pub(crate) fn manifest_ts(&self) -> Timestamp {
+        self.manifest_ts
+    }
+
+    pub(crate) fn kind(&self) -> ProtectedVersionKind {
+        self.kind
+    }
+}
+
+/// Kind of physical SST object protected by the current manifest root set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProtectedObjectKind {
+    /// Primary SST Parquet file.
+    Data,
+    /// Optional delete-sidecar Parquet file.
+    DeleteSidecar,
+}
+
+/// Physical SST object path protected from GC by one or more manifest versions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ProtectedSstObject {
+    path: Path,
+    sst_id: SsTableId,
+    level: u32,
+    kind: ProtectedObjectKind,
+}
+
+impl ProtectedSstObject {
+    pub(crate) fn new(
+        path: Path,
+        sst_id: SsTableId,
+        level: u32,
+        kind: ProtectedObjectKind,
+    ) -> Self {
+        Self {
+            path,
+            sst_id,
+            level,
+            kind,
+        }
+    }
+
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn sst_id(&self) -> &SsTableId {
+        &self.sst_id
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn level(&self) -> u32 {
+        self.level
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn kind(&self) -> ProtectedObjectKind {
+        self.kind
+    }
+}
+
+/// Deterministic current root set for SST GC decisions.
+///
+/// In the current single-process model the protected set is the union of the table HEAD and any
+/// manifest versions pinned by live in-process snapshots. Physical SST deletion must treat any
+/// object referenced by this set as live.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct CurrentRootSet {
+    protected_versions: Vec<ProtectedVersionRef>,
+    protected_objects: Vec<ProtectedSstObject>,
+    active_snapshot_version_count: usize,
+}
+
+impl CurrentRootSet {
+    pub(crate) fn new(
+        protected_versions: Vec<ProtectedVersionRef>,
+        protected_objects: Vec<ProtectedSstObject>,
+        active_snapshot_version_count: usize,
+    ) -> Self {
+        Self {
+            protected_versions,
+            protected_objects,
+            active_snapshot_version_count,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn protected_versions(&self) -> &[ProtectedVersionRef] {
+        &self.protected_versions
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn protected_objects(&self) -> &[ProtectedSstObject] {
+        &self.protected_objects
+    }
+
+    pub(crate) fn protected_version_count(&self) -> usize {
+        self.protected_versions.len()
+    }
+
+    pub(crate) fn protected_object_count(&self) -> usize {
+        self.protected_objects.len()
+    }
+
+    pub(crate) fn active_snapshot_version_count(&self) -> usize {
+        self.active_snapshot_version_count
+    }
+
+    pub(crate) fn contains_path(&self, path: &Path) -> bool {
+        self.protected_objects
+            .binary_search_by(|protected| protected.path().as_ref().cmp(path.as_ref()))
+            .is_ok()
+    }
+
+    pub(crate) fn from_versions(
+        head_manifest_ts: Option<Timestamp>,
+        active_pins: &[Timestamp],
+        versions: &[VersionState],
+    ) -> Self {
+        let active_pin_set = active_pins.iter().copied().collect::<BTreeSet<_>>();
+        let mut protected_versions = Vec::with_capacity(
+            active_pin_set
+                .len()
+                .saturating_add(usize::from(head_manifest_ts.is_some())),
+        );
+        let mut seen_paths = BTreeSet::new();
+        let mut protected_objects = Vec::new();
+
+        for version in versions {
+            let manifest_ts = version.commit_timestamp();
+            let is_head = Some(manifest_ts) == head_manifest_ts;
+            let is_active_pin = active_pin_set.contains(&manifest_ts);
+            if !is_head && !is_active_pin {
+                continue;
+            }
+            let kind = if is_head {
+                ProtectedVersionKind::Head
+            } else {
+                ProtectedVersionKind::ActiveSnapshotPin
+            };
+            protected_versions.push(ProtectedVersionRef::new(manifest_ts, kind));
+
+            for (level, bucket) in version.ssts().iter().enumerate() {
+                let level = u32::try_from(level).unwrap_or(u32::MAX);
+                for entry in bucket {
+                    let data_path_key = entry.data_path().as_ref().to_owned();
+                    if seen_paths.insert(data_path_key) {
+                        protected_objects.push(ProtectedSstObject::new(
+                            entry.data_path().clone(),
+                            entry.sst_id().clone(),
+                            level,
+                            ProtectedObjectKind::Data,
+                        ));
+                    }
+                    if let Some(delete_path) = entry.delete_path() {
+                        let delete_path_key = delete_path.as_ref().to_owned();
+                        if seen_paths.insert(delete_path_key) {
+                            protected_objects.push(ProtectedSstObject::new(
+                                delete_path.clone(),
+                                entry.sst_id().clone(),
+                                level,
+                                ProtectedObjectKind::DeleteSidecar,
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+
+        protected_versions.sort_by_key(|version| {
+            (
+                match version.kind() {
+                    ProtectedVersionKind::Head => 0u8,
+                    ProtectedVersionKind::ActiveSnapshotPin => 1u8,
+                },
+                std::cmp::Reverse(version.manifest_ts()),
+            )
+        });
+        protected_objects.sort_by(|lhs, rhs| lhs.path().as_ref().cmp(rhs.path().as_ref()));
+
+        Self::new(protected_versions, protected_objects, active_pin_set.len())
+    }
+}
+
 impl TryFrom<CatalogValue> for CatalogState {
     type Error = ManifestError;
 
@@ -212,8 +417,6 @@ pub(crate) struct TableMeta {
     pub schema_fingerprint: String,
     /// Columns participating in the primary key.
     pub primary_key_columns: Vec<String>,
-    /// Optional retention policy overrides.
-    pub retention: Option<TableRetionConfig>,
     /// Monotonic schema version number.
     pub schema_version: u32,
 }
@@ -227,29 +430,8 @@ pub struct TableDefinition {
     pub schema_fingerprint: String,
     /// Columns participating in the primary key.
     pub primary_key_columns: Vec<String>,
-    /// Optional retention policy overrides.
-    pub retention: Option<TableRetionConfig>,
     /// Monotonic schema version number.
     pub schema_version: u32,
-}
-
-/// Retention policy knobs for a table.
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct TableRetionConfig {
-    /// Maximum number of committed versions to retain.
-    pub max_versions: u64,
-    /// Maximum age to retain versions and their WAL segments.
-    pub max_ttl: Duration,
-}
-
-impl Default for TableRetionConfig {
-    fn default() -> Self {
-        Self {
-            max_versions: 5,
-            max_ttl: Duration::from_secs(12 * 60 * 60),
-        }
-    }
 }
 
 /// Mutable head view for a table.
@@ -372,6 +554,13 @@ impl VersionState {
 
     pub(crate) fn wal_segments(&self) -> &[WalSegmentRef] {
         &self.wal_segments
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn contains_sst(&self, sst_id: &SsTableId) -> bool {
+        self.ssts
+            .iter()
+            .any(|bucket| bucket.iter().any(|entry| entry.sst_id() == sst_id))
     }
 
     #[cfg(all(test, feature = "tokio"))]
@@ -512,17 +701,148 @@ impl WalSegmentRef {
     }
 }
 
-/// Garbage-collection plan for a table.
+/// Garbage-collection candidates for a table.
+///
+/// This state is a staging queue for a future sweeper, not the correctness authority
+/// for SST deletion. Physical SST reclamation must re-check the current manifest root
+/// set and may only delete candidates that are unreachable from that root set.
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub(crate) struct GcPlanState {
-    /// SST identifiers and paths that can be removed.
+    /// SST identifiers and paths proposed for removal.
     pub obsolete_ssts: Vec<GcSstRef>,
     /// WAL sequence numbers that can be truncated.
     pub obsolete_wal_segments: Vec<WalSegmentRef>,
 }
 
-/// Reference to an obsolete SST scheduled for deletion.
+/// Summary of how a staged GC plan relates to the current manifest root set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct GcAuthorizationSummary {
+    /// Total staged SST candidates currently recorded in the GC plan.
+    pub staged_sst_candidates: u64,
+    /// SST candidates that are currently unreachable and therefore safe to sweep.
+    pub authorized_sst_candidates: u64,
+    /// SST candidates still protected by the current root set.
+    pub blocked_sst_candidates: u64,
+    /// WAL candidates staged alongside the SST plan.
+    pub obsolete_wal_segments: u64,
+    /// Manifest versions currently contributing to the protection root set.
+    pub protected_versions: u64,
+    /// Unique manifest versions currently pinned by live in-process snapshots.
+    pub active_snapshot_versions: u64,
+    /// Physical SST objects currently protected by the manifest root set.
+    pub protected_sst_objects: u64,
+}
+
+impl GcPlanState {
+    /// Merge additional staged GC candidates into this plan without duplicating entries.
+    pub(crate) fn merge(&mut self, other: Self) {
+        self.obsolete_ssts.extend(other.obsolete_ssts);
+        self.obsolete_wal_segments
+            .extend(other.obsolete_wal_segments);
+        self.normalize_in_place();
+    }
+
+    /// Remove SST candidates that were already reclaimed from the staged plan.
+    pub(crate) fn remove_sst_candidates(&mut self, reclaimed: &[GcSstRef]) {
+        if reclaimed.is_empty() {
+            return;
+        }
+
+        let reclaimed_keys = reclaimed
+            .iter()
+            .map(GcSstRef::dedupe_key)
+            .collect::<BTreeSet<_>>();
+        self.obsolete_ssts
+            .retain(|candidate| !reclaimed_keys.contains(&candidate.dedupe_key()));
+        self.normalize_in_place();
+    }
+
+    /// Authorize the staged SST candidate set against the current manifest root set.
+    ///
+    /// The returned plan keeps only candidates that are currently unreachable and therefore still
+    /// eligible for a future sweeper.
+    #[allow(dead_code)]
+    pub(crate) fn authorize_with_root_set(mut self, root_set: &CurrentRootSet) -> Self {
+        self.obsolete_ssts.retain(|candidate| {
+            !root_set.contains_path(&candidate.data_path)
+                && candidate
+                    .delete_path
+                    .as_ref()
+                    .is_none_or(|path| !root_set.contains_path(path))
+        });
+        self
+    }
+
+    /// Compute authorization counts for the staged plan against the current root set.
+    pub(crate) fn authorization_summary(
+        &self,
+        root_set: &CurrentRootSet,
+    ) -> GcAuthorizationSummary {
+        let authorized_sst_candidates = self
+            .obsolete_ssts
+            .iter()
+            .filter(|candidate| {
+                !root_set.contains_path(&candidate.data_path)
+                    && candidate
+                        .delete_path
+                        .as_ref()
+                        .is_none_or(|path| !root_set.contains_path(path))
+            })
+            .count() as u64;
+        let staged_sst_candidates = self.obsolete_ssts.len() as u64;
+
+        GcAuthorizationSummary {
+            staged_sst_candidates,
+            authorized_sst_candidates,
+            blocked_sst_candidates: staged_sst_candidates.saturating_sub(authorized_sst_candidates),
+            obsolete_wal_segments: self.obsolete_wal_segments.len() as u64,
+            protected_versions: root_set.protected_version_count() as u64,
+            active_snapshot_versions: root_set.active_snapshot_version_count() as u64,
+            protected_sst_objects: root_set.protected_object_count() as u64,
+        }
+    }
+
+    /// Split staged SST candidates into authorized and still-blocked subsets.
+    pub(crate) fn split_sst_candidates(
+        self,
+        root_set: &CurrentRootSet,
+    ) -> (Vec<GcSstRef>, Vec<GcSstRef>) {
+        let mut authorized = Vec::new();
+        let mut blocked = Vec::new();
+        for candidate in self.obsolete_ssts {
+            if !root_set.contains_path(&candidate.data_path)
+                && candidate
+                    .delete_path
+                    .as_ref()
+                    .is_none_or(|path| !root_set.contains_path(path))
+            {
+                authorized.push(candidate);
+            } else {
+                blocked.push(candidate);
+            }
+        }
+        (authorized, blocked)
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.obsolete_ssts.is_empty() && self.obsolete_wal_segments.is_empty()
+    }
+
+    fn normalize_in_place(&mut self) {
+        self.obsolete_ssts
+            .sort_by(|lhs, rhs| lhs.cmp_for_dedupe(rhs));
+        self.obsolete_ssts
+            .dedup_by(|lhs, rhs| lhs.dedupe_key() == rhs.dedupe_key());
+
+        self.obsolete_wal_segments.sort_by(WalSegmentRef::cmp);
+        self.obsolete_wal_segments
+            .dedup_by(|lhs, rhs| WalSegmentRef::cmp(lhs, rhs).is_eq());
+    }
+}
+
+/// Reference to an SST candidate staged for future deletion.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct GcSstRef {
     /// Identifier of the SST.
@@ -535,6 +855,33 @@ pub(crate) struct GcSstRef {
     /// Optional delete sidecar path for the SST.
     #[serde(with = "path_serde_option")]
     pub delete_path: Option<Path>,
+}
+
+impl GcSstRef {
+    fn cmp_for_dedupe(&self, other: &Self) -> Ordering {
+        self.data_path
+            .as_ref()
+            .cmp(other.data_path.as_ref())
+            .then_with(|| {
+                self.delete_path
+                    .as_ref()
+                    .map(Path::as_ref)
+                    .cmp(&other.delete_path.as_ref().map(Path::as_ref))
+            })
+            .then_with(|| self.level.cmp(&other.level))
+            .then_with(|| self.id.raw().cmp(&other.id.raw()))
+    }
+
+    fn dedupe_key(&self) -> (String, Option<String>, u32, u64) {
+        (
+            self.data_path.as_ref().to_owned(),
+            self.delete_path
+                .as_ref()
+                .map(|path| path.as_ref().to_owned()),
+            self.level,
+            self.id.raw(),
+        )
+    }
 }
 
 mod path_serde {

--- a/src/manifest/driver.rs
+++ b/src/manifest/driver.rs
@@ -19,8 +19,8 @@ use super::{
     VersionEdit,
     codec::{CatalogCodec, GcPlanCodec, ManifestCodec, VersionCodec},
     domain::{
-        CatalogKey, CatalogState, CatalogValue, GcPlanKey, GcPlanState, GcPlanValue,
-        TableCatalogEntry, TableDefinition, TableHead, TableId, TableMeta, VersionKey,
+        CatalogKey, CatalogState, CatalogValue, CurrentRootSet, GcPlanKey, GcPlanState,
+        GcPlanValue, TableCatalogEntry, TableDefinition, TableHead, TableId, TableMeta, VersionKey,
         VersionState, VersionValue, WalSegmentRef,
     },
 };
@@ -45,6 +45,17 @@ pub enum ManifestError {
     /// Catalog metadata did not match expectations.
     #[error("catalog conflict: {0}")]
     CatalogConflict(String),
+    /// Requested snapshot/version is unavailable in manifest history.
+    #[error(
+        "requested manifest version at or before timestamp {requested:?} is unavailable; oldest \
+         available version is {oldest_available:?}"
+    )]
+    VersionUnavailable {
+        /// Requested snapshot timestamp.
+        requested: Timestamp,
+        /// Oldest manifest version timestamp still available.
+        oldest_available: Timestamp,
+    },
 }
 
 /// Convenience result alias for manifest operations.
@@ -143,6 +154,7 @@ where
 {
     /// Apply a sequence of edits, atomically publishing a new table version together with head
     /// metadata.
+    #[allow(dead_code)]
     pub(crate) async fn apply_version_edits(
         &self,
         table: TableId,
@@ -153,6 +165,7 @@ where
 
     /// Apply edits with a CAS guard on the current head transaction. If the manifest head has
     /// advanced since `expected_head`, this returns `ManifestError::CasConflict`.
+    #[allow(dead_code)]
     pub(crate) async fn apply_version_edits_cas(
         &self,
         table: TableId,
@@ -370,7 +383,19 @@ where
                 <VersionCodec as ManifestCodec>::validate_key_value(&version_key, &value)?;
                 Some(VersionState::try_from(value)?)
             }
-            None => None,
+            None => {
+                session.end().await?;
+                let versions = self.list_versions(table, 0).await?;
+                let oldest_available = versions.last().map(VersionState::commit_timestamp).ok_or(
+                    ManifestError::Invariant(
+                        "requested version is unavailable and no committed versions exist",
+                    ),
+                )?;
+                return Err(ManifestError::VersionUnavailable {
+                    requested: manifest_ts,
+                    oldest_available,
+                });
+            }
         };
 
         session.end().await?;
@@ -456,6 +481,71 @@ where
         Ok(versions)
     }
 
+    /// Build the deterministic set of protected SST objects from current manifest state.
+    #[allow(dead_code)]
+    pub(crate) async fn current_root_set(&self, table: TableId) -> ManifestResult<CurrentRootSet> {
+        self.current_root_set_with_pins(table, &[]).await
+    }
+
+    /// Build the protected root set from the current HEAD and any active snapshot pins.
+    pub(crate) async fn current_root_set_with_pins(
+        &self,
+        table: TableId,
+        active_pins: &[Timestamp],
+    ) -> ManifestResult<CurrentRootSet> {
+        let session = self.inner.session_read().await?;
+
+        let head_key = VersionKey::TableHead { table_id: table };
+        let head = match session.get(&head_key).await? {
+            Some(value) => {
+                <VersionCodec as ManifestCodec>::validate_key_value(&head_key, &value)?;
+                TableHead::try_from(value)?
+            }
+            None => {
+                session.end().await?;
+                return Err(ManifestError::Invariant(
+                    "Head cannot be empty for current_root_set",
+                ));
+            }
+        };
+
+        let entries = match session
+            .scan_range(ScanRange {
+                start: Some(VersionKey::TableVersion {
+                    table_id: table,
+                    manifest_ts: Timestamp::MIN,
+                }),
+                end: Some(VersionKey::TableVersion {
+                    table_id: table,
+                    manifest_ts: Timestamp::MAX,
+                }),
+            })
+            .await
+        {
+            Ok(entries) => entries,
+            Err(err) => {
+                session.end().await?;
+                return Err(err.into());
+            }
+        };
+
+        let mut versions = Vec::new();
+        for (key, value) in entries {
+            <VersionCodec as ManifestCodec>::validate_key_value(&key, &value)?;
+            if let VersionValue::TableVersion(state) = value {
+                versions.push(state);
+            }
+        }
+        session.end().await?;
+
+        versions.sort_by_key(|version| std::cmp::Reverse(version.commit_timestamp()));
+        Ok(CurrentRootSet::from_versions(
+            head.last_manifest_txn,
+            active_pins,
+            &versions,
+        ))
+    }
+
     /// Fetch the persisted WAL floor for a table.
     #[instrument(
         name = "manifest::wal_floor",
@@ -485,6 +575,33 @@ where
     LS: LeaseStore + MaybeSend + MaybeSync + 'static,
     E: Executor + Timer + Clone + 'static,
 {
+    pub(crate) async fn update_gc_plan<F>(
+        &self,
+        table_id: TableId,
+        updater: F,
+    ) -> ManifestResult<(Option<GcPlanState>, Option<GcPlanState>)>
+    where
+        F: FnOnce(Option<GcPlanState>) -> Option<GcPlanState>,
+    {
+        let mut session = self.inner.session_write().await?;
+        let key = GcPlanKey::Table { table_id };
+        let previous = match session.get(&key).await? {
+            Some(value) => {
+                <GcPlanCodec as ManifestCodec>::validate_key_value(&key, &value)?;
+                Some(GcPlanState::try_from(value)?)
+            }
+            None => None,
+        };
+        let next = updater(previous.clone());
+        match next.clone() {
+            Some(plan) => session.put(key, GcPlanValue::Plan(plan)),
+            None => session.delete(key),
+        }
+        session.commit().await?;
+        Ok((previous, next))
+    }
+
+    #[cfg(test)]
     #[instrument(
         name = "manifest::put_gc_plan",
         skip(self),
@@ -502,28 +619,25 @@ where
         Ok(())
     }
 
-    #[cfg(all(test, feature = "tokio"))]
     #[instrument(
-        name = "manifest::take_gc_plan",
+        name = "manifest::peek_gc_plan",
         skip(self),
         fields(component = "manifest", table_id = ?table_id)
     )]
-    pub(crate) async fn take_gc_plan(
+    pub(crate) async fn peek_gc_plan(
         &self,
         table_id: TableId,
     ) -> ManifestResult<Option<GcPlanState>> {
-        let mut session = self.inner.session_write().await?;
+        let session = self.inner.session_read().await?;
         let key = GcPlanKey::Table { table_id };
-        let value = session.get(&key).await?;
-        let plan = match value {
+        let plan = match session.get(&key).await? {
             Some(value) => {
                 <GcPlanCodec as ManifestCodec>::validate_key_value(&key, &value)?;
                 Some(GcPlanState::try_from(value)?)
             }
             None => None,
         };
-        session.delete(key);
-        session.commit().await?;
+        session.end().await?;
         Ok(plan)
     }
 }
@@ -595,7 +709,6 @@ where
             name: definition.name.clone(),
             schema_fingerprint: definition.schema_fingerprint.clone(),
             primary_key_columns: definition.primary_key_columns.clone(),
-            retention: definition.retention.clone(),
             schema_version: definition.schema_version,
         };
 
@@ -682,12 +795,6 @@ fn ensure_table_compat(meta: &TableMeta, definition: &TableDefinition) -> Manife
             definition.name, meta.schema_version, definition.schema_version
         )));
     }
-    if meta.retention != definition.retention {
-        return Err(ManifestError::CatalogConflict(format!(
-            "table `{}` retention policy mismatch",
-            definition.name
-        )));
-    }
     Ok(())
 }
 
@@ -702,7 +809,7 @@ mod tests {
     };
 
     use super::{
-        super::domain::{SstEntry, TableDefinition},
+        super::domain::{ProtectedObjectKind, ProtectedVersionKind, SstEntry, TableDefinition},
         *,
     };
     use crate::{
@@ -1057,6 +1164,90 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn current_root_set_includes_head_historical_versions_and_delete_sidecars() {
+        let file_ids = FileIdGenerator::default();
+        let (manifest, table_id) =
+            init_in_memory_manifest_raw(1, &file_ids, DefaultExecutor::default())
+                .await
+                .expect("manifest should initialize");
+
+        let historical_data = Path::parse("sst/L0/00000000000000000001.parquet").expect("path");
+        let historical_delete =
+            Path::parse("sst/L0/00000000000000000001.delete.parquet").expect("path");
+        let head_data = Path::parse("sst/L1/00000000000000000002.parquet").expect("path");
+
+        manifest
+            .apply_version_edits(
+                table_id,
+                &[VersionEdit::AddSsts {
+                    level: 0,
+                    entries: vec![SstEntry::new(
+                        SsTableId::new(1),
+                        Some(SsTableStats::default()),
+                        None,
+                        historical_data.clone(),
+                        Some(historical_delete.clone()),
+                    )],
+                }],
+            )
+            .await
+            .expect("first version");
+
+        manifest
+            .apply_version_edits(
+                table_id,
+                &[
+                    VersionEdit::RemoveSsts {
+                        level: 0,
+                        sst_ids: vec![SsTableId::new(1)],
+                    },
+                    VersionEdit::AddSsts {
+                        level: 1,
+                        entries: vec![SstEntry::new(
+                            SsTableId::new(2),
+                            Some(SsTableStats::default()),
+                            None,
+                            head_data.clone(),
+                            None,
+                        )],
+                    },
+                ],
+            )
+            .await
+            .expect("second version");
+
+        let root_set = manifest
+            .current_root_set_with_pins(table_id, &[Timestamp::new(1)])
+            .await
+            .expect("current root set");
+        assert_eq!(root_set.protected_version_count(), 2);
+        assert_eq!(root_set.protected_object_count(), 3);
+        assert_eq!(
+            root_set
+                .protected_versions()
+                .iter()
+                .map(|version| (version.manifest_ts(), version.kind()))
+                .collect::<Vec<_>>(),
+            vec![
+                (Timestamp::new(2), ProtectedVersionKind::Head),
+                (Timestamp::new(1), ProtectedVersionKind::ActiveSnapshotPin),
+            ]
+        );
+        assert_eq!(
+            root_set
+                .protected_objects()
+                .iter()
+                .map(|object| (object.path().clone(), object.kind()))
+                .collect::<Vec<_>>(),
+            vec![
+                (historical_delete, ProtectedObjectKind::DeleteSidecar),
+                (historical_data, ProtectedObjectKind::Data),
+                (head_data, ProtectedObjectKind::Data),
+            ]
+        );
+    }
+
+    #[tokio::test]
     async fn catalog_registers_and_validates_tables() {
         let file_ids = FileIdGenerator::default();
         let catalog = bare_catalog_manifest();
@@ -1065,7 +1256,6 @@ mod tests {
             name: "test-table".into(),
             schema_fingerprint: "fingerprint-a".into(),
             primary_key_columns: vec!["pk".into()],
-            retention: None,
             schema_version: 1,
         };
 

--- a/src/mode/mod.rs
+++ b/src/mode/mod.rs
@@ -103,7 +103,6 @@ pub(crate) fn table_definition(config: &DynModeConfig, table_name: &str) -> Tabl
         name: table_name.to_string(),
         schema_fingerprint: fingerprint_schema(&config.schema),
         primary_key_columns: key_columns,
-        retention: None,
         schema_version: 0,
     }
 }

--- a/src/ondisk/sstable.rs
+++ b/src/ondisk/sstable.rs
@@ -1148,6 +1148,51 @@ fn build_table_paths(
     Ok((dir_path, data_path, delete_path))
 }
 
+pub(crate) fn manifest_storage_path(root: &Path, storage_path: &Path) -> Path {
+    let storage_raw = storage_path.as_ref();
+    let root_raw = root.as_ref().trim_end_matches('/');
+    if root_raw.is_empty() {
+        return storage_path.clone();
+    }
+
+    if let Some(stripped) = storage_raw.strip_prefix(root_raw) {
+        let stripped = stripped.trim_start_matches('/');
+        if !stripped.is_empty() {
+            return Path::from(stripped.to_string());
+        }
+    }
+
+    if let Some(stripped_root) = root_raw.strip_prefix('/')
+        && let Some(stripped) = storage_raw.strip_prefix(stripped_root)
+    {
+        let stripped = stripped.trim_start_matches('/');
+        if !stripped.is_empty() {
+            return Path::from(stripped.to_string());
+        }
+    }
+
+    storage_path.clone()
+}
+
+pub(crate) fn storage_path_from_manifest(root: &Path, manifest_path: &Path) -> Path {
+    if root == &Path::default() {
+        return manifest_path.clone();
+    }
+
+    let manifest_raw = manifest_path.as_ref();
+    let root_raw = root.as_ref().trim_end_matches('/');
+    if manifest_raw.starts_with(root_raw) {
+        return manifest_path.clone();
+    }
+    if let Some(root_without_leading_slash) = root_raw.strip_prefix('/')
+        && manifest_raw.starts_with(root_without_leading_slash)
+    {
+        return Path::from(format!("/{manifest_raw}"));
+    }
+
+    Path::from(format!("{root_raw}/{manifest_raw}"))
+}
+
 /// Planner responsible for turning immutable runs into SSTable files.
 pub struct SsTableBuilder {
     writer: ParquetTableWriter,
@@ -2457,6 +2502,22 @@ mod tests {
         let descriptor = table.descriptor();
         let delete_path = descriptor.delete_path().expect("delete sidecar present");
         assert!(delete_path.as_ref().ends_with(".delete.parquet"));
+    }
+
+    #[test]
+    fn manifest_storage_path_strips_sst_root_prefix() {
+        let root = Path::from("/tmp/tonbo/sst");
+        let storage = Path::from("/tmp/tonbo/sst/L1/00000000000000000007.parquet");
+        assert_eq!(
+            manifest_storage_path(&root, &storage).as_ref(),
+            "L1/00000000000000000007.parquet"
+        );
+
+        let legacy_storage = Path::from("tmp/tonbo/sst/L1/00000000000000000007.parquet");
+        assert_eq!(
+            manifest_storage_path(&root, &legacy_storage).as_ref(),
+            "L1/00000000000000000007.parquet"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/tests_internal/compaction_gc_e2e.rs
+++ b/src/tests_internal/compaction_gc_e2e.rs
@@ -8,6 +8,7 @@ use fusio::{DynFs, disk::LocalFs, executor::tokio::TokioExecutor, path::Path as 
 
 use crate::{
     db::{BatchesThreshold, Expr},
+    extractor::projection_for_field,
     test_support::{
         TestFsWalStateStore as FsWalStateStore, TestSsTableConfig as SsTableConfig,
         TestSsTableDescriptor as SsTableDescriptor, TestSsTableId as SsTableId,
@@ -66,22 +67,25 @@ async fn compaction_gc_prunes_obsolete_wal_and_preserves_visible_rows()
 
     let wal_dir = temp_root.join("wal");
     let wal_cfg = wal_cfg_with_backend(&wal_dir);
+    let extractor = projection_for_field(schema.clone(), 0).expect("extractor");
 
     let mut db = crate::db::DB::<LocalFs, TokioExecutor>::builder(config)
         .on_disk(root_str.clone())?
         .wal_config(wal_cfg.clone())
-        .with_minor_compaction(1, 0)
         .open_with_executor(Arc::clone(&executor))
         .await?
         .into_inner();
     db.set_seal_policy(Arc::new(BatchesThreshold { batches: 1 }));
 
     // Ingest two batches that will become two L0 SSTs.
-    let sst_cfg = Arc::new(SsTableConfig::new(
-        schema.clone(),
-        Arc::new(LocalFs {}),
-        FusioPath::from_filesystem_path(temp_root.join("sst")).expect("sst path"),
-    ));
+    let sst_cfg = Arc::new(
+        SsTableConfig::new(
+            schema.clone(),
+            Arc::new(LocalFs {}),
+            FusioPath::from_filesystem_path(temp_root.join("sst")).expect("sst path"),
+        )
+        .with_key_extractor(extractor.into()),
+    );
     for pass in 0..2 {
         let batch = RecordBatch::try_new(
             schema.clone(),
@@ -93,17 +97,11 @@ async fn compaction_gc_prunes_obsolete_wal_and_preserves_visible_rows()
         db.ingest(batch).await?;
         // Seal + flush each immutable to distinct SSTs.
         let descriptor = SsTableDescriptor::new(SsTableId::new(pass as u64 + 1), 0);
-        if let Err(err) = flush_immutables(&db, Arc::clone(&sst_cfg), descriptor).await {
-            eprintln!("flush skipped: {err}");
-            return Ok(());
-        }
+        flush_immutables(&db, Arc::clone(&sst_cfg), descriptor).await?;
     }
 
     // Plan a compaction that merges both L0 SSTs into L1 and records WAL GC.
-    if let Err(err) = compact_merge_l0(&db, vec![1, 2], 1, Arc::clone(&sst_cfg), 100).await {
-        eprintln!("compaction merge skipped: {err}");
-        return Ok(());
-    }
+    compact_merge_l0(&db, vec![1, 2], 1, Arc::clone(&sst_cfg), 100).await?;
 
     prune_wal_segments_below_floor(&db).await;
 

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -20,7 +20,10 @@ use typed_arrow_dyn::{
 #[cfg(all(test, feature = "tokio"))]
 use crate::manifest::{TableHead, VersionState};
 use crate::{
-    db::{DBError, DbInner, DynDbHandle, ScanBuilder, TxnWalPublishContext, WalFrameRange},
+    db::{
+        DBError, DbInner, DynDbHandle, ScanBuilder, SnapshotPinGuard, TxnWalPublishContext,
+        WalFrameRange,
+    },
     extractor::{KeyExtractError, KeyProjection, row_from_batch},
     key::{KeyOwned, KeyTsViewRaw},
     manifest::{ManifestError, TableSnapshot, VersionEdit},
@@ -64,13 +67,19 @@ pub enum SnapshotError {
 pub struct Snapshot {
     read_view: ReadView,
     manifest: TableSnapshot,
+    _manifest_pin: Option<SnapshotPinGuard>,
 }
 
 impl Snapshot {
-    pub(crate) fn from_table_snapshot(read_view: ReadView, manifest: TableSnapshot) -> Self {
+    pub(crate) fn from_table_snapshot(
+        read_view: ReadView,
+        manifest: TableSnapshot,
+        manifest_pin: Option<SnapshotPinGuard>,
+    ) -> Self {
         Self {
             read_view,
             manifest,
+            _manifest_pin: manifest_pin,
         }
     }
 


### PR DESCRIPTION
## Summary

This PR ships the single-process root-set SST GC milestone for Tonbo.

It adds the full path needed to benchmark, authorize, execute, observe, and validate SST garbage collection under the current single-process model, and it finalizes the protection model around active in-process snapshot pins rather than manifest version retention.

## Included

- SST GC benchmark scenarios and saved-baseline workflow
- root-set authority boundary for SST GC
- protected-object/root-set construction from manifest HEAD plus active snapshot pins
- manifest-authorized SST sweeper
- single-process correctness coverage for snapshot-protected historical reads
- minimal GC metrics and benchmark-visible storage/latency reporting
- follow-up fixes for staged-plan persistence, reporting clarity, normalized manifest-path reclamation, and benchmark harness compatibility after removing manifest version retention knobs
- full manifest history via `list_versions()` without retention pruning

## Not Included

- distributed reader registry or distributed GC semantics
- durable or cross-process snapshot protection
- WAL GC redesign

## Why

Before this work, Tonbo could accumulate obsolete SST objects after compaction, but the system did not have a complete, benchmarked, single-process-safe SST GC path.

This PR makes manifest/root-set reachability the correctness authority for SST reclamation, adds the sweeper path, and adds observability for storage reclamation and steady-state cost. Historical snapshots now stay valid because they pin the manifest versions they depend on for the lifetime of the in-process snapshot object.

## Key Changes

- Added benchmark baseline harness and GC-focused scenarios
- Added benchmark-visible request counters and persisted-size/reclaim accounting
- Made manifest/root-set reachability the SST GC safety authority
- Added manifest root-set builder for protected SST object enumeration from HEAD plus active snapshot pins
- Added in-process snapshot pin registration so historical snapshots block SST reclamation until dropped
- Removed manifest `max_versions` retention policy and related builder/schema/catalog surfaces
- Added manifest-authorized SST sweeper for unreachable SST objects
- Added deterministic correctness coverage for root-set protection and sweep behavior
- Added minimal GC metrics and benchmark/reporting updates
- Hardened staged GC-plan persistence
- Fixed stale SST reclamation when manifest paths required normalization to match physical object paths
- Kept full manifest version history available for `list_versions()` / `snapshot_at()` instead of pruning old versions

## Benchmark Takeaway

The branch-local SST GC rerun in `benches/compaction/results/sst_gc_rerun_2026-03-19.md` captures the final branch semantics as of 2026-03-22.

What the kept local `scale=20` run validates:

- in the read-focused GC scenario, prior background sweeps deleted `251,362,341` bytes across `230` SST objects in `2,498 ms`
- that sweep time was `3.15%` of setup wall-clock time (`79,402 ms`)
- the implied physical SST footprint at the read observation point would have been `257,848,523` bytes without prior GC, versus `6,486,182` bytes after reclaim
- paired steady-state read latency only moved by `-1.04%` after reclaim
- in the write-focused GC scenario, cumulative sweeps deleted `19,727,917` bytes across `18` SST objects in `199 ms`
- paired steady-state write latency moved by `-5.19%`, but remained too small/noisy to treat as a clear GC win on its own
- the read scenario’s sweep work landed before the explicit observation point, while the write scenario showed one additional sweep overlapping the observation window rather than a stable foreground speedup

Conclusion:

- GC can materially reduce physical SST footprint and bound object count in this single-process model
- the observable win in this harness is storage reclamation, not a demonstrated steady-state latency improvement
- active in-process snapshot pins preserve historical-read correctness while still allowing reclaim once those snapshots drop

## Validation

- `cargo +nightly fmt --all`
- `cargo test`
- `cargo clippy -- -D warnings`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --bench compaction_local --no-run`
- `TONBO_BENCH_BACKEND=local TONBO_BENCH_DATASET_SCALE=20 TONBO_COMPACTION_BENCH_INGEST_BATCHES=640 TONBO_COMPACTION_BENCH_ROWS_PER_BATCH=64 TONBO_COMPACTION_BENCH_WAL_SYNC=always TONBO_COMPACTION_BENCH_ENABLE_READ_WHILE_COMPACTION=0 TONBO_COMPACTION_BENCH_ENABLE_WRITE_THROUGHPUT_VS_COMPACTION_FREQUENCY=0 TONBO_COMPACTION_BENCH_ARTIFACT_ITERATIONS=4 TONBO_COMPACTION_BENCH_CRITERION_SAMPLE_SIZE=10 cargo bench -p tonbo --bench compaction_local -- 'read_baseline|read_compaction_quiesced|read_compaction_quiesced_after_gc|write_heavy_no_sst_sweep|write_heavy_with_sst_sweep|estimate_sweep_candidates' --nocapture`

## Reviewer Checklist

- Root-set reachability, not compaction output, is the SST GC safety authority
- Protected-object enumeration matches manifest-visible HEAD plus active in-process snapshot pins
- Sweeper deletes only unreachable manifest-published SST objects
- Historical snapshots remain valid until dropped and block reclaim while pinned
- `list_versions()` / `snapshot_at()` semantics match full manifest history rather than retained-window behavior
- Correctness coverage matches the intended single-process scope
- Benchmark/report outputs support the storage reclamation and latency claims
- Remaining non-goals are still appropriately out of scope
