### PR TITLE
chore: update release dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ s3-smoke = []
 
 [dependencies]
 anyhow = "1"
-aisle = { version = "0.2.0", git = "https://github.com/tonbo-io/aisle", branch = "main" }
+aisle = { version = "0.2.1", git = "https://github.com/tonbo-io/aisle", branch = "main" }
 arrow-array = "57.1.0"
 arrow-buffer = "57.1.0"
 arrow-ipc = "57.1.0"
@@ -48,16 +48,16 @@ bytes = "1"
 crc32c = "0.6"
 crossbeam-skiplist = "0.1"
 datafusion-common = "51.0.0"
-fusio = { version = "0.6.0", git = "https://github.com/tonbo-io/fusio", rev = "62738727bd5be6e7591fb5d5de008959ed45a20d", default-features = false, features = [
+fusio = { version = "0.6.1", git = "https://github.com/tonbo-io/fusio", rev = "c33a96c8a124c17500924823658541ec1d4bbfb3", default-features = false, features = [
     "aws",
     "dyn",
     "executor",
     "fs",
 ] }
-fusio-manifest = { version = "0.6.0", git = "https://github.com/tonbo-io/fusio", rev = "62738727bd5be6e7591fb5d5de008959ed45a20d", package = "fusio-manifest", default-features = false, features = [
+fusio-manifest = { version = "0.6.1", git = "https://github.com/tonbo-io/fusio", rev = "c33a96c8a124c17500924823658541ec1d4bbfb3", package = "fusio-manifest", default-features = false, features = [
     "std",
 ] }
-fusio-parquet = { version = "0.6.0", git = "https://github.com/tonbo-io/fusio", rev = "62738727bd5be6e7591fb5d5de008959ed45a20d", package = "fusio-parquet" }
+fusio-parquet = { version = "0.6.1", git = "https://github.com/tonbo-io/fusio", rev = "c33a96c8a124c17500924823658541ec1d4bbfb3", package = "fusio-parquet" }
 futures = "0.3"
 lockable = "0.2"
 once_cell = "1"


### PR DESCRIPTION
## Summary

- update Tonbo's release dependency metadata to the published upstream crate versions:
  - `aisle 0.2.1`
  - `fusio 0.6.1`
  - `fusio-manifest 0.6.1`
  - `fusio-parquet 0.6.1`
- move the Fusio git pin to the merged `0.6.1` release commit

## Validation

- `cargo +nightly fmt --all`
- `env RUSTC_WRAPPER= cargo test`
- `env RUSTC_WRAPPER= cargo clippy -- -D warnings`
- `env RUSTC_WRAPPER= cargo publish --dry-run --allow-dirty`

Notes:

- The first full `cargo test` run had one manifest CAS test fail once with `Manifest(Backend(PreconditionFailed))`; the exact test passed on rerun, and the full suite passed on the next run.
- The publish dry-run now verifies the packaged crate against crates.io `aisle 0.2.1` and `fusio* 0.6.1`.
