### PR TITLE
perf: improve write latency in SWMR benchmark path

### DIFF
--- a/benches/compaction/README.md
+++ b/benches/compaction/README.md
@@ -390,10 +390,18 @@ The SWMR workload now also includes a writer-phase breakdown:
   - end-to-end writer latency observed by the SWMR mixed step
 - `summary.swmr.writer_path_ns.mean_partition_ns`:
   - partitioning the mixed batch into upsert/delete payloads
+- `summary.swmr.writer_path_ns.mean_wal_append_submit_ns`:
+  - time to submit WAL append payloads to the writer
+- `summary.swmr.writer_path_ns.mean_wal_append_wait_ns`:
+  - time waiting for WAL append payload durable acks
 - `summary.swmr.writer_path_ns.mean_wal_append_ns`:
-  - WAL append durable-ack time for the batch payload frames
+  - total WAL append cost, equal to submit plus durable-wait
+- `summary.swmr.writer_path_ns.mean_wal_commit_submit_ns`:
+  - time to submit the WAL commit marker to the writer
+- `summary.swmr.writer_path_ns.mean_wal_commit_wait_ns`:
+  - time waiting for the WAL commit-marker durable ack
 - `summary.swmr.writer_path_ns.mean_wal_commit_ns`:
-  - WAL commit-marker durable-ack time
+  - total WAL commit cost, equal to submit plus durable-wait
 - `summary.swmr.writer_path_ns.mean_mutable_insert_ns`:
   - applying rows into the mutable memtable
 - `summary.swmr.writer_path_ns.mean_seal_ns`:
@@ -406,7 +414,8 @@ The SWMR workload now also includes a writer-phase breakdown:
 Interpretation guideline:
 
 - if `writer_path_ns.mean_total_ns` is close to `writer_latency_ns.mean`, the slowdown is largely inside Tonbo's measured write path rather than outside harness overhead
-- if `mean_wal_append_ns + mean_wal_commit_ns` dominates, focus on WAL durability and object-store request cost first
+- if `mean_wal_append_wait_ns + mean_wal_commit_wait_ns` dominates, focus on WAL durability and writer flush behavior first
+- if `mean_wal_append_submit_ns + mean_wal_commit_submit_ns` dominates, focus on writer queueing/submission overhead first
 - if `mean_minor_compaction_ns` dominates, focus on flush/manifest publish work before tuning the pure ingest path
 
 For schema `8+` artifacts, setup payloads include both logical and physical volume sections:

--- a/benches/compaction/common.rs
+++ b/benches/compaction/common.rs
@@ -38,7 +38,7 @@ use tonbo::db::{
 };
 
 pub(crate) const BENCH_ID: &str = "compaction_local";
-pub(crate) const BENCH_SCHEMA_VERSION: u32 = 13;
+pub(crate) const BENCH_SCHEMA_VERSION: u32 = 14;
 
 const DEFAULT_INGEST_BATCHES: usize = 640;
 const DEFAULT_DATASET_SCALE: usize = 1;
@@ -1835,7 +1835,11 @@ struct ReadPathInternalSummary {
 #[derive(Debug, Serialize)]
 struct WritePathSummary {
     mean_partition_ns: f64,
+    mean_wal_append_submit_ns: f64,
+    mean_wal_append_wait_ns: f64,
     mean_wal_append_ns: f64,
+    mean_wal_commit_submit_ns: f64,
+    mean_wal_commit_wait_ns: f64,
     mean_wal_commit_ns: f64,
     mean_mutable_insert_ns: f64,
     mean_seal_ns: f64,
@@ -2008,7 +2012,11 @@ impl ReadPathAggregate {
 struct WritePathAggregate {
     samples: usize,
     partition_ns_total: u128,
+    wal_append_submit_ns_total: u128,
+    wal_append_wait_ns_total: u128,
     wal_append_ns_total: u128,
+    wal_commit_submit_ns_total: u128,
+    wal_commit_wait_ns_total: u128,
     wal_commit_ns_total: u128,
     mutable_insert_ns_total: u128,
     seal_ns_total: u128,
@@ -2022,9 +2030,21 @@ impl WritePathAggregate {
         self.partition_ns_total = self
             .partition_ns_total
             .saturating_add(u128::from(profile.partition_ns()));
+        self.wal_append_submit_ns_total = self
+            .wal_append_submit_ns_total
+            .saturating_add(u128::from(profile.wal_append_submit_ns()));
+        self.wal_append_wait_ns_total = self
+            .wal_append_wait_ns_total
+            .saturating_add(u128::from(profile.wal_append_wait_ns()));
         self.wal_append_ns_total = self
             .wal_append_ns_total
             .saturating_add(u128::from(profile.wal_append_ns()));
+        self.wal_commit_submit_ns_total = self
+            .wal_commit_submit_ns_total
+            .saturating_add(u128::from(profile.wal_commit_submit_ns()));
+        self.wal_commit_wait_ns_total = self
+            .wal_commit_wait_ns_total
+            .saturating_add(u128::from(profile.wal_commit_wait_ns()));
         self.wal_commit_ns_total = self
             .wal_commit_ns_total
             .saturating_add(u128::from(profile.wal_commit_ns()));
@@ -2049,7 +2069,11 @@ impl WritePathAggregate {
         let samples = self.samples as f64;
         Some(WritePathSummary {
             mean_partition_ns: self.partition_ns_total as f64 / samples,
+            mean_wal_append_submit_ns: self.wal_append_submit_ns_total as f64 / samples,
+            mean_wal_append_wait_ns: self.wal_append_wait_ns_total as f64 / samples,
             mean_wal_append_ns: self.wal_append_ns_total as f64 / samples,
+            mean_wal_commit_submit_ns: self.wal_commit_submit_ns_total as f64 / samples,
+            mean_wal_commit_wait_ns: self.wal_commit_wait_ns_total as f64 / samples,
             mean_wal_commit_ns: self.wal_commit_ns_total as f64 / samples,
             mean_mutable_insert_ns: self.mutable_insert_ns_total as f64 / samples,
             mean_seal_ns: self.seal_ns_total as f64 / samples,

--- a/src/compaction/handle.rs
+++ b/src/compaction/handle.rs
@@ -1,6 +1,6 @@
 //! Unified handle for background compaction workers.
 
-use std::marker::PhantomData;
+use std::{marker::PhantomData, sync::Mutex};
 
 use fusio::executor::Executor;
 #[cfg(test)]
@@ -23,7 +23,7 @@ pub(crate) enum CompactionTrigger {
 
 pub(crate) struct CompactionHandle<E: Executor> {
     abort: Option<AbortHandle>,
-    join: Option<E::JoinHandle<()>>,
+    join: Mutex<Option<E::JoinHandle<()>>>,
     trigger: Option<mpsc::Sender<CompactionTrigger>>,
     _marker: PhantomData<E>,
 }
@@ -37,7 +37,7 @@ impl<E: Executor> CompactionHandle<E> {
     ) -> Self {
         Self {
             abort: Some(abort),
-            join,
+            join: Mutex::new(join),
             trigger,
             _marker: PhantomData,
         }
@@ -58,7 +58,12 @@ impl<E: Executor> CompactionHandle<E> {
         if let Some(mut sender) = self.trigger.take() {
             let _ = sender.send(CompactionTrigger::Shutdown).await;
         }
-        if let Some(join) = self.join.take() {
+        let join = self
+            .join
+            .lock()
+            .expect("compaction join mutex poisoned")
+            .take();
+        if let Some(join) = join {
             let _ = join.join().await;
         }
         self.abort.take();
@@ -74,7 +79,11 @@ impl<E: Executor> Drop for CompactionHandle<E> {
         if let Some(abort) = self.abort.take() {
             abort.abort();
         }
-        let _ = self.join.take();
+        let _ = self
+            .join
+            .lock()
+            .expect("compaction join mutex poisoned")
+            .take();
         log_debug!(component = "compaction", event = "compaction_shutdown",);
     }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -43,6 +43,8 @@ pub use error::DBError;
 pub use scan::{DEFAULT_SCAN_BATCH_ROWS, ScanBuilder, ScanSetupProfile};
 pub(crate) use wal::{TxnWalPublishContext, WalFrameRange};
 
+#[cfg(not(test))]
+use crate::observability::log_warn;
 pub use crate::{
     compaction::{
         metrics::{
@@ -503,7 +505,19 @@ where
 
     /// Ingest a RecordBatch into the database (auto-commit mode).
     pub async fn ingest(&self, batch: RecordBatch) -> Result<(), DBError> {
-        self.inner.ingest(batch).await.map_err(DBError::Key)
+        #[cfg(test)]
+        {
+            self.inner.ingest(batch).await.map_err(DBError::Key)
+        }
+        #[cfg(not(test))]
+        {
+            self.inner
+                .ingest_without_minor_compaction(batch)
+                .await
+                .map_err(DBError::Key)?;
+            DbInner::schedule_background_minor_compaction(Arc::clone(&self.inner));
+            Ok(())
+        }
     }
 
     /// Ingest a batch along with its tombstone bitmap, routing through the WAL when enabled.
@@ -515,10 +529,22 @@ where
         batch: RecordBatch,
         tombstones: Vec<bool>,
     ) -> Result<(), DBError> {
-        self.inner
-            .ingest_with_tombstones(batch, tombstones)
-            .await
-            .map_err(DBError::Key)
+        #[cfg(test)]
+        {
+            self.inner
+                .ingest_with_tombstones(batch, tombstones)
+                .await
+                .map_err(DBError::Key)
+        }
+        #[cfg(not(test))]
+        {
+            self.inner
+                .ingest_with_tombstones_without_minor_compaction(batch, tombstones)
+                .await
+                .map_err(DBError::Key)?;
+            DbInner::schedule_background_minor_compaction(Arc::clone(&self.inner));
+            Ok(())
+        }
     }
 
     /// Ingest a batch and return a write-path timing breakdown.
@@ -527,10 +553,23 @@ where
         batch: RecordBatch,
         tombstones: Vec<bool>,
     ) -> Result<WritePathProfile, DBError> {
-        self.inner
-            .ingest_with_tombstones_with_profile(batch, tombstones)
-            .await
-            .map_err(DBError::Key)
+        #[cfg(test)]
+        {
+            self.inner
+                .ingest_with_tombstones_with_profile(batch, tombstones)
+                .await
+                .map_err(DBError::Key)
+        }
+        #[cfg(not(test))]
+        {
+            let profile = self
+                .inner
+                .ingest_with_tombstones_with_profile_without_minor_compaction(batch, tombstones)
+                .await
+                .map_err(DBError::Key)?;
+            DbInner::schedule_background_minor_compaction(Arc::clone(&self.inner));
+            Ok(profile)
+        }
     }
 
     /// Start building a scan query.
@@ -710,6 +749,12 @@ where
     flush_lock: AsyncMutex<()>,
     /// Optional minor compaction hook.
     minor_compaction: Option<MinorCompactionState>,
+    #[cfg(not(test))]
+    /// Single-flight guard for background minor compaction spawned from foreground writes.
+    minor_compaction_pending: AtomicBool,
+    #[cfg(not(test))]
+    /// Sticky rerun flag set when writes arrive while a background minor compaction is active.
+    minor_compaction_rerun: AtomicBool,
     /// Optional L0 backpressure configuration for ingest and minor compaction.
     l0_backpressure: Option<L0BackpressureConfig>,
     l0_stats_cache: AsyncMutex<L0StatsCache>,
@@ -775,6 +820,12 @@ where
     flush_lock: AsyncMutex<()>,
     /// Optional minor compaction hook.
     minor_compaction: Option<MinorCompactionState>,
+    #[cfg(not(test))]
+    /// Single-flight guard for background minor compaction spawned from foreground writes.
+    minor_compaction_pending: AtomicBool,
+    #[cfg(not(test))]
+    /// Sticky rerun flag set when writes arrive while a background minor compaction is active.
+    minor_compaction_rerun: AtomicBool,
     /// Optional L0 backpressure configuration for ingest and minor compaction.
     l0_backpressure: Option<L0BackpressureConfig>,
     l0_stats_cache: AsyncMutex<L0StatsCache>,
@@ -907,6 +958,10 @@ where
             compaction_metrics: None,
             flush_lock: AsyncMutex::new(()),
             minor_compaction: None,
+            #[cfg(not(test))]
+            minor_compaction_pending: AtomicBool::new(false),
+            #[cfg(not(test))]
+            minor_compaction_rerun: AtomicBool::new(false),
             l0_backpressure: None,
             l0_stats_cache: AsyncMutex::new(L0StatsCache::new(now)),
             l0_stats_refreshing: AtomicBool::new(false),
@@ -1003,7 +1058,24 @@ where
     }
 
     /// Unified ingestion entry point for dynamic batches.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub async fn ingest(&self, batch: RecordBatch) -> Result<(), KeyExtractError> {
+        self.ingest_impl(batch, true).await
+    }
+
+    #[cfg(not(test))]
+    pub(crate) async fn ingest_without_minor_compaction(
+        &self,
+        batch: RecordBatch,
+    ) -> Result<(), KeyExtractError> {
+        self.ingest_impl(batch, false).await
+    }
+
+    async fn ingest_impl(
+        &self,
+        batch: RecordBatch,
+        run_minor_compaction: bool,
+    ) -> Result<(), KeyExtractError> {
         if self.schema.as_ref() != batch.schema().as_ref() {
             return Err(KeyExtractError::SchemaMismatch {
                 expected: self.schema.clone(),
@@ -1038,11 +1110,13 @@ where
         }
         self.insert_into_mutable(batch, commit_ts)?;
         self.maybe_seal_after_insert()?;
-        self.maybe_run_minor_compaction().await.map_err(|err| {
-            KeyExtractError::Arrow(ArrowError::ComputeError(format!(
-                "minor compaction failed: {err}"
-            )))
-        })?;
+        if run_minor_compaction {
+            self.maybe_run_minor_compaction().await.map_err(|err| {
+                KeyExtractError::Arrow(ArrowError::ComputeError(format!(
+                    "minor compaction failed: {err}"
+                )))
+            })?;
+        }
         Ok(())
     }
 
@@ -1334,6 +1408,48 @@ where
         } else {
             Ok(None)
         }
+    }
+
+    #[cfg(not(test))]
+    pub(crate) fn schedule_background_minor_compaction(db: Arc<Self>)
+    where
+        E: 'static,
+    {
+        if db.minor_compaction.is_none() {
+            return;
+        }
+        if db
+            .minor_compaction_pending
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            db.minor_compaction_rerun.store(true, Ordering::Release);
+            return;
+        }
+
+        let runtime = Arc::clone(&db.executor);
+        let db_for_task = Arc::clone(&db);
+        runtime.spawn(async move {
+            let result = db_for_task.maybe_run_minor_compaction().await;
+            let rerun = db_for_task
+                .minor_compaction_rerun
+                .swap(false, Ordering::AcqRel);
+            db_for_task
+                .minor_compaction_pending
+                .store(false, Ordering::Release);
+
+            if let Err(err) = result {
+                log_warn!(
+                    component = "compaction",
+                    event = "minor_compaction_background_failed",
+                    error = ?err,
+                );
+            }
+
+            if rerun {
+                Self::schedule_background_minor_compaction(db_for_task);
+            }
+        });
     }
 
     /// Plan and flush immutable segments into a Parquet-backed SSTable.

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -114,7 +114,11 @@ pub struct Version {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct WritePathProfile {
     partition_ns: u64,
+    wal_append_submit_ns: u64,
+    wal_append_wait_ns: u64,
     wal_append_ns: u64,
+    wal_commit_submit_ns: u64,
+    wal_commit_wait_ns: u64,
     wal_commit_ns: u64,
     mutable_insert_ns: u64,
     seal_ns: u64,
@@ -128,9 +132,29 @@ impl WritePathProfile {
         self.partition_ns
     }
 
+    /// Time spent submitting WAL append payloads to the writer.
+    pub fn wal_append_submit_ns(&self) -> u64 {
+        self.wal_append_submit_ns
+    }
+
+    /// Time spent waiting for WAL append payload durable acks.
+    pub fn wal_append_wait_ns(&self) -> u64 {
+        self.wal_append_wait_ns
+    }
+
     /// Time spent appending write payloads to the WAL and waiting for durable acks.
     pub fn wal_append_ns(&self) -> u64 {
         self.wal_append_ns
+    }
+
+    /// Time spent submitting the WAL commit marker to the writer.
+    pub fn wal_commit_submit_ns(&self) -> u64 {
+        self.wal_commit_submit_ns
+    }
+
+    /// Time spent waiting for the WAL commit marker durable ack.
+    pub fn wal_commit_wait_ns(&self) -> u64 {
+        self.wal_commit_wait_ns
     }
 
     /// Time spent writing the WAL commit marker and waiting for durability.
@@ -163,7 +187,19 @@ impl WritePathProfile {
     pub fn saturating_add(self, other: Self) -> Self {
         Self {
             partition_ns: self.partition_ns.saturating_add(other.partition_ns),
+            wal_append_submit_ns: self
+                .wal_append_submit_ns
+                .saturating_add(other.wal_append_submit_ns),
+            wal_append_wait_ns: self
+                .wal_append_wait_ns
+                .saturating_add(other.wal_append_wait_ns),
             wal_append_ns: self.wal_append_ns.saturating_add(other.wal_append_ns),
+            wal_commit_submit_ns: self
+                .wal_commit_submit_ns
+                .saturating_add(other.wal_commit_submit_ns),
+            wal_commit_wait_ns: self
+                .wal_commit_wait_ns
+                .saturating_add(other.wal_commit_wait_ns),
             wal_commit_ns: self.wal_commit_ns.saturating_add(other.wal_commit_ns),
             mutable_insert_ns: self
                 .mutable_insert_ns

--- a/src/db/tests/core/ingest.rs
+++ b/src/db/tests/core/ingest.rs
@@ -134,6 +134,21 @@ async fn ingest_with_tombstones_profile_reports_coherent_timings() {
         .await
         .expect("ingest");
 
+    assert_eq!(
+        profile.wal_append_ns(),
+        profile
+            .wal_append_submit_ns()
+            .saturating_add(profile.wal_append_wait_ns()),
+        "wal append total should equal submit plus durable wait"
+    );
+    assert_eq!(
+        profile.wal_commit_ns(),
+        profile
+            .wal_commit_submit_ns()
+            .saturating_add(profile.wal_commit_wait_ns()),
+        "wal commit total should equal submit plus durable wait"
+    );
+
     let component_sum = profile
         .partition_ns()
         .saturating_add(profile.wal_append_ns())

--- a/src/db/wal.rs
+++ b/src/db/wal.rs
@@ -208,6 +208,7 @@ where
     }
 
     /// Ingest a batch along with its tombstone bitmap, routing through the WAL when enabled.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub async fn ingest_with_tombstones(
         &self,
         batch: RecordBatch,
@@ -218,13 +219,34 @@ where
             .map(|_| ())
     }
 
+    #[cfg(not(test))]
+    pub async fn ingest_with_tombstones_without_minor_compaction(
+        &self,
+        batch: RecordBatch,
+        tombstones: Vec<bool>,
+    ) -> Result<(), KeyExtractError> {
+        self.ingest_with_tombstones_with_profile_without_minor_compaction(batch, tombstones)
+            .await
+            .map(|_| ())
+    }
+
     /// Ingest a batch and return a write-path timing breakdown.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub async fn ingest_with_tombstones_with_profile(
         &self,
         batch: RecordBatch,
         tombstones: Vec<bool>,
     ) -> Result<WritePathProfile, KeyExtractError> {
-        insert_dyn_wal_batch(self, batch, tombstones).await
+        insert_dyn_wal_batch(self, batch, tombstones, true).await
+    }
+
+    #[cfg(not(test))]
+    pub async fn ingest_with_tombstones_with_profile_without_minor_compaction(
+        &self,
+        batch: RecordBatch,
+        tombstones: Vec<bool>,
+    ) -> Result<WritePathProfile, KeyExtractError> {
+        insert_dyn_wal_batch(self, batch, tombstones, false).await
     }
 
     pub(crate) fn replay_wal_events(
@@ -446,6 +468,7 @@ async fn insert_dyn_wal_batch<FS, E>(
     db: &DbInner<FS, E>,
     batch: RecordBatch,
     tombstones: Vec<bool>,
+    run_minor_compaction: bool,
 ) -> Result<WritePathProfile, KeyExtractError>
 where
     FS: ManifestFs<E>,
@@ -546,11 +569,13 @@ where
         let seal_started = Instant::now();
         db.maybe_seal_after_insert()?;
         profile.seal_ns = duration_ns_u64(seal_started.elapsed());
-        let minor_compaction_started = Instant::now();
-        db.maybe_run_minor_compaction()
-            .await
-            .map_err(compaction_as_key_extract_error)?;
-        profile.minor_compaction_ns = duration_ns_u64(minor_compaction_started.elapsed());
+        if run_minor_compaction {
+            let minor_compaction_started = Instant::now();
+            db.maybe_run_minor_compaction()
+                .await
+                .map_err(compaction_as_key_extract_error)?;
+            profile.minor_compaction_ns = duration_ns_u64(minor_compaction_started.elapsed());
+        }
     }
     profile.total_ns = duration_ns_u64(total_started.elapsed());
     Ok(profile)

--- a/src/db/wal.rs
+++ b/src/db/wal.rs
@@ -508,6 +508,7 @@ where
     let mut wal_range: Option<WalFrameRange> = None;
     if let Some(handle) = db.wal_handle().cloned() {
         let provisional_id = handle.next_provisional_id();
+        let append_submit_started = Instant::now();
         let mut append_tickets = Vec::new();
         if let Some(ref batch) = upsert_batch {
             let ticket = handle
@@ -523,23 +524,35 @@ where
                 .map_err(KeyExtractError::from)?;
             append_tickets.push(ticket);
         }
+        profile.wal_append_submit_ns = duration_ns_u64(append_submit_started.elapsed());
+
         let mut tracker = WalRangeAccumulator::default();
-        let wal_append_started = Instant::now();
+        let wal_append_wait_started = Instant::now();
         for ticket in append_tickets {
             let ack = ticket.durable().await.map_err(KeyExtractError::from)?;
             tracker.observe_range(ack.first_seq, ack.last_seq);
         }
-        profile.wal_append_ns = duration_ns_u64(wal_append_started.elapsed());
+        profile.wal_append_wait_ns = duration_ns_u64(wal_append_wait_started.elapsed());
+        profile.wal_append_ns = profile
+            .wal_append_submit_ns
+            .saturating_add(profile.wal_append_wait_ns);
+
+        let wal_commit_submit_started = Instant::now();
         let commit_ticket = handle
             .txn_commit(provisional_id, commit_ts)
             .await
             .map_err(KeyExtractError::from)?;
-        let wal_commit_started = Instant::now();
+        profile.wal_commit_submit_ns = duration_ns_u64(wal_commit_submit_started.elapsed());
+
+        let wal_commit_wait_started = Instant::now();
         let commit_ack = commit_ticket
             .durable()
             .await
             .map_err(KeyExtractError::from)?;
-        profile.wal_commit_ns = duration_ns_u64(wal_commit_started.elapsed());
+        profile.wal_commit_wait_ns = duration_ns_u64(wal_commit_wait_started.elapsed());
+        profile.wal_commit_ns = profile
+            .wal_commit_submit_ns
+            .saturating_add(profile.wal_commit_wait_ns);
         tracker.observe_range(commit_ack.first_seq, commit_ack.last_seq);
         wal_range = tracker.into_range();
     }

--- a/src/wal/writer.rs
+++ b/src/wal/writer.rs
@@ -644,7 +644,6 @@ where
 
         let durable_seq = self.current_frame_seq();
         self.record_frame_progress(durable_seq, commit_hint);
-        self.persist_state_if_dirty().await?;
 
         let ack = WalAck {
             first_seq: first_frame_seq,
@@ -689,6 +688,8 @@ where
                 }
             }
         }
+
+        self.persist_state_if_dirty().await?;
 
         Ok(HandleBatchOutcome {
             sync_performed,

--- a/src/wal/writer.rs
+++ b/src/wal/writer.rs
@@ -248,21 +248,15 @@ where
                                 }
                             }
 
-                            match ctx.handle_enqueue_batch(&batch).await {
-                                Ok(HandleBatchOutcome { acks, sync_performed, timer_directive }) => {
+                            match ctx.handle_enqueue_batch(batch).await {
+                                Ok(HandleBatchOutcome { sync_performed, timer_directive }) => {
                                     if sync_performed {
                                         ctx.record_sync().await;
                                     }
                                     ctx.apply_timer_directive(timer_directive, &mut timer);
-                                    for ((_, _, tx), ack) in batch.into_iter().zip(acks.into_iter()) {
-                                        let _ = tx.send(Ok(ack));
-                                    }
                                 }
                                 Err(err) => {
                                     ctx.apply_timer_directive(TimerDirective::Cancel, &mut timer);
-                                    for (_, _, tx) in batch.into_iter() {
-                                        let _ = tx.send(Err(err.clone()));
-                                    }
                                     return Err(err);
                                 }
                             }
@@ -362,9 +356,8 @@ where
                         }
                     }
 
-                    match ctx.handle_enqueue_batch(&batch).await {
+                    match ctx.handle_enqueue_batch(batch).await {
                         Ok(HandleBatchOutcome {
-                            acks,
                             sync_performed,
                             timer_directive,
                         }) => {
@@ -372,14 +365,8 @@ where
                                 ctx.record_sync().await;
                             }
                             ctx.apply_timer_directive(timer_directive, &mut timer);
-                            for ((_, _, tx), ack) in batch.into_iter().zip(acks) {
-                                let _ = tx.send(Ok(ack));
-                            }
                         }
                         Err(err) => {
-                            for (_, _, tx) in batch.into_iter() {
-                                let _ = tx.send(Err(err.clone()));
-                            }
                             return Err(err);
                         }
                     }
@@ -489,7 +476,6 @@ where
 }
 
 struct HandleBatchOutcome {
-    acks: Vec<WalAck>,
     sync_performed: bool,
     timer_directive: TimerDirective,
 }
@@ -681,21 +667,30 @@ where
 
     async fn handle_enqueue_batch(
         &mut self,
-        batch: &[(WalCommand, Instant, oneshot::Sender<WalResult<WalAck>>)],
+        batch: Vec<(WalCommand, Instant, oneshot::Sender<WalResult<WalAck>>)>,
     ) -> WalResult<HandleBatchOutcome> {
-        let mut acks = Vec::with_capacity(batch.len());
         let mut sync_performed = false;
         let mut timer_directive = TimerDirective::None;
+        let mut pending = batch.into_iter();
 
-        for (command, enqueued_at, _) in batch.iter() {
-            let outcome = self.handle_enqueue(command.clone(), *enqueued_at).await?;
-            sync_performed |= outcome.sync_performed;
-            timer_directive = outcome.timer_directive;
-            acks.push(outcome.ack);
+        while let Some((command, enqueued_at, ack_tx)) = pending.next() {
+            match self.handle_enqueue(command, enqueued_at).await {
+                Ok(outcome) => {
+                    sync_performed |= outcome.sync_performed;
+                    timer_directive = outcome.timer_directive;
+                    let _ = ack_tx.send(Ok(outcome.ack));
+                }
+                Err(err) => {
+                    let _ = ack_tx.send(Err(err.clone()));
+                    for (_, _, pending_tx) in pending {
+                        let _ = pending_tx.send(Err(err.clone()));
+                    }
+                    return Err(err);
+                }
+            }
         }
 
         Ok(HandleBatchOutcome {
-            acks,
             sync_performed,
             timer_directive,
         })


### PR DESCRIPTION
## Summary
- move minor compaction behind the ingest durable-ack boundary
- release WAL acks as batch commands complete and batch WAL state persistence per drain
- split WAL submit and durable-wait timing so benchmark artifacts expose where writer time is spent

## Why
This branch materially improves write latency, especially in object-store-backed topologies. In the validated SWMR 1 GB EC2 benchmark, same-region standard S3 writer mean improved from 5.840s to 1.011s, and local writer mean improved from 0.148s to 0.109s.

## Validation
- cargo test -j 1
- cargo test --lib --tests -j 1 on `eu-central-1` benchmark host
- cargo test --lib --tests -j 1 on `us-east-1` benchmark host
- SWMR 1 GB benchmark artifacts collected for:
  - `eu-central-1` local
  - `eu-central-1` same-region standard S3
  - `eu-central-1 -> us-east-1` cross-region standard S3
  - `us-east-1` same-AZ S3 Express

## Notes
- `us-east-1` same-region standard S3 currently fails during preload while closing a WAL multipart upload, so there is no same-branch artifact for that cell yet.
- Follow-up tracking issue: #607
