### PR TITLE
fix: re-export typed-arrow derives from prelude

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Run cargo test
         run: cargo test --verbose --workspace
 
+      - name: Check prelude-only typed-arrow derives
+        run: cargo check --manifest-path tests/fixtures/prelude_consumer/Cargo.toml
+
   compaction-correctness-deterministic:
     name: compaction correctness (required deterministic baseline)
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2024"
 name = "tonbo"
 resolver = "2"
-version = "0.4.0-a1"
+version = "0.4.0-a2"
 description = "Embedded database for serverless and edge runtimes, storing data as Parquet on S3"
 license = "Apache-2.0"
 repository = "https://github.com/tonbo-io/tonbo"
@@ -80,8 +80,8 @@ tokio = { version = "1", default-features = false, features = [
     "sync",
     "time",
 ], optional = true }
-typed-arrow = { version = "0.6.0", default-features = false, features = ["arrow-57", "ext-hooks", "views"], optional = true }
-typed-arrow-dyn = { version = "0.0.7", default-features = false, features = ["arrow-57", "serde"] }
+typed-arrow = { version = "0.7.1", default-features = false, features = ["arrow-57", "ext-hooks", "views"], optional = true }
+typed-arrow-dyn = { version = "0.0.8", default-features = false, features = ["arrow-57", "serde"] }
 ulid = { version = "1", features = ["serde"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -96,7 +96,7 @@ futures = "0.3"
 tempfile = "3"
 tracing = { version = "0.1", default-features = false, features = ["attributes", "std"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
-typed-arrow = { version = "0.6.0", default-features = false, features = ["arrow-57", "ext-hooks", "views"] }
+typed-arrow = { version = "0.7.1", default-features = false, features = ["arrow-57", "ext-hooks", "views"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 criterion = "0.5"

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -17,6 +17,6 @@
 //! ```
 
 #[cfg(feature = "typed-arrow")]
-pub use typed_arrow::{Record, prelude::*, schema::SchemaMeta};
+pub use typed_arrow::{self, Record, prelude::*, schema::SchemaMeta};
 
 pub use crate::db::{BatchesThreshold, CommitAckMode, DB, DbBuilder, Expr, ScalarValue};

--- a/tests/fixtures/prelude_consumer/Cargo.toml
+++ b/tests/fixtures/prelude_consumer/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "tonbo-prelude-consumer"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[workspace]
+
+[dependencies]
+tonbo = { path = "../../.." }

--- a/tests/fixtures/prelude_consumer/src/main.rs
+++ b/tests/fixtures/prelude_consumer/src/main.rs
@@ -1,0 +1,24 @@
+mod model {
+    use tonbo::prelude::*;
+
+    #[derive(Union)]
+    pub(crate) enum Value {
+        Int(i64),
+        Text(String),
+    }
+
+    #[derive(Record)]
+    pub(crate) struct Row {
+        #[metadata(k = "tonbo.key", v = "true")]
+        id: String,
+        value: Value,
+    }
+
+    pub(crate) fn field_count() -> usize {
+        Row::schema().fields().len()
+    }
+}
+
+fn main() {
+    assert_eq!(model::field_count(), 2);
+}


### PR DESCRIPTION
## Rationale

`Record` and `Union` are re-exported by `tonbo::prelude`, but their generated code previously required consumers to declare `typed-arrow` directly. Upgrade to typed-arrow 0.7.1, re-export its crate path, and add a downstream-only compile fixture.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo test`
- `cargo clippy -- -D warnings`
- `cargo check --manifest-path tests/fixtures/prelude_consumer/Cargo.toml`