### PR TITLE
fix: pin historical snapshot before manifest load

### DIFF
--- a/src/compaction/driver.rs
+++ b/src/compaction/driver.rs
@@ -36,7 +36,9 @@ use crate::{
         scheduler::{CompactionScheduleError, CompactionScheduler, ScheduledCompaction},
     },
     db::{CasBackoffConfig, CascadeConfig, SnapshotPinRegistry},
-    manifest::{ManifestError, ManifestFs, ManifestResult, TableId, TonboManifest, WalSegmentRef},
+    manifest::{
+        GcSstRef, ManifestError, ManifestFs, ManifestResult, TableId, TonboManifest, WalSegmentRef,
+    },
     observability::{log_debug, log_info, log_warn},
     ondisk::sstable::manifest_storage_path,
     wal::{WalConfig as RuntimeWalConfig, WalHandle, manifest_ext},
@@ -300,6 +302,15 @@ where
 
         let attempted_candidates = authorized_ssts.len();
         for candidate in authorized_ssts {
+            if !self.sst_candidate_is_still_authorized(&candidate).await? {
+                log_debug!(
+                    component = "compaction",
+                    event = "sst_sweep_candidate_reblocked",
+                    table_id = ?self.table_id,
+                    path = candidate.data_path.as_ref(),
+                );
+                continue;
+            }
             match self.sweep_candidate(&candidate, &mut summary).await {
                 Ok(()) => reclaimed_ssts.push(candidate),
                 Err(_requeue_candidate) => {}
@@ -439,9 +450,9 @@ where
 
     async fn sweep_candidate(
         &self,
-        candidate: &crate::manifest::GcSstRef,
+        candidate: &GcSstRef,
         summary: &mut SstSweepSummary,
-    ) -> Result<(), crate::manifest::GcSstRef> {
+    ) -> Result<(), GcSstRef> {
         let mut success = true;
         let data_path = self.resolve_sst_path(&candidate.data_path);
         if self
@@ -467,6 +478,23 @@ where
         } else {
             Err(candidate.clone())
         }
+    }
+
+    async fn sst_candidate_is_still_authorized(
+        &self,
+        candidate: &GcSstRef,
+    ) -> ManifestResult<bool> {
+        let active_pins = self.snapshot_pins.active_versions();
+        let root_set = self
+            .manifest
+            .current_root_set_with_pins(self.table_id, &active_pins)
+            .await?;
+
+        Ok(!root_set.contains_path(&candidate.data_path)
+            && candidate
+                .delete_path
+                .as_ref()
+                .is_none_or(|path| !root_set.contains_path(path)))
     }
 
     fn resolve_sst_path(&self, relative: &Path) -> Path {

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1215,17 +1215,24 @@ where
         // Find the version at or before the requested timestamp (versions are newest-first)
         let target_version = versions.iter().find(|v| v.commit_timestamp <= timestamp);
 
-        let manifest_snapshot = if let Some(version) = target_version {
-            // Load the historical version from manifest
-            self.manifest
+        let (manifest_snapshot, manifest_pin) = if let Some(version) = target_version {
+            // Register the historical version before loading it so SST GC sees the version as
+            // protected while the manifest snapshot is in flight.
+            let manifest_pin = Some(self.pin_snapshot_version(version.commit_timestamp));
+            let manifest_snapshot = self
+                .manifest
                 .snapshot_at_version(self.manifest_table, version.commit_timestamp)
-                .await?
+                .await?;
+            (manifest_snapshot, manifest_pin)
         } else if versions.is_empty() {
             // No committed manifest versions exist yet, so only the current in-memory/head view can
             // answer the request.
-            self.manifest
+            let manifest_snapshot = self
+                .manifest
                 .snapshot_latest_with_fallback(self.manifest_table, &self.table_meta)
-                .await?
+                .await?;
+            let manifest_pin = self.snapshot_pin_for_manifest(&manifest_snapshot);
+            (manifest_snapshot, manifest_pin)
         } else {
             return Err(ManifestError::VersionUnavailable {
                 requested: timestamp,
@@ -1240,7 +1247,6 @@ where
         };
 
         let read_view = ReadView::new(timestamp);
-        let manifest_pin = self.snapshot_pin_for_manifest(&manifest_snapshot);
         Ok(TxSnapshot::from_table_snapshot(
             read_view,
             manifest_snapshot,

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1216,13 +1216,20 @@ where
         let target_version = versions.iter().find(|v| v.commit_timestamp <= timestamp);
 
         let (manifest_snapshot, manifest_pin) = if let Some(version) = target_version {
-            // Register the historical version before loading it so SST GC sees the version as
-            // protected while the manifest snapshot is in flight.
+            // Pin the target manifest timestamp before loading its snapshot, so SST GC sees the
+            // version as protected during the in-flight load.
             let manifest_pin = Some(self.pin_snapshot_version(version.commit_timestamp));
             let manifest_snapshot = self
                 .manifest
                 .snapshot_at_version(self.manifest_table, version.commit_timestamp)
                 .await?;
+            debug_assert_eq!(
+                manifest_snapshot
+                    .latest_version
+                    .as_ref()
+                    .map(|snapshot_version| snapshot_version.commit_timestamp()),
+                Some(version.commit_timestamp)
+            );
             (manifest_snapshot, manifest_pin)
         } else if versions.is_empty() {
             // No committed manifest versions exist yet, so only the current in-memory/head view can


### PR DESCRIPTION
## Summary

Fixes the TOCTOU race called out in the #601 review where `snapshot_at()` could select a historical manifest version, then GC could authorize and delete SSTs for that version before the snapshot registered its pin.

`snapshot_at()` now registers a pin for the target historical manifest timestamp before awaiting `snapshot_at_version()`. If the manifest load fails, the guard is dropped and the pin is released normally.

## Root Cause

The old ordering loaded the historical manifest first and only registered the snapshot pin afterward. During that await window, `sweep_authorized_ssts()` could observe no active pin for the historical version and reclaim SSTs that the reader was about to depend on.

## Validation

- `env RUSTC_WRAPPER= cargo test snapshot --lib`
- `cargo +nightly fmt --all`
- `env RUSTC_WRAPPER= cargo test`
- `env RUSTC_WRAPPER= cargo clippy -- -D warnings`
- `git diff --check`
