### PR TITLE
chore: bump tonbo to 0.4.0-a1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2024"
 name = "tonbo"
 resolver = "2"
-version = "0.4.0-a0"
+version = "0.4.0-a1"
 description = "Embedded database for serverless and edge runtimes, storing data as Parquet on S3"
 license = "Apache-2.0"
 repository = "https://github.com/tonbo-io/tonbo"
@@ -38,7 +38,7 @@ s3-smoke = []
 
 [dependencies]
 anyhow = "1"
-aisle = { git = "https://github.com/tonbo-io/aisle", branch = "main", default-features = false, features = ["row_filter"] }
+aisle = { version = "0.2.0", git = "https://github.com/tonbo-io/aisle", branch = "main" }
 arrow-array = "57.1.0"
 arrow-buffer = "57.1.0"
 arrow-ipc = "57.1.0"
@@ -48,16 +48,16 @@ bytes = "1"
 crc32c = "0.6"
 crossbeam-skiplist = "0.1"
 datafusion-common = "51.0.0"
-fusio = { git = "https://github.com/tonbo-io/fusio", rev = "62738727bd5be6e7591fb5d5de008959ed45a20d", default-features = false, features = [
+fusio = { version = "0.6.0", git = "https://github.com/tonbo-io/fusio", rev = "62738727bd5be6e7591fb5d5de008959ed45a20d", default-features = false, features = [
     "aws",
     "dyn",
     "executor",
     "fs",
 ] }
-fusio-manifest = { git = "https://github.com/tonbo-io/fusio", rev = "62738727bd5be6e7591fb5d5de008959ed45a20d", package = "fusio-manifest", default-features = false, features = [
+fusio-manifest = { version = "0.6.0", git = "https://github.com/tonbo-io/fusio", rev = "62738727bd5be6e7591fb5d5de008959ed45a20d", package = "fusio-manifest", default-features = false, features = [
     "std",
 ] }
-fusio-parquet = { git = "https://github.com/tonbo-io/fusio", rev = "62738727bd5be6e7591fb5d5de008959ed45a20d", package = "fusio-parquet" }
+fusio-parquet = { version = "0.6.0", git = "https://github.com/tonbo-io/fusio", rev = "62738727bd5be6e7591fb5d5de008959ed45a20d", package = "fusio-parquet" }
 futures = "0.3"
 lockable = "0.2"
 once_cell = "1"

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@
 
 # Tonbo
 
-[![crates.io](https://img.shields.io/crates/v/tonbo.svg)](https://crates.io/crates/tonbo/) [![crates.io](https://img.shields.io/crates/l/tonbo)](https://github.com/tonbo-io/tonbo/blob/main/LICENSE) [![docs.rs](https://img.shields.io/docsrs/tonbo)](https://docs.rs/tonbo/0.4.0-a0/tonbo/) [![ci](https://github.com/tonbo-io/tonbo/actions/workflows/rust.yml/badge.svg?branch=dev)](https://github.com/tonbo-io/tonbo/actions/workflows/rust.yml) [![discord](https://img.shields.io/discord/1270294987355197460?logo=discord)](https://discord.gg/j27XVFVmJM)
+[![crates.io](https://img.shields.io/crates/v/tonbo.svg)](https://crates.io/crates/tonbo/) [![crates.io](https://img.shields.io/crates/l/tonbo)](https://github.com/tonbo-io/tonbo/blob/main/LICENSE) [![docs.rs](https://img.shields.io/docsrs/tonbo)](https://docs.rs/tonbo/0.4.0-a1/tonbo/) [![ci](https://github.com/tonbo-io/tonbo/actions/workflows/rust.yml/badge.svg?branch=main)](https://github.com/tonbo-io/tonbo/actions/workflows/rust.yml) [![discord](https://img.shields.io/discord/1270294987355197460?logo=discord)](https://discord.gg/j27XVFVmJM)
 
 
-**[Website](https://tonbo.io/) | [Rust Doc](https://docs.rs/tonbo/0.4.0-a0/tonbo/) | [Blog](https://tonbo.io/blogs) | [Community](https://discord.gg/j27XVFVmJM)**
+**[Website](https://tonbo.io/) | [Rust Doc](https://docs.rs/tonbo/0.4.0-a1/tonbo/) | [Blog](https://tonbo.io/blogs) | [Community](https://discord.gg/j27XVFVmJM)**
 
 
 Tonbo is an embedded database for serverless and edge runtimes. Your data is stored as Parquet on S3, coordination happens through a manifest, and compute stays fully stateless.
@@ -67,14 +67,14 @@ For local development, use `.on_disk("/tmp/users")?` instead. See [`examples/`](
 ## Installation
 
 ```bash
-cargo add tonbo@0.4.0-a0 tokio
+cargo add tonbo@0.4.0-a1 tokio
 ```
 
 Or add to `Cargo.toml`:
 
 ```toml
 [dependencies]
-tonbo = "0.4.0-a0"
+tonbo = "0.4.0-a1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 


### PR DESCRIPTION
## Summary

- bump the Tonbo crate version and install/docs references to `0.4.0-a1`
- update README docs.rs links and the CI badge branch
- add crates.io version metadata alongside the current git dependencies needed for a future publish

## Validation

- `cargo +nightly fmt --all`
- `env RUSTC_WRAPPER= cargo test`
- `env RUSTC_WRAPPER= cargo clippy -- -D warnings`
- `env RUSTC_WRAPPER= cargo publish --dry-run --allow-dirty`

## Release blocker

The publish dry-run packages Tonbo successfully, then fails while verifying against crates.io dependencies. The published `aisle 0.2.0` crate is missing the `CmpOp`, `Expr`, `RowFilter`, and pruning APIs used by current Tonbo, and the published `fusio 0.6.0` crate is missing `AmazonS3Builder::s3_express`.

Before publishing `tonbo 0.4.0-a1`, release compatible `aisle` and `fusio` crates and update the version metadata in this PR if their published versions change.
