### PR TITLE
feat: tonbo datafusion table provider

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/tonbo-io/tonbo"
 readme = "README.md"
 
 [workspace]
-members = ["."]
+members = [".", "tonbo-datafusion"]
 
 
 [features]

--- a/tonbo-datafusion/Cargo.toml
+++ b/tonbo-datafusion/Cargo.toml
@@ -8,6 +8,10 @@ datafusion = { version = "51.0.0", default-features = false } # aisle depends on
 aisle = { version = "0.2.1", features = ["datafusion"] }
 async-trait = "0.1.89"
 fusio = { version = "0.6.1", features = ["tokio"] }
-tonbo = "=0.4.0-a2" # tonbo 0.4.0-a1 depends on arrow 57 so, we use use df version that uses same arrow version, which is 51.0.0
+tonbo = "=0.4.0-a2" # tonbo 0.4.0-a2 depends on arrow 57 so, we use use df version that uses same arrow version, which is 51.0.0
 tokio-util = { version = "0.7.18", features = ["rt"] }
 futures = "0.3.33"
+
+[dev-dependencies]
+datafusion = { version = "51.0.0", default-features = false, features = ["sql"] }
+tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread"] }

--- a/tonbo-datafusion/Cargo.toml
+++ b/tonbo-datafusion/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "tonbo-datafusion"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+datafusion = { version = "51.0.0", default-features = false } # aisle depends on 51.0.0
+aisle = { version = "0.2.1", features = ["datafusion"] }
+async-trait = "0.1.89"
+fusio = { version = "0.6.1", features = ["tokio"] }
+tonbo = "=0.4.0-a2" # tonbo 0.4.0-a1 depends on arrow 57 so, we use use df version that uses same arrow version, it is 51.0.0
+tokio-util = { version = "0.7.18", features = ["rt"] }
+futures = "0.3.33"

--- a/tonbo-datafusion/Cargo.toml
+++ b/tonbo-datafusion/Cargo.toml
@@ -8,6 +8,6 @@ datafusion = { version = "51.0.0", default-features = false } # aisle depends on
 aisle = { version = "0.2.1", features = ["datafusion"] }
 async-trait = "0.1.89"
 fusio = { version = "0.6.1", features = ["tokio"] }
-tonbo = "=0.4.0-a2" # tonbo 0.4.0-a1 depends on arrow 57 so, we use use df version that uses same arrow version, it is 51.0.0
+tonbo = "=0.4.0-a2" # tonbo 0.4.0-a1 depends on arrow 57 so, we use use df version that uses same arrow version, which is 51.0.0
 tokio-util = { version = "0.7.18", features = ["rt"] }
 futures = "0.3.33"

--- a/tonbo-datafusion/examples/datafusion.rs
+++ b/tonbo-datafusion/examples/datafusion.rs
@@ -1,0 +1,53 @@
+//! Query the database created by Tonbo's `01_basic` example through DataFusion.
+//!
+//! Run the following commands from the workspace root:
+//!
+//! ```text
+//! cargo run --example 01_basic
+//! cargo run -p tonbo-datafusion --example datafusion
+//! ```
+
+use std::sync::Arc;
+
+use datafusion::prelude::SessionContext;
+use tonbo::prelude::*;
+use tonbo_datafusion::tonbo_table::TonboTable;
+
+#[derive(Record)]
+struct User {
+    #[metadata(k = "tonbo.key", v = "true")]
+    id: String,
+    name: String,
+    score: Option<i64>,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // `01_basic` creates this database and inserts the sample users.
+    let db = DbBuilder::from_schema(User::schema())?
+        .on_disk("/tmp/tonbo_example")?
+        .open()
+        .await?;
+
+    let ctx = SessionContext::new();
+    ctx.register_table(
+        "users",
+        Arc::new(TonboTable::from(Arc::new(db), User::schema())),
+    )?;
+
+    let df = ctx
+        .sql("SELECT id, name, score FROM users WHERE score > 80 ORDER BY id")
+        .await?;
+
+    df.show().await?;
+
+    // Output:
+    // +----+-------+-------+
+    // | id | name  | score |
+    // +----+-------+-------+
+    // | u1 | Alice | 100   |
+    // | u2 | Bob   | 85    |
+    // +----+-------+-------+
+
+    Ok(())
+}

--- a/tonbo-datafusion/src/lib.rs
+++ b/tonbo-datafusion/src/lib.rs
@@ -1,0 +1,2 @@
+/// Apache DataFusion table provider for Tonbo
+pub mod tonbo_table;

--- a/tonbo-datafusion/src/tonbo_table.rs
+++ b/tonbo-datafusion/src/tonbo_table.rs
@@ -1,34 +1,39 @@
-use std::any::Any;
-use std::fmt::Debug;
-use std::sync::Arc;
+use std::{any::Any, fmt::Debug, sync::Arc};
 
 use aisle::{Expr as AisleExpr, compile_pruning_ir};
 use async_trait::async_trait;
-use datafusion::arrow::datatypes::{Schema, SchemaRef};
-use datafusion::catalog::{Session, TableProvider};
-use datafusion::datasource::TableType;
-use datafusion::error::{DataFusionError, Result as DataFusionResult};
-use datafusion::execution::SendableRecordBatchStream;
-use datafusion::execution::TaskContext;
-use datafusion::logical_expr::{Expr as DfExpr, TableProviderFilterPushDown};
-use datafusion::physical_expr::EquivalenceProperties;
-use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
-use datafusion::physical_plan::{
-    DisplayAs, ExecutionPlan, Partitioning, PlanProperties, stream::RecordBatchStreamAdapter,
+use datafusion::{
+    arrow::datatypes::{Schema, SchemaRef},
+    catalog::{Session, TableProvider},
+    datasource::TableType,
+    error::{DataFusionError, Result as DataFusionResult},
+    execution::{SendableRecordBatchStream, TaskContext},
+    logical_expr::{Expr as DfExpr, TableProviderFilterPushDown},
+    physical_expr::EquivalenceProperties,
+    physical_plan::{
+        DisplayAs, ExecutionPlan, Partitioning, PlanProperties,
+        execution_plan::{Boundedness, EmissionType},
+        stream::RecordBatchStreamAdapter,
+    },
 };
-use fusio::disk::TokioFs;
-use fusio::executor::tokio::TokioExecutor;
-use futures::TryStreamExt;
+use fusio::{disk::TokioFs, executor::tokio::TokioExecutor};
+use futures::{SinkExt, StreamExt, channel::mpsc};
 use tokio_util::task::LocalPoolHandle;
 use tonbo::db::DB;
 
 pub struct TonboTable {
     db: Arc<DB<TokioFs, TokioExecutor>>,
     schema: SchemaRef,
+    local_pool: LocalPoolHandle,
 }
+
 impl TonboTable {
     pub fn from(db: Arc<DB<TokioFs, TokioExecutor>>, schema: SchemaRef) -> Self {
-        Self { db, schema }
+        Self {
+            db,
+            schema,
+            local_pool: LocalPoolHandle::new(1),
+        }
     }
 }
 impl Debug for TonboTable {
@@ -59,9 +64,10 @@ impl TableProvider for TonboTable {
         Ok(Arc::new(TonboExec::new(
             self.db.clone(),
             self.schema.clone(),
-            projection.map(|p| p.clone()),
+            projection.cloned(),
             filters.to_vec(),
             limit,
+            self.local_pool.clone(),
         )?))
     }
 
@@ -69,11 +75,14 @@ impl TableProvider for TonboTable {
         &self,
         filters: &[&DfExpr],
     ) -> DataFusionResult<Vec<TableProviderFilterPushDown>> {
+        // Tonbo uses filters for pruning, while DataFusion retains the exact
+        // filter as a residual to preserve correctness.
         Ok(filters
             .iter()
             .map(|_| TableProviderFilterPushDown::Inexact)
             .collect())
     }
+
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -87,7 +96,7 @@ pub struct TonboExec {
     filters: Vec<DfExpr>,
     limit: Option<usize>,
     properties: Arc<PlanProperties>,
-    local_pool: LocalPoolHandle, // think about creating shared pool
+    local_pool: LocalPoolHandle,
 }
 
 impl TonboExec {
@@ -97,8 +106,8 @@ impl TonboExec {
         projection: Option<Vec<usize>>,
         filters: Vec<DfExpr>,
         limit: Option<usize>,
+        local_pool: LocalPoolHandle,
     ) -> DataFusionResult<Self> {
-        // Excluding the columns that we don't want to read
         let projected_schema: SchemaRef = match &projection {
             Some(indices) => Arc::new(schema.project(indices)?),
             None => schema.clone(),
@@ -112,25 +121,22 @@ impl TonboExec {
             filters,
             limit,
             properties: Arc::new(PlanProperties::new(
-                EquivalenceProperties::new(output_schema.into()),
+                EquivalenceProperties::new(output_schema),
                 Partitioning::UnknownPartitioning(1),
                 EmissionType::Final,
                 Boundedness::Bounded,
             )),
-            local_pool: LocalPoolHandle::new(1),
+            local_pool,
         };
         Ok(instance)
     }
-    pub fn df_to_aisle(&self, filters: &Vec<DfExpr>) -> AisleExpr {
-        let filter = if filters.is_empty() {
-            AisleExpr::True
-        } else {
-            let predicate = filters.iter().cloned().reduce(DfExpr::and).unwrap();
-            let result = compile_pruning_ir(&predicate, self.schema.as_ref());
-            AisleExpr::and(result.ir_exprs().to_vec())
+    pub fn df_to_aisle(&self, filters: &[DfExpr]) -> AisleExpr {
+        let Some((first, rest)) = filters.split_first() else {
+            return AisleExpr::True;
         };
-
-        filter
+        let predicate = rest.iter().cloned().fold(first.clone(), DfExpr::and);
+        let result = compile_pruning_ir(&predicate, self.schema.as_ref());
+        AisleExpr::and(result.ir_exprs().to_vec())
     }
 }
 
@@ -182,47 +188,67 @@ impl ExecutionPlan for TonboExec {
 
     fn with_new_children(
         self: Arc<Self>,
-        _children: Vec<Arc<dyn ExecutionPlan>>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
-        Ok(self)
+        if children.is_empty() {
+            Ok(self)
+        } else {
+            Err(DataFusionError::Plan(
+                "TonboExec does not accept child execution plans".to_owned(),
+            ))
+        }
     }
 
     fn execute(
         &self,
-        _partition: usize,
+        partition: usize,
         _context: Arc<TaskContext>,
     ) -> datafusion::error::Result<SendableRecordBatchStream> {
+        if partition != 0 {
+            return Err(DataFusionError::Execution(format!(
+                "invalid Tonbo partition: {partition}"
+            )));
+        }
+
         let filter = self.df_to_aisle(&self.filters);
-        let db = self.db.clone();
-        //let schema = Arc::clone(&self.schema);
-        let local_pool = self.local_pool.clone();
+        let db = Arc::clone(&self.db);
         let projected_schema = Arc::clone(&self.projected_schema);
         let output_schema = Arc::clone(&self.projected_schema);
         let has_projection = self.projection.is_some();
+        let pool = self.local_pool.clone();
+        let (mut sender, receiver) = mpsc::channel(2);
 
-        let future = async move {
-            local_pool
-                .spawn_pinned(move || async move {
-                    let scan = db.scan().filter(filter);
-                    let scan = if has_projection {
-                        scan.projection(projected_schema)
-                    } else {
-                        scan
-                    };
-                    scan.collect().await
-                })
-                .await
-                .map_err(|e| DataFusionError::Execution(format!("scan task panicked: {e}")))?
-                .map_err(|e| DataFusionError::Execution(e.to_string()))
-                .map(|batches| {
-                    futures::stream::iter(batches.into_iter().map(Ok::<_, DataFusionError>))
-                })
-        };
+        // Tonbo's scan() is a !Send so, we isolate that
+        let _scan_task = pool.spawn_pinned(move || async move {
+            let scan = db.scan().filter(filter);
+            let scan = if has_projection {
+                scan.projection(projected_schema)
+            } else {
+                scan
+            };
 
-        let stream = futures::stream::once(future).try_flatten();
+            match scan.stream().await {
+                Ok(stream) => {
+                    futures::pin_mut!(stream);
+                    while let Some(batch) = stream.next().await {
+                        let batch =
+                            batch.map_err(|error| DataFusionError::Execution(error.to_string()));
+                        if sender.send(batch).await.is_err() {
+                            break;
+                        }
+                    }
+                }
+                Err(error) => {
+                    let _ = sender
+                        .send(Err(DataFusionError::Execution(error.to_string())))
+                        .await;
+                }
+            }
+        });
+
         Ok(Box::pin(RecordBatchStreamAdapter::new(
             output_schema,
-            stream,
+            receiver,
         )))
     }
 }

--- a/tonbo-datafusion/src/tonbo_table.rs
+++ b/tonbo-datafusion/src/tonbo_table.rs
@@ -1,0 +1,228 @@
+use std::any::Any;
+use std::fmt::Debug;
+use std::sync::Arc;
+
+use aisle::{Expr as AisleExpr, compile_pruning_ir};
+use async_trait::async_trait;
+use datafusion::arrow::datatypes::{Schema, SchemaRef};
+use datafusion::catalog::{Session, TableProvider};
+use datafusion::datasource::TableType;
+use datafusion::error::{DataFusionError, Result as DataFusionResult};
+use datafusion::execution::SendableRecordBatchStream;
+use datafusion::execution::TaskContext;
+use datafusion::logical_expr::{Expr as DfExpr, TableProviderFilterPushDown};
+use datafusion::physical_expr::EquivalenceProperties;
+use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
+use datafusion::physical_plan::{
+    DisplayAs, ExecutionPlan, Partitioning, PlanProperties, stream::RecordBatchStreamAdapter,
+};
+use fusio::disk::TokioFs;
+use fusio::executor::tokio::TokioExecutor;
+use futures::TryStreamExt;
+use tokio_util::task::LocalPoolHandle;
+use tonbo::db::DB;
+
+pub struct TonboTable {
+    db: Arc<DB<TokioFs, TokioExecutor>>,
+    schema: SchemaRef,
+}
+impl TonboTable {
+    pub fn from(db: Arc<DB<TokioFs, TokioExecutor>>, schema: SchemaRef) -> Self {
+        Self { db, schema }
+    }
+}
+impl Debug for TonboTable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TonboTableProvider")
+            .field("db", &"db")
+            .field("schema", &self.schema)
+            .finish()
+    }
+}
+#[async_trait]
+impl TableProvider for TonboTable {
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    async fn scan(
+        &self,
+        _state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[DfExpr],
+        limit: Option<usize>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(TonboExec::new(
+            self.db.clone(),
+            self.schema.clone(),
+            projection.map(|p| p.clone()),
+            filters.to_vec(),
+            limit,
+        )?))
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&DfExpr],
+    ) -> DataFusionResult<Vec<TableProviderFilterPushDown>> {
+        Ok(filters
+            .iter()
+            .map(|_| TableProviderFilterPushDown::Inexact)
+            .collect())
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+pub struct TonboExec {
+    db: Arc<DB<TokioFs, TokioExecutor>>,
+    schema: Arc<Schema>,
+    projection: Option<Vec<usize>>,
+    projected_schema: SchemaRef,
+    filters: Vec<DfExpr>,
+    limit: Option<usize>,
+    properties: Arc<PlanProperties>,
+    local_pool: LocalPoolHandle, // think about creating shared pool
+}
+
+impl TonboExec {
+    pub fn new(
+        db: Arc<DB<TokioFs, TokioExecutor>>,
+        schema: SchemaRef,
+        projection: Option<Vec<usize>>,
+        filters: Vec<DfExpr>,
+        limit: Option<usize>,
+    ) -> DataFusionResult<Self> {
+        // Excluding the columns that we don't want to read
+        let projected_schema: SchemaRef = match &projection {
+            Some(indices) => Arc::new(schema.project(indices)?),
+            None => schema.clone(),
+        };
+        let output_schema = projected_schema.clone();
+        let instance = Self {
+            db,
+            schema: schema.clone(),
+            projection,
+            projected_schema,
+            filters,
+            limit,
+            properties: Arc::new(PlanProperties::new(
+                EquivalenceProperties::new(output_schema.into()),
+                Partitioning::UnknownPartitioning(1),
+                EmissionType::Final,
+                Boundedness::Bounded,
+            )),
+            local_pool: LocalPoolHandle::new(1),
+        };
+        Ok(instance)
+    }
+    pub fn df_to_aisle(&self, filters: &Vec<DfExpr>) -> AisleExpr {
+        let filter = if filters.is_empty() {
+            AisleExpr::True
+        } else {
+            let predicate = filters.iter().cloned().reduce(DfExpr::and).unwrap();
+            let result = compile_pruning_ir(&predicate, self.schema.as_ref());
+            AisleExpr::and(result.ir_exprs().to_vec())
+        };
+
+        filter
+    }
+}
+
+impl Debug for TonboExec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TonboExec")
+            .field("db", &"DB")
+            .field("schema", &self.schema)
+            .field("projection", &self.projection)
+            .field("filters", &self.filters)
+            .field("limit", &self.limit)
+            .field("properties", &self.properties)
+            .finish()
+    }
+}
+
+impl DisplayAs for TonboExec {
+    fn fmt_as(
+        &self,
+        _t: datafusion::physical_plan::DisplayFormatType,
+        f: &mut std::fmt::Formatter<'_>,
+    ) -> std::fmt::Result {
+        write!(
+            f,
+            "TonboExec: projection={:?}, filters={}, limit={:?}",
+            self.projection,
+            self.filters.len(),
+            self.limit
+        )
+    }
+}
+
+impl ExecutionPlan for TonboExec {
+    fn name(&self) -> &str {
+        "TonboExecutionPlan"
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> datafusion::error::Result<SendableRecordBatchStream> {
+        let filter = self.df_to_aisle(&self.filters);
+        let db = self.db.clone();
+        //let schema = Arc::clone(&self.schema);
+        let local_pool = self.local_pool.clone();
+        let projected_schema = Arc::clone(&self.projected_schema);
+        let output_schema = Arc::clone(&self.projected_schema);
+        let has_projection = self.projection.is_some();
+
+        let future = async move {
+            local_pool
+                .spawn_pinned(move || async move {
+                    let scan = db.scan().filter(filter);
+                    let scan = if has_projection {
+                        scan.projection(projected_schema)
+                    } else {
+                        scan
+                    };
+                    scan.collect().await
+                })
+                .await
+                .map_err(|e| DataFusionError::Execution(format!("scan task panicked: {e}")))?
+                .map_err(|e| DataFusionError::Execution(e.to_string()))
+                .map(|batches| {
+                    futures::stream::iter(batches.into_iter().map(Ok::<_, DataFusionError>))
+                })
+        };
+
+        let stream = futures::stream::once(future).try_flatten();
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            output_schema,
+            stream,
+        )))
+    }
+}

--- a/tonbo-datafusion/src/tonbo_table.rs
+++ b/tonbo-datafusion/src/tonbo_table.rs
@@ -77,10 +77,7 @@ impl TableProvider for TonboTable {
     ) -> DataFusionResult<Vec<TableProviderFilterPushDown>> {
         // Tonbo uses filters for pruning, while DataFusion retains the exact
         // filter as a residual to preserve correctness.
-        Ok(filters
-            .iter()
-            .map(|_| TableProviderFilterPushDown::Inexact)
-            .collect())
+        Ok(inexact_filter_pushdowns(filters))
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -108,10 +105,7 @@ impl TonboExec {
         limit: Option<usize>,
         local_pool: LocalPoolHandle,
     ) -> DataFusionResult<Self> {
-        let projected_schema: SchemaRef = match &projection {
-            Some(indices) => Arc::new(schema.project(indices)?),
-            None => schema.clone(),
-        };
+        let projected_schema = project_schema(&schema, projection.as_deref())?;
         let output_schema = projected_schema.clone();
         let instance = Self {
             db,
@@ -130,13 +124,8 @@ impl TonboExec {
         };
         Ok(instance)
     }
-    pub fn df_to_aisle(&self, filters: &[DfExpr]) -> AisleExpr {
-        let Some((first, rest)) = filters.split_first() else {
-            return AisleExpr::True;
-        };
-        let predicate = rest.iter().cloned().fold(first.clone(), DfExpr::and);
-        let result = compile_pruning_ir(&predicate, self.schema.as_ref());
-        AisleExpr::and(result.ir_exprs().to_vec())
+    pub fn aisle_expr(&self, filters: &[DfExpr]) -> AisleExpr {
+        df_to_aisle(self.schema.as_ref(), filters)
     }
 }
 
@@ -190,13 +179,8 @@ impl ExecutionPlan for TonboExec {
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
-        if children.is_empty() {
-            Ok(self)
-        } else {
-            Err(DataFusionError::Plan(
-                "TonboExec does not accept child execution plans".to_owned(),
-            ))
-        }
+        validate_leaf_children(children.len())?;
+        Ok(self)
     }
 
     fn execute(
@@ -204,13 +188,9 @@ impl ExecutionPlan for TonboExec {
         partition: usize,
         _context: Arc<TaskContext>,
     ) -> datafusion::error::Result<SendableRecordBatchStream> {
-        if partition != 0 {
-            return Err(DataFusionError::Execution(format!(
-                "invalid Tonbo partition: {partition}"
-            )));
-        }
+        validate_partition(partition)?;
 
-        let filter = self.df_to_aisle(&self.filters);
+        let filter = self.aisle_expr(&self.filters);
         let db = Arc::clone(&self.db);
         let projected_schema = Arc::clone(&self.projected_schema);
         let output_schema = Arc::clone(&self.projected_schema);
@@ -250,5 +230,133 @@ impl ExecutionPlan for TonboExec {
             output_schema,
             receiver,
         )))
+    }
+}
+
+/// Datafusion Expr to Aisle Expr
+fn df_to_aisle(schema: &Schema, filters: &[DfExpr]) -> AisleExpr {
+    let Some((first, rest)) = filters.split_first() else {
+        return AisleExpr::True;
+    };
+    let predicate = rest.iter().cloned().fold(first.clone(), DfExpr::and);
+    let result = compile_pruning_ir(&predicate, schema);
+    AisleExpr::and(result.ir_exprs().to_vec())
+}
+
+fn project_schema(schema: &SchemaRef, projection: Option<&[usize]>) -> DataFusionResult<SchemaRef> {
+    match projection {
+        Some(indices) => Ok(Arc::new(schema.project(indices)?)),
+        None => Ok(Arc::clone(schema)),
+    }
+}
+
+fn inexact_filter_pushdowns(filters: &[&DfExpr]) -> Vec<TableProviderFilterPushDown> {
+    filters
+        .iter()
+        .map(|_| TableProviderFilterPushDown::Inexact)
+        .collect()
+}
+
+fn validate_partition(partition: usize) -> DataFusionResult<()> {
+    if partition == 0 {
+        Ok(())
+    } else {
+        Err(DataFusionError::Execution(format!(
+            "invalid Tonbo partition: {partition}"
+        )))
+    }
+}
+
+fn validate_leaf_children(child_count: usize) -> DataFusionResult<()> {
+    if child_count == 0 {
+        Ok(())
+    } else {
+        Err(DataFusionError::Plan(
+            "TonboExec does not accept child execution plans".to_owned(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::{
+        arrow::datatypes::{DataType, Field},
+        logical_expr::{col, lit},
+    };
+
+    use super::*;
+
+    fn test_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("score", DataType::Int64, true),
+            Field::new("name", DataType::Utf8, true),
+        ]))
+    }
+
+    #[test]
+    fn project_schema_selects_requested_columns_in_order() {
+        let schema = test_schema();
+
+        let projected = project_schema(&schema, Some(&[2, 0])).expect("valid projection");
+
+        assert_eq!(projected.fields().len(), 2);
+        assert_eq!(projected.field(0).name(), "name");
+        assert_eq!(projected.field(1).name(), "id");
+    }
+
+    #[test]
+    fn project_schema_rejects_unknown_column_index() {
+        let schema = test_schema();
+
+        assert!(project_schema(&schema, Some(&[3])).is_err());
+    }
+
+    #[test]
+    fn empty_filters_compile_to_true_predicate() {
+        assert!(matches!(
+            df_to_aisle(test_schema().as_ref(), &[]),
+            AisleExpr::True
+        ));
+    }
+
+    #[test]
+    fn supported_filter_compiles_to_non_trivial_pruning_predicate() {
+        let schema = test_schema();
+        let filter = col("score").gt(lit(80_i64));
+
+        assert!(!matches!(
+            df_to_aisle(schema.as_ref(), &[filter]),
+            AisleExpr::True
+        ));
+    }
+
+    #[test]
+    fn filters_are_reported_as_inexact_pushdowns() {
+        let filters = vec![col("score").gt(lit(80_i64)), col("name").is_not_null()];
+        let filter_refs = filters.iter().collect::<Vec<_>>();
+
+        let pushdowns = inexact_filter_pushdowns(&filter_refs);
+
+        assert_eq!(pushdowns.len(), filters.len());
+        assert!(
+            pushdowns
+                .iter()
+                .all(|pushdown| matches!(pushdown, TableProviderFilterPushDown::Inexact))
+        );
+    }
+
+    #[test]
+    fn execution_plan_rejects_invalid_partition_and_children() {
+        assert!(validate_partition(0).is_ok());
+        assert!(matches!(
+            validate_partition(1),
+            Err(DataFusionError::Execution(_))
+        ));
+        assert!(validate_leaf_children(0).is_ok());
+        assert!(matches!(
+            validate_leaf_children(1),
+            Err(DataFusionError::Plan(_))
+        ));
     }
 }


### PR DESCRIPTION
## Summary
- Datafusion table provider integration for tonbo to query tonbo tables using datafusion.
- test cases.
- code example. 

## Testing
- `cargo test -p tonbo-datafusion`
- `cargo run --example 01_basic`
- `cargo run -p tonbo-datafusion --example datafusion`